### PR TITLE
switch to dune package management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,10 @@ jobs:
         with:
           cache: "yarn"
       - name: Setup OCaml
-        uses: ocaml-dune/setup-dune@v0
-      - run: dune pkg lock
+        uses: ocaml-dune/setup-dune@v1
+        with:
+          automagic: true
       # OCaml build
-      - name: Build OCaml stuff
-        run: make ocaml
       - name: Check formatting
         run: make ocaml-format-check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,22 +38,9 @@ jobs:
         with:
           cache: "yarn"
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: 5.3.0
-          dune-cache: true
-          opam-pin: false
-      - name: Restore opam cache
-        uses: actions/cache@v4
-        with:
-          path: _opam
-          key: ${{ runner.os }}-${{ runner.arch }}-opam-${{ hashFiles('*.opam') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-opam-
-      - run: opam update
+        uses: ocaml-dune/setup-dune@v0
+      - run: dune pkg lock --update
       # OCaml build
-      - name: setup dependencies
-        run: make ocaml-deps
       - name: Build OCaml stuff
         run: make ocaml
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           cache: "yarn"
       - name: Setup OCaml
         uses: ocaml-dune/setup-dune@v0
-      - run: dune pkg lock --update
+      - run: dune pkg lock
       # OCaml build
       - name: Build OCaml stuff
         run: make ocaml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-OPAM=opam
-OPAMX=$(OPAM) exec --
-DUNE=$(OPAMX) dune
+DUNE=dune
 WHICHX=$(DUNE) exec -- which 
 
 YARN=yarn

--- a/dune-project
+++ b/dune-project
@@ -23,6 +23,59 @@
 (source
  (github soteria-tools/soteria))
 
+(pin
+ (url
+  "git+https://github.com/NatKarmios/simple-smt-ocaml#9db7ef0bb61a76010de255af3cbe4066dd8dd622")
+ (package
+  (name simple_smt)))
+
+(pin
+ (url
+  "git+https://github.com/giltho/progress#c1eb9495a83c956ee765b30cb3f058431b1c8877")
+ (package
+  (name progress)))
+
+(pin
+ (url
+  "git+https://github.com/giltho/progress#c1eb9495a83c956ee765b30cb3f058431b1c8877")
+ (package
+  (name terminal)))
+
+(pin
+ (url "git+https://github.com/kmemarian/cerberus#frontend-for-system-libc")
+ (package
+  (name cerberus-lib)))
+
+(pin
+ (url
+  "git+https://github.com/AeneasVerif/charon#aeaf873b600381bf2a5dc968f096a39994b37746")
+ (package
+  (name name_matcher_parser)))
+
+(pin
+ (url
+  "git+https://github.com/AeneasVerif/charon#aeaf873b600381bf2a5dc968f096a39994b37746")
+ (package
+  (name charon)))
+
+(pin
+ (url
+  "git+https://github.com/ocamllabs/vscode-ocaml-platform#205efaf51a709a9ef23a1ba62f32db571a7f6a8c")
+ (package
+  (name vscode)))
+
+(pin
+ (url
+  "git+https://github.com/ocamllabs/vscode-ocaml-platform#205efaf51a709a9ef23a1ba62f32db571a7f6a8c")
+ (package
+  (name vscode-node)))
+
+(pin
+ (url
+  "git+https://github.com/ocamllabs/vscode-ocaml-platform#205efaf51a709a9ef23a1ba62f32db571a7f6a8c")
+ (package
+  (name vscode-interop)))
+
 (package
  (name soteria)
  (synopsis "Soteria is a toolkit for writing symbolic bug-finding tools")

--- a/dune-project
+++ b/dune-project
@@ -30,31 +30,19 @@
   (name simple_smt)))
 
 (pin
- (url
-  "git+https://github.com/giltho/progress#c1eb9495a83c956ee765b30cb3f058431b1c8877")
- (package
-  (name progress)))
-
-(pin
- (url
-  "git+https://github.com/giltho/progress#c1eb9495a83c956ee765b30cb3f058431b1c8877")
- (package
-  (name terminal)))
-
-(pin
  (url "git+https://github.com/kmemarian/cerberus#frontend-for-system-libc")
  (package
   (name cerberus-lib)))
 
 (pin
  (url
-  "git+https://github.com/AeneasVerif/charon#aeaf873b600381bf2a5dc968f096a39994b37746")
+  "git+https://github.com/giltho/charon#852f899fd8fe3d7501a5de352fdfd3fe2f6b0ef0")
  (package
   (name name_matcher_parser)))
 
 (pin
  (url
-  "git+https://github.com/AeneasVerif/charon#aeaf873b600381bf2a5dc968f096a39994b37746")
+  "git+https://github.com/giltho/charon#852f899fd8fe3d7501a5de352fdfd3fe2f6b0ef0")
  (package
   (name charon)))
 
@@ -82,7 +70,7 @@
  (description "Soteria is a toolkit for writing symbolic bug-finding tools")
  (depends
   (ocaml
-   (>= 5.3.0))
+   (= 5.3.0))
   (tsort
    (>= 2.1.0))
   eio_main

--- a/soteria-c.opam.template
+++ b/soteria-c.opam.template
@@ -1,3 +1,1 @@
-pin-depends: [
-  ["cerberus-lib.~dev" "git+https://github.com/kmemarian/cerberus#frontend-for-system-libc"]
-]
+

--- a/soteria-rust.opam.template
+++ b/soteria-rust.opam.template
@@ -1,4 +1,1 @@
-pin-depends: [
-  ["name_matcher_parser.~dev" "git+https://github.com/soteria-tools/charon#dc438b20ff10b213dc8c5c9917e575e030af3db0"]
-  ["charon.~dev" "git+https://github.com/soteria-tools/charon#dc438b20ff10b213dc8c5c9917e575e030af3db0"]
-]
+

--- a/soteria-vscode.opam.template
+++ b/soteria-vscode.opam.template
@@ -1,5 +1,1 @@
-pin-depends: [
-  ["vscode.~dev" "git+https://github.com/ocamllabs/vscode-ocaml-platform#205efaf51a709a9ef23a1ba62f32db571a7f6a8c"]
-  ["vscode-node.~dev" "git+https://github.com/ocamllabs/vscode-ocaml-platform#205efaf51a709a9ef23a1ba62f32db571a7f6a8c"]
-  ["vscode-interop.~dev" "git+https://github.com/ocamllabs/vscode-ocaml-platform#205efaf51a709a9ef23a1ba62f32db571a7f6a8c"]
-]
+

--- a/soteria.opam.template
+++ b/soteria.opam.template
@@ -1,3 +1,0 @@
-pin-depends: [
-  ["simple_smt.~dev" "git+https://github.com/NatKarmios/simple-smt-ocaml#9db7ef0bb61a76010de255af3cbe4066dd8dd622"]
-]


### PR DESCRIPTION
Todos:
- [x] Update dune-project to have pins
- [x] Update CI to actually use dune package management
- [x] Wait for it to actually work, currently blocked by [dune#11606](https://github.com/ocaml/dune/issues/11606) but expecting more issues on the way
- [ ] There is now a new issue while installing name_matcher_parser
- [x] Remove opam.template files
- [ ] Adjust makefile and existing scripts


# Name matcher issue :x:
```
File "dune.lock/name_matcher_parser.pkg", line 10, characters 3-79:
10 |    git+https://github.com/N1ark/charon#f47e331b9bc770852a9bcec7d51957f296ae4f1e)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Error trying to read targets after a rule was run:
- url/ac9e16babf03062c7f6bd17abd09657c/dir/doc-ml.html: Broken symbolic link
- url/ac9e16babf03062c7f6bd17abd09657c/dir/doc-rust.html: Broken symbolic link
Context: _private                              
File "runtime/dune", line 5, characters 13-19:
5 |   (libraries result)
                 ^^^^^^
Error: Library "result" not found.
-> required by library "visitors.runtime" in _build/default/runtime
-> required by _build/default/META.visitors
-> required by _build/install/default/lib/visitors/META
-> required by _build/default/visitors.install
-> required by alias install
File "src/dune", line 6, characters 48-64:
6 |   (libraries result compiler-libs.common ppxlib ppx_deriving.api)
                                                    ^^^^^^^^^^^^^^^^
Error: Library "ppx_deriving.api" not found.
-> required by library "visitors.ppx" in _build/default/src
-> required by _build/default/META.visitors
-> required by _build/install/default/lib/visitors/META
-> required by _build/default/visitors.install
-> required by alias install
```