### PR TITLE
Cerberus new error nodes + short-circuiting boolean operators

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,5 @@
 
 # Opale has control over `soteria-rust`
 soteria-rust/ @N1ark
+soteria-rust.opam @N1ark
+soteria-rust.opam.template @N1ark

--- a/soteria-c.opam
+++ b/soteria-c.opam
@@ -53,5 +53,5 @@ build: [
 dev-repo: "git+https://github.com/soteria-tools/soteria.git"
 pin-depends: [
   ["simple_smt.~dev" "git+https://github.com/NatKarmios/simple-smt-ocaml#9db7ef0bb61a76010de255af3cbe4066dd8dd622"]
-  ["cerberus-lib.~dev" "git+https://github.com/rems-project/cerberus#5a3c0d73622cd01458b5a6289a76096c4a43ca3e"]
+  ["cerberus-lib.~dev" "git+https://github.com/kmemarian/cerberus#8b50f2ae9bed20009ad5372b6b2d382be47d1fd4"]
 ]

--- a/soteria-c.opam
+++ b/soteria-c.opam
@@ -53,5 +53,5 @@ build: [
 dev-repo: "git+https://github.com/soteria-tools/soteria.git"
 pin-depends: [
   ["simple_smt.~dev" "git+https://github.com/NatKarmios/simple-smt-ocaml#9db7ef0bb61a76010de255af3cbe4066dd8dd622"]
-  ["cerberus-lib.~dev" "git+https://github.com/kmemarian/cerberus#8b50f2ae9bed20009ad5372b6b2d382be47d1fd4"]
+  ["cerberus-lib.~dev" "git+https://github.com/rems-project/cerberus#4aebc2a6e553e439f60ce4948e26ed5a3d1849db"]
 ]

--- a/soteria-c.opam.template
+++ b/soteria-c.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
   ["simple_smt.~dev" "git+https://github.com/NatKarmios/simple-smt-ocaml#9db7ef0bb61a76010de255af3cbe4066dd8dd622"]
-  ["cerberus-lib.~dev" "git+https://github.com/kmemarian/cerberus#8b50f2ae9bed20009ad5372b6b2d382be47d1fd4"]
+  ["cerberus-lib.~dev" "git+https://github.com/rems-project/cerberus#4aebc2a6e553e439f60ce4948e26ed5a3d1849db"]
 ]

--- a/soteria-c.opam.template
+++ b/soteria-c.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
   ["simple_smt.~dev" "git+https://github.com/NatKarmios/simple-smt-ocaml#9db7ef0bb61a76010de255af3cbe4066dd8dd622"]
-  ["cerberus-lib.~dev" "git+https://github.com/rems-project/cerberus#5a3c0d73622cd01458b5a6289a76096c4a43ca3e"]
+  ["cerberus-lib.~dev" "git+https://github.com/kmemarian/cerberus#8b50f2ae9bed20009ad5372b6b2d382be47d1fd4"]
 ]

--- a/soteria-c/includes/soteria-c.h
+++ b/soteria-c/includes/soteria-c.h
@@ -1,1 +1,3 @@
+int __soteria_nondet__();
+
 #define __attribute__(X)

--- a/soteria-c/lib/abductor.ml
+++ b/soteria-c/lib/abductor.ml
@@ -37,6 +37,7 @@ let generate_summaries_for ~prog (fundef : fundef) =
     let@ () = with_section "Running symbolic execution" in
     Csymex.run process
   in
+  let@ () = with_section "Building summary" in
   let pre, post = Bi_state.to_spec bi_state in
   Summary.make ~args ~ret ~pre ~post ~pc ()
 

--- a/soteria-c/lib/ail_linking.ml
+++ b/soteria-c/lib/ail_linking.ml
@@ -125,7 +125,7 @@ let rec free_syms_expr acc expr =
       let res = List.fold_left free_syms_stmt acc stmts in
       Sym_set.diff res exclude
   | AilEbuiltin _ | AilEstr _ | AilEconst _ | AilEsizeof _ | AilEalignof _
-  | AilEreg_load _ | AilEoffsetof _ ->
+  | AilEreg_load _ | AilEoffsetof _ | AilEinvalid _ ->
       acc
 
 and free_syms_stmt acc stmt =

--- a/soteria-c/lib/ail_linking.ml
+++ b/soteria-c/lib/ail_linking.ml
@@ -178,7 +178,6 @@ let merge_globs (globs_1 : 'a sigma_object_definition list)
             (free_syms_object_definition (Sym_set.of_list acc) glob) ))
       globs
   in
-  (* init_set is the list of symbol with no dependencies *)
   (* We order the symbols in topological order! *)
   let ordered_syms =
     match Tsort.sort dep_map with
@@ -190,11 +189,17 @@ let merge_globs (globs_1 : 'a sigma_object_definition list)
     List.fold_left (fun acc (s, g) -> Sym_map.add s g acc) Sym_map.empty globs
   in
   let ordered_gs =
-    List.map
+    List.filter_map
       (fun k ->
-        match Sym_map.find_opt k gs_map with
-        | None -> raise (LinkError "linking: merge_globs")
-        | Some g -> (k, g))
+        (* TODO: should the None case be allowed to happen? *)
+        Option.map (fun g -> (k, g)) (Sym_map.find_opt k gs_map)
+        (* match Sym_map.find_opt k gs_map with
+        | None ->
+            None
+            (* Fmt.kstr
+              (fun s -> raise (LinkError s))
+              "merge_globs: %a not found" Fmt_ail.pp_sym k *)
+        | Some g -> Some (k, g) *))
       ordered_syms
   in
   (* We have now ordered the globs *)

--- a/soteria-c/lib/call_graph.ml
+++ b/soteria-c/lib/call_graph.ml
@@ -60,7 +60,7 @@ let rec expr_callees d (e : Ail_tys.expr) =
   | AilEcompound (_, _, expr) -> expr_callees expr
   | AilEgcc_statement (_, stmt) -> List.iter (stmt_callees d) stmt
   | AilEbuiltin _ | AilEstr _ | AilEconst _ | AilEident _ | AilEoffsetof _
-  | AilEsizeof _ | AilEalignof _ | AilEreg_load _ ->
+  | AilEsizeof _ | AilEalignof _ | AilEreg_load _ | AilEinvalid _ ->
       ()
 
 and stmt_callees d stmt =

--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -50,7 +50,6 @@ module Frontend = struct
   let frontend = ref (fun ~cpp_cmd:_ _ -> failwith "Frontend not set")
 
   let include_libc () =
-    L.trace (fun m -> m "Cerb_runtime is at: %s" (Cerb_runtime.in_runtime ""));
     let root_includes = Cerb_runtime.in_runtime "libc/include" in
     let posix = Filename.concat root_includes "posix" in
     "-I" ^ root_includes ^ " -I" ^ posix

--- a/soteria-c/lib/fmt_ail.ml
+++ b/soteria-c/lib/fmt_ail.ml
@@ -27,6 +27,12 @@ let pp_binop = pp_to_fmt pp_binaryOperator
 let pp_unop = pp_to_fmt pp_unaryOperator
 let pp_constant = pp_to_fmt pp_constant
 
+let pp_invalid_reason ft (reason : ail_invalid_reason) =
+  match reason with
+  | AilInvalid_desugaring_init_failed msg ->
+      Fmt.pf ft "desugaring init failed: %s" msg
+  | AilInvalid_other msg -> Fmt.pf ft "other: %s" msg
+
 let pp_expr : Format.formatter -> expr -> unit =
   pp_to_fmt (fun e -> pp_expression e)
 

--- a/soteria-c/lib/interp.ml
+++ b/soteria-c/lib/interp.ml
@@ -138,7 +138,7 @@ module Make (State : State_intf.S) = struct
     match descr with
     | Cerb_frontend.Symbol.SD_Id name -> (
         match name with
-        | "__nondet__" -> Some C_std.nondet_int_fun
+        | "__soteria_nondet__" -> Some C_std.nondet_int_fun
         | "malloc" -> Some C_std.malloc
         | "calloc" -> Some C_std.calloc
         | "free" -> Some C_std.free
@@ -422,8 +422,36 @@ module Make (State : State_intf.S) = struct
         | _ ->
             Fmt.kstr not_impl "Unsupported unary operator %a" Fmt_ail.pp_unop op
         )
+    | AilEbinary (e1, Or, e2) ->
+        (* Or is short-circuiting. In case of side-effects on the RHS,
+           not doing this properly might lead to unsoundnesses.
+           We still optimize by returning a disjunction of the two
+           expressions if the RHS is side-effect free. *)
+        let** v1, state = eval_expr state e1 in
+        if Ail_helpers.sure_side_effect_free e2 then
+          let** v2, state = eval_expr state e2 in
+          let b_res = cast_to_bool v1 ||@ cast_to_bool v2 in
+          Result.ok (Typed.int_of_bool b_res, state)
+        else
+          if%sat cast_to_bool v1 then Result.ok (Typed.one, state)
+          else
+            let** v2, state = eval_expr state e2 in
+            let b_res = cast_to_bool v2 in
+            Result.ok (Typed.int_of_bool b_res, state)
+    | AilEbinary (e1, And, e2) ->
+        (* Same as Or, we need to short-circuit *)
+        let** v1, state = eval_expr state e1 in
+        if Ail_helpers.sure_side_effect_free e2 then
+          let** v2, state = eval_expr state e2 in
+          let b_res = cast_to_bool v1 &&@ cast_to_bool v2 in
+          Result.ok (Typed.int_of_bool b_res, state)
+        else
+          if%sat cast_to_bool v1 then
+            let** v2, state = eval_expr state e2 in
+            let b_res = cast_to_bool v2 in
+            Result.ok (Typed.int_of_bool b_res, state)
+          else Result.ok (Typed.zero, state)
     | AilEbinary (e1, op, e2) -> (
-        (* TODO: Binary operators should return a cval, right now this is not right, I need to model integers *)
         let** v1, state = eval_expr state e1 in
         let** v2, state = eval_expr state e2 in
         match op with
@@ -439,9 +467,7 @@ module Make (State : State_intf.S) = struct
         | And ->
             let b_res = cast_to_bool v1 &&@ cast_to_bool v2 in
             Result.ok (Typed.int_of_bool b_res, state)
-        | Or ->
-            let b_res = cast_to_bool v1 ||@ cast_to_bool v2 in
-            Result.ok (Typed.int_of_bool b_res, state)
+        | Or -> failwith "Unreachable, handled earlier."
         | Arithmetic a_op -> arith ~state (v1, type_of e1) a_op (v2, type_of e2)
         | Comma -> Result.ok (v2, state))
     | AilErvalue e ->

--- a/soteria-c/lib/interp.ml
+++ b/soteria-c/lib/interp.ml
@@ -464,10 +464,7 @@ module Make (State : State_intf.S) = struct
             (* TODO: Semantics of Ne might be different from semantics of not eq? *)
             let++ res, state = equality_check ~state v1 v2 in
             (Typed.not_int_bool res, state)
-        | And ->
-            let b_res = cast_to_bool v1 &&@ cast_to_bool v2 in
-            Result.ok (Typed.int_of_bool b_res, state)
-        | Or -> failwith "Unreachable, handled earlier."
+        | Or | And -> failwith "Unreachable, handled earlier."
         | Arithmetic a_op -> arith ~state (v1, type_of e1) a_op (v2, type_of e2)
         | Comma -> Result.ok (v2, state))
     | AilErvalue e ->

--- a/soteria-c/lib/interp.ml
+++ b/soteria-c/lib/interp.ml
@@ -517,6 +517,9 @@ module Make (State : State_intf.S) = struct
         | _ ->
             Fmt.kstr not_impl "Unsupported function decay: %a" Fmt_ail.pp_expr
               outer_fexpr)
+    | AilEinvalid (_ty, reason) ->
+        Fmt.kstr not_impl "Cerberus could not parse an expression because %a"
+          Fmt_ail.pp_invalid_reason reason
     | AilEcond (_, _, _)
     | AilEassert _
     | AilEoffsetof (_, _)

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -44,6 +44,8 @@ let filter_serialized_state relevant_vars (state : State.serialized) =
           let () =
             match b with Csymex.Freeable.Freed -> () | Alive _ -> leak := true
           in
+          L.trace (fun m ->
+              m "Filtering out unreable location: %a" Typed.ppa loc);
           false)
   in
   (* Globals are not filtered: if they are in the spec, they were bi-abduced and necessary *)
@@ -74,6 +76,7 @@ let init_reachable_vars summary =
     well as a boolean capturing whether a memory leak was detected. A memory
     leak is detected if there was an unreachable block that was not freed. *)
 let pruned summary =
+  L.trace (fun m -> m "Pruning summary %a" (pp (Fmt.any "error")) summary);
   let module Var_graph = Graph.Make_in_place (Var) in
   let graph = Var_graph.with_node_capacity 0 in
   let init_reachable = init_reachable_vars summary in

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -184,6 +184,9 @@ let analyse_summary ~prog ~fid (summary : 'err t) =
   in
   if summary.memory_leak then
     let loc = Ail_helpers.find_fun_loc ~prog fid in
-    (`Memory_leak, Call_trace.singleton ~loc:(Option.get loc) ())
+    ( `Memory_leak,
+      Call_trace.singleton
+        ~loc:(Option.value ~default:Cerb_location.unknown loc)
+        () )
     :: manifest_bugs
   else manifest_bugs

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -187,9 +187,7 @@ let analyse_summary ~prog ~fid (summary : 'err t) =
   in
   if summary.memory_leak then
     let loc = Ail_helpers.find_fun_loc ~prog fid in
-    ( `Memory_leak,
-      Call_trace.singleton
-        ~loc:(Option.value ~default:Cerb_location.unknown loc)
-        () )
+    let loc = Option.value ~default:Cerb_location.unknown loc in
+    (`Memory_leak, Call_trace.singleton ~loc ())
     :: manifest_bugs
   else manifest_bugs

--- a/soteria-c/test/cram/comp_db.t/run.t
+++ b/soteria-c/test/cram/comp_db.t/run.t
@@ -1,5 +1,5 @@
   $ soteria-c capture-db compilation_database.json
-  Summaries for test2_491:
+  Summaries for test2_492:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []
@@ -14,7 +14,7 @@
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []
   
-  Summaries for main_492:
+  Summaries for main_493:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []

--- a/soteria-c/test/cram/comp_db.t/run.t
+++ b/soteria-c/test/cram/comp_db.t/run.t
@@ -1,25 +1,25 @@
   $ soteria-c capture-db compilation_database.json
-  Summaries for test2_492:
+  Summaries for test2_494:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []
   
-  Summaries for test3_486:
+  Summaries for test1_484:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []
   
-  Summaries for test1_483:
+  Summaries for test3_488:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []
   
-  Summaries for main_493:
+  Summaries for main_495:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []
   
-  Summaries for test2_487:
+  Summaries for test2_489:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []

--- a/soteria-c/test/cram/failed_parse.t/run.t
+++ b/soteria-c/test/cram/failed_parse.t/run.t
@@ -4,7 +4,7 @@
   parsing "conditional_expression": seen "logical_OR_expression QUESTION", expecting "expression COLON conditional_expression"
   }
   ^ 
-  Summaries for test_483:
+  Summaries for test_484:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []

--- a/soteria-c/test/cram/fixme.t/run.t
+++ b/soteria-c/test/cram/fixme.t/run.t
@@ -1,16 +1,9 @@
   $ soteria-c gen-summaries global_local_eq.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
-<<<<<<< HEAD
-  Summaries for main_486:
+  Summaries for main_487:
     { args = []; pre = []; pc = [(V|0| == V|1|); (0 != V|1|); (0 != V|0|)];
       post =
       { heap = [(V|0|, [Uninit {offset = 0; len = 4}; (Bound 4)])];
-        globs = [(x_483, V|1|)] };
-=======
-  Summaries for main_487:
-    { args = []; pre = [];
-      pc = [(0 Eq IntOfBool(Not((V|0| Eq V|1|)))); Not((0 Eq V|1|))];
-      post = { heap = []; globs = [(x_484, V|1|)] };
->>>>>>> f8274ffd (short-circuit and tests)
+        globs = [(x_484, V|1|)] };
       ret =
       (Error Failed assertion with trace [(global_local_eq.c:8:3-23,
                                            Call trace);
@@ -18,14 +11,8 @@
                                            Triggering memory operation)]);
       memory_leak = false }
       manifest bugs: []
-<<<<<<< HEAD
     { args = []; pre = []; pc = [(V|0| != V|1|); (0 != V|1|)];
-      post = { heap = []; globs = [(x_483, V|1|)] }; ret = (Ok 0);
-=======
-    { args = []; pre = [];
-      pc = [Not((0 Eq IntOfBool(Not((V|0| Eq V|1|))))); Not((0 Eq V|1|))];
       post = { heap = []; globs = [(x_484, V|1|)] }; ret = (Ok 0);
->>>>>>> f8274ffd (short-circuit and tests)
       memory_leak = false }
       manifest bugs: []
   

--- a/soteria-c/test/cram/fixme.t/run.t
+++ b/soteria-c/test/cram/fixme.t/run.t
@@ -1,9 +1,16 @@
   $ soteria-c gen-summaries global_local_eq.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
+<<<<<<< HEAD
   Summaries for main_486:
     { args = []; pre = []; pc = [(V|0| == V|1|); (0 != V|1|); (0 != V|0|)];
       post =
       { heap = [(V|0|, [Uninit {offset = 0; len = 4}; (Bound 4)])];
         globs = [(x_483, V|1|)] };
+=======
+  Summaries for main_487:
+    { args = []; pre = [];
+      pc = [(0 Eq IntOfBool(Not((V|0| Eq V|1|)))); Not((0 Eq V|1|))];
+      post = { heap = []; globs = [(x_484, V|1|)] };
+>>>>>>> f8274ffd (short-circuit and tests)
       ret =
       (Error Failed assertion with trace [(global_local_eq.c:8:3-23,
                                            Call trace);
@@ -11,8 +18,14 @@
                                            Triggering memory operation)]);
       memory_leak = false }
       manifest bugs: []
+<<<<<<< HEAD
     { args = []; pre = []; pc = [(V|0| != V|1|); (0 != V|1|)];
       post = { heap = []; globs = [(x_483, V|1|)] }; ret = (Ok 0);
+=======
+    { args = []; pre = [];
+      pc = [Not((0 Eq IntOfBool(Not((V|0| Eq V|1|))))); Not((0 Eq V|1|))];
+      post = { heap = []; globs = [(x_484, V|1|)] }; ret = (Ok 0);
+>>>>>>> f8274ffd (short-circuit and tests)
       memory_leak = false }
       manifest bugs: []
   

--- a/soteria-c/test/cram/multi-files/duplicate-sym.t/run.t
+++ b/soteria-c/test/cram/multi-files/duplicate-sym.t/run.t
@@ -1,5 +1,5 @@
   $ soteria-c gen-summaries file1.c file2.c -I .
-  Summaries for test_485:
+  Summaries for test_486:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []

--- a/soteria-c/test/cram/multi-files/test0.t/run.t
+++ b/soteria-c/test/cram/multi-files/test0.t/run.t
@@ -1,33 +1,40 @@
   $ soteria-c show-ail file1.c file2.c -I .
   Extern idmap:
-    get_x -> (get_x_485, def);
-    get_xx -> (get_xx_483, def);
-    main -> (main_491, def);
-    x -> (x_490, def)
+    __soteria_nondet__ -> (__soteria_nondet___490, decl);
+    get_x -> (get_x_486, def);
+    get_xx -> (get_xx_484, def);
+    main -> (main_493, def);
+    x -> (x_492, def)
   
   Declarations:
-    get_xx_483 -> function;
-    x_484 -> object;
-    get_x_485 -> function;
-    get_xx_489 -> function;
-    x_490 -> object;
-    main_491 -> function
+    __soteria_nondet___483 -> function;
+    get_xx_484 -> function;
+    x_485 -> object;
+    get_x_486 -> function;
+    __soteria_nondet___490 -> function;
+    get_xx_491 -> function;
+    x_492 -> object;
+    main_493 -> function
   
   Object definitions:
-    (x_484, 12)
-    (x_490, 13)
+    (x_492, 13)
+    (x_485, 12)
   
   Function definitions:
-    get_xx_483
-    get_x_485
-    main_491
+    get_xx_484
+    get_x_486
+    main_493
   
    Symmap:
-    get_xx_483 -> get_xx_483;
-    get_x_485 -> get_x_485;
-    get_xx_489 -> get_xx_483;
-    x_490 -> x_490;
-    main_491 -> main_491
+    __soteria_nondet___483 -> __soteria_nondet___490;
+    get_xx_484 -> get_xx_484;
+    get_x_486 -> get_x_486;
+    get_xx_491 -> get_xx_484;
+    x_492 -> x_492;
+    main_493 -> main_493
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare get_xx WITH PROTO as function () returning signed int
   signed int get_xx()
@@ -43,6 +50,9 @@
   {
     return rvalue(x);
   }
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare get_xx WITH PROTO as function () returning signed int
   signed int get_xx();
@@ -61,8 +71,8 @@
   Symex terminated with the following outcomes:
     [Ok: (25,
           { heap =
-            [(V|0|, [TypedVal {offset = 0; ty = signed int; v = 12}]);
-             (V|1|, [TypedVal {offset = 0; ty = signed int; v = 13}]);
+            [(V|0|, [TypedVal {offset = 0; ty = signed int; v = 13}]);
+             (V|1|, [TypedVal {offset = 0; ty = signed int; v = 12}]);
              (V|2|, Freed)];
-            globs = [(x_484, V|0|); (x_490, V|1|)] })]
+            globs = [(x_485, V|1|); (x_492, V|0|)] })]
   Executed 7 statements

--- a/soteria-c/test/cram/multi-files/test1.t/run.t
+++ b/soteria-c/test/cram/multi-files/test1.t/run.t
@@ -1,43 +1,50 @@
   $ soteria-c show-ail file1.c file2.c -I .
   Extern idmap:
-    __assert__ -> (__assert___486, decl);
-    exposed -> (exposed_496, def);
-    glob -> (glob_494, def);
-    main -> (main_491, def);
-    ref -> (ref_495, def);
-    test -> (test_487, def);
-    update -> (update_489, def)
+    __assert__ -> (__assert___487, decl);
+    __soteria_nondet__ -> (__soteria_nondet___495, decl);
+    exposed -> (exposed_498, def);
+    glob -> (glob_496, def);
+    main -> (main_492, def);
+    ref -> (ref_497, def);
+    test -> (test_488, def);
+    update -> (update_490, def)
   
   Declarations:
-    glob_483 -> object;
-    exposed_484 -> function;
-    __assert___486 -> function;
-    test_487 -> function;
-    update_489 -> function;
-    main_491 -> function;
-    glob_494 -> object;
-    ref_495 -> object;
-    exposed_496 -> function
+    __soteria_nondet___483 -> function;
+    glob_484 -> object;
+    exposed_485 -> function;
+    __assert___487 -> function;
+    test_488 -> function;
+    update_490 -> function;
+    main_492 -> function;
+    __soteria_nondet___495 -> function;
+    glob_496 -> object;
+    ref_497 -> object;
+    exposed_498 -> function
   
   Object definitions:
-    (ref_495, &glob)
-    (glob_494, 42)
+    (ref_497, &glob)
+    (glob_496, 42)
   
   Function definitions:
-    test_487
-    update_489
-    main_491
-    exposed_496
+    test_488
+    update_490
+    main_492
+    exposed_498
   
    Symmap:
-    glob_483 -> glob_494;
-    exposed_484 -> exposed_496;
-    test_487 -> test_487;
-    update_489 -> update_489;
-    main_491 -> main_491;
-    glob_494 -> glob_494;
-    ref_495 -> ref_495;
-    exposed_496 -> exposed_496
+    __soteria_nondet___483 -> __soteria_nondet___495;
+    glob_484 -> glob_496;
+    exposed_485 -> exposed_498;
+    test_488 -> test_488;
+    update_490 -> update_490;
+    main_492 -> main_492;
+    glob_496 -> glob_496;
+    ref_497 -> ref_497;
+    exposed_498 -> exposed_498
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare glob as signed int
   signed int glob;
@@ -69,6 +76,9 @@
     return 0;
   }
   
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
+  
   // declare glob as signed int
   signed int glob = 42;
   
@@ -87,5 +97,5 @@
           { heap =
             [(V|0|, [TypedVal {offset = 0; ty = signed int*; v = &(V|1|, 0)}]);
              (V|1|, [TypedVal {offset = 0; ty = signed int; v = 1024}])];
-            globs = [(glob_494, V|1|); (ref_495, V|0|)] })]
+            globs = [(glob_496, V|1|); (ref_497, V|0|)] })]
   Executed 15 statements

--- a/soteria-c/test/cram/multi-files/test2.t/run.t
+++ b/soteria-c/test/cram/multi-files/test2.t/run.t
@@ -1,30 +1,37 @@
   $ soteria-c show-ail file1.c file2.c -I .
   Extern idmap:
-    __assert__ -> (__assert___491, decl);
-    compute -> (compute_485, def);
-    main -> (main_493, def)
+    __assert__ -> (__assert___493, decl);
+    __soteria_nondet__ -> (__soteria_nondet___491, decl);
+    compute -> (compute_486, def);
+    main -> (main_495, def)
   
   Declarations:
-    __assert___484 -> function;
-    compute_485 -> function;
-    helper_486 -> function;
-    __assert___491 -> function;
-    compute_492 -> function;
-    main_493 -> function
+    __soteria_nondet___483 -> function;
+    __assert___485 -> function;
+    compute_486 -> function;
+    helper_487 -> function;
+    __soteria_nondet___491 -> function;
+    __assert___493 -> function;
+    compute_494 -> function;
+    main_495 -> function
   
   Object definitions:
     
   
   Function definitions:
-    compute_485
-    helper_486
-    main_493
+    compute_486
+    helper_487
+    main_495
   
    Symmap:
-    compute_492 -> compute_485;
-    main_493 -> main_493;
-    __assert___484 -> __assert___491;
-    compute_485 -> compute_485
+    compute_494 -> compute_486;
+    main_495 -> main_495;
+    __soteria_nondet___483 -> __soteria_nondet___491;
+    __assert___485 -> __assert___493;
+    compute_486 -> compute_486
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare __assert__ WITH PROTO as function (signed int) returning signed int
   signed int __assert__(signed int);
@@ -40,6 +47,9 @@
   {
     return 7;
   }
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare __assert__ WITH PROTO as function (signed int) returning signed int
   signed int __assert__(signed int);

--- a/soteria-c/test/cram/multi-files/test3.t/run.t
+++ b/soteria-c/test/cram/multi-files/test3.t/run.t
@@ -1,132 +1,139 @@
   $ soteria-c show-ail file1.c file2.c -I .
   Extern idmap:
-    __assert__ -> (__assert___493, decl);
-    __stderr -> (__stderr_503, decl);
-    __stdin -> (__stdin_504, decl);
-    __stdout -> (__stdout_502, decl);
-    add -> (add_487, def);
-    clearerr -> (clearerr_629, decl);
-    fclose -> (fclose_514, decl);
-    fdopen -> (fdopen_636, decl);
-    feof -> (feof_631, decl);
-    ferror -> (ferror_633, decl);
-    fflush -> (fflush_516, decl);
-    fgetc -> (fgetc_580, decl);
-    fgetpos -> (fgetpos_616, decl);
-    fgets -> (fgets_584, decl);
-    fileno -> (fileno_637, decl);
-    fopen -> (fopen_519, decl);
-    fprintf -> (fprintf_534, decl);
-    fputc -> (fputc_587, decl);
-    fputs -> (fputs_590, decl);
-    fread -> (fread_608, decl);
-    freopen -> (freopen_523, decl);
-    fscanf -> (fscanf_537, decl);
-    fseek -> (fseek_620, decl);
-    fsetpos -> (fsetpos_623, decl);
-    ftell -> (ftell_625, decl);
-    fwrite -> (fwrite_613, decl);
-    getc -> (getc_592, decl);
-    getchar -> (getchar_593, decl);
-    main -> (main_647, def);
-    operate -> (operate_642, def);
-    perror -> (perror_635, decl);
-    printf -> (printf_539, decl);
-    putc -> (putc_596, decl);
-    putchar -> (putchar_598, decl);
-    puts -> (puts_600, decl);
-    remove -> (remove_506, decl);
-    rename -> (rename_509, decl);
-    rewind -> (rewind_627, decl);
-    scanf -> (scanf_541, decl);
-    setbuf -> (setbuf_526, decl);
-    setvbuf -> (setvbuf_531, decl);
-    snprintf -> (snprintf_545, decl);
-    sprintf -> (sprintf_548, decl);
-    sscanf -> (sscanf_551, decl);
-    tmpfile -> (tmpfile_510, decl);
-    tmpnam -> (tmpnam_512, decl);
-    ungetc -> (ungetc_603, decl);
-    vfprintf -> (vfprintf_555, decl);
-    vfscanf -> (vfscanf_559, decl);
-    vprintf -> (vprintf_562, decl);
-    vscanf -> (vscanf_565, decl);
-    vsnprintf -> (vsnprintf_570, decl);
-    vsprintf -> (vsprintf_574, decl);
-    vsscanf -> (vsscanf_578, decl)
+    __assert__ -> (__assert___495, decl);
+    __soteria_nondet__ -> (__soteria_nondet___493, decl);
+    __stderr -> (__stderr_505, decl);
+    __stdin -> (__stdin_506, decl);
+    __stdout -> (__stdout_504, decl);
+    add -> (add_488, def);
+    clearerr -> (clearerr_631, decl);
+    fclose -> (fclose_516, decl);
+    fdopen -> (fdopen_638, decl);
+    feof -> (feof_633, decl);
+    ferror -> (ferror_635, decl);
+    fflush -> (fflush_518, decl);
+    fgetc -> (fgetc_582, decl);
+    fgetpos -> (fgetpos_618, decl);
+    fgets -> (fgets_586, decl);
+    fileno -> (fileno_639, decl);
+    fopen -> (fopen_521, decl);
+    fprintf -> (fprintf_536, decl);
+    fputc -> (fputc_589, decl);
+    fputs -> (fputs_592, decl);
+    fread -> (fread_610, decl);
+    freopen -> (freopen_525, decl);
+    fscanf -> (fscanf_539, decl);
+    fseek -> (fseek_622, decl);
+    fsetpos -> (fsetpos_625, decl);
+    ftell -> (ftell_627, decl);
+    fwrite -> (fwrite_615, decl);
+    getc -> (getc_594, decl);
+    getchar -> (getchar_595, decl);
+    main -> (main_649, def);
+    operate -> (operate_644, def);
+    perror -> (perror_637, decl);
+    printf -> (printf_541, decl);
+    putc -> (putc_598, decl);
+    putchar -> (putchar_600, decl);
+    puts -> (puts_602, decl);
+    remove -> (remove_508, decl);
+    rename -> (rename_511, decl);
+    rewind -> (rewind_629, decl);
+    scanf -> (scanf_543, decl);
+    setbuf -> (setbuf_528, decl);
+    setvbuf -> (setvbuf_533, decl);
+    snprintf -> (snprintf_547, decl);
+    sprintf -> (sprintf_550, decl);
+    sscanf -> (sscanf_553, decl);
+    tmpfile -> (tmpfile_512, decl);
+    tmpnam -> (tmpnam_514, decl);
+    ungetc -> (ungetc_605, decl);
+    vfprintf -> (vfprintf_557, decl);
+    vfscanf -> (vfscanf_561, decl);
+    vprintf -> (vprintf_564, decl);
+    vscanf -> (vscanf_567, decl);
+    vsnprintf -> (vsnprintf_572, decl);
+    vsprintf -> (vsprintf_576, decl);
+    vsscanf -> (vsscanf_580, decl)
   
   Declarations:
-    __assert___484 -> function;
-    add_487 -> function;
-    __assert___493 -> function;
-    add_496 -> function;
-    __stdout_502 -> object;
-    __stderr_503 -> object;
-    __stdin_504 -> object;
-    remove_506 -> function;
-    rename_509 -> function;
-    tmpfile_510 -> function;
-    tmpnam_512 -> function;
-    fclose_514 -> function;
-    fflush_516 -> function;
-    fopen_519 -> function;
-    freopen_523 -> function;
-    setbuf_526 -> function;
-    setvbuf_531 -> function;
-    fprintf_534 -> function;
-    fscanf_537 -> function;
-    printf_539 -> function;
-    scanf_541 -> function;
-    snprintf_545 -> function;
-    sprintf_548 -> function;
-    sscanf_551 -> function;
-    vfprintf_555 -> function;
-    vfscanf_559 -> function;
-    vprintf_562 -> function;
-    vscanf_565 -> function;
-    vsnprintf_570 -> function;
-    vsprintf_574 -> function;
-    vsscanf_578 -> function;
-    fgetc_580 -> function;
-    fgets_584 -> function;
-    fputc_587 -> function;
-    fputs_590 -> function;
-    getc_592 -> function;
-    getchar_593 -> function;
-    putc_596 -> function;
-    putchar_598 -> function;
-    puts_600 -> function;
-    ungetc_603 -> function;
-    fread_608 -> function;
-    fwrite_613 -> function;
-    fgetpos_616 -> function;
-    fseek_620 -> function;
-    fsetpos_623 -> function;
-    ftell_625 -> function;
-    rewind_627 -> function;
-    clearerr_629 -> function;
-    feof_631 -> function;
-    ferror_633 -> function;
-    perror_635 -> function;
-    fdopen_636 -> function;
-    fileno_637 -> function;
-    operate_642 -> function;
-    main_647 -> function
+    __soteria_nondet___483 -> function;
+    __assert___485 -> function;
+    add_488 -> function;
+    __soteria_nondet___493 -> function;
+    __assert___495 -> function;
+    add_498 -> function;
+    __stdout_504 -> object;
+    __stderr_505 -> object;
+    __stdin_506 -> object;
+    remove_508 -> function;
+    rename_511 -> function;
+    tmpfile_512 -> function;
+    tmpnam_514 -> function;
+    fclose_516 -> function;
+    fflush_518 -> function;
+    fopen_521 -> function;
+    freopen_525 -> function;
+    setbuf_528 -> function;
+    setvbuf_533 -> function;
+    fprintf_536 -> function;
+    fscanf_539 -> function;
+    printf_541 -> function;
+    scanf_543 -> function;
+    snprintf_547 -> function;
+    sprintf_550 -> function;
+    sscanf_553 -> function;
+    vfprintf_557 -> function;
+    vfscanf_561 -> function;
+    vprintf_564 -> function;
+    vscanf_567 -> function;
+    vsnprintf_572 -> function;
+    vsprintf_576 -> function;
+    vsscanf_580 -> function;
+    fgetc_582 -> function;
+    fgets_586 -> function;
+    fputc_589 -> function;
+    fputs_592 -> function;
+    getc_594 -> function;
+    getchar_595 -> function;
+    putc_598 -> function;
+    putchar_600 -> function;
+    puts_602 -> function;
+    ungetc_605 -> function;
+    fread_610 -> function;
+    fwrite_615 -> function;
+    fgetpos_618 -> function;
+    fseek_622 -> function;
+    fsetpos_625 -> function;
+    ftell_627 -> function;
+    rewind_629 -> function;
+    clearerr_631 -> function;
+    feof_633 -> function;
+    ferror_635 -> function;
+    perror_637 -> function;
+    fdopen_638 -> function;
+    fileno_639 -> function;
+    operate_644 -> function;
+    main_649 -> function
   
   Object definitions:
     
   
   Function definitions:
-    add_487
-    operate_642
-    main_647
+    add_488
+    operate_644
+    main_649
   
    Symmap:
-    add_496 -> add_487;
-    operate_642 -> operate_642;
-    main_647 -> main_647;
-    __assert___484 -> __assert___493;
-    add_487 -> add_487
+    add_498 -> add_488;
+    operate_644 -> operate_644;
+    main_649 -> main_649;
+    __soteria_nondet___483 -> __soteria_nondet___493;
+    __assert___485 -> __assert___495;
+    add_488 -> add_488
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare __assert__ WITH PROTO as function (signed int) returning signed int
   signed int __assert__(signed int);
@@ -136,6 +143,9 @@
   {
     return rvalue(x) + rvalue(y);
   }
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare __assert__ WITH PROTO as function (signed int) returning signed int
   signed int __assert__(signed int);

--- a/soteria-c/test/cram/multi-files/test4.t/run.t
+++ b/soteria-c/test/cram/multi-files/test4.t/run.t
@@ -1,34 +1,41 @@
   $ soteria-c show-ail file1.c file2.c -I .
   Extern idmap:
-    __assert__ -> (__assert___491, decl);
-    funcA -> (funcA_492, def);
-    funcB -> (funcB_485, def);
-    main -> (main_488, def)
+    __assert__ -> (__assert___493, decl);
+    __soteria_nondet__ -> (__soteria_nondet___492, decl);
+    funcA -> (funcA_494, def);
+    funcB -> (funcB_486, def);
+    main -> (main_489, def)
   
   Declarations:
-    __assert___483 -> function;
-    funcA_484 -> function;
-    funcB_485 -> function;
-    main_488 -> function;
-    __assert___491 -> function;
-    funcA_492 -> function;
-    funcB_493 -> function
+    __soteria_nondet___483 -> function;
+    __assert___484 -> function;
+    funcA_485 -> function;
+    funcB_486 -> function;
+    main_489 -> function;
+    __soteria_nondet___492 -> function;
+    __assert___493 -> function;
+    funcA_494 -> function;
+    funcB_495 -> function
   
   Object definitions:
     
   
   Function definitions:
-    funcB_485
-    main_488
-    funcA_492
+    funcB_486
+    main_489
+    funcA_494
   
    Symmap:
-    __assert___483 -> __assert___491;
-    funcA_484 -> funcA_492;
-    funcB_485 -> funcB_485;
-    main_488 -> main_488;
-    funcA_492 -> funcA_492;
-    funcB_493 -> funcB_485
+    __soteria_nondet___483 -> __soteria_nondet___492;
+    __assert___484 -> __assert___493;
+    funcA_485 -> funcA_494;
+    funcB_486 -> funcB_486;
+    main_489 -> main_489;
+    funcA_494 -> funcA_494;
+    funcB_495 -> funcB_486
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare __assert__ WITH PROTO as function (signed int) returning signed int
   signed int __assert__(signed int);
@@ -53,6 +60,9 @@
     function_decay(__assert__)((function_decay(funcA)(5) == 1));
     return 0;
   }
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare __assert__ WITH PROTO as function (signed int) returning signed int
   signed int __assert__(signed int);

--- a/soteria-c/test/cram/multi-files/test5.t/run.t
+++ b/soteria-c/test/cram/multi-files/test5.t/run.t
@@ -1,32 +1,41 @@
   $ soteria-c show-ail file1.c file2.c file3.c -I .
   Extern idmap:
-    __assert__ -> (__assert___489, decl);
-    fnA -> (fnA_483, def);
-    fnB -> (fnB_486, def);
-    main -> (main_492, def)
+    __assert__ -> (__assert___492, decl);
+    __soteria_nondet__ -> (__soteria_nondet___491, decl);
+    fnA -> (fnA_484, def);
+    fnB -> (fnB_488, def);
+    main -> (main_495, def)
   
   Declarations:
-    fnA_483 -> function;
-    fnB_486 -> function;
-    __assert___489 -> function;
-    fnA_490 -> function;
-    fnB_491 -> function;
-    main_492 -> function
+    __soteria_nondet___483 -> function;
+    fnA_484 -> function;
+    __soteria_nondet___487 -> function;
+    fnB_488 -> function;
+    __soteria_nondet___491 -> function;
+    __assert___492 -> function;
+    fnA_493 -> function;
+    fnB_494 -> function;
+    main_495 -> function
   
   Object definitions:
     
   
   Function definitions:
-    fnA_483
-    fnB_486
-    main_492
+    fnA_484
+    fnB_488
+    main_495
   
    Symmap:
-    fnB_486 -> fnB_486;
-    fnA_490 -> fnA_483;
-    fnB_491 -> fnB_486;
-    main_492 -> main_492;
-    fnA_483 -> fnA_483
+    __soteria_nondet___487 -> __soteria_nondet___491;
+    fnB_488 -> fnB_488;
+    fnA_493 -> fnA_484;
+    fnB_494 -> fnB_488;
+    main_495 -> main_495;
+    __soteria_nondet___483 -> __soteria_nondet___491;
+    fnA_484 -> fnA_484
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare fnA as function () returning signed int
   signed int fnA()
@@ -34,11 +43,17 @@
     return 12;
   }
   
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
+  
   // declare fnB as function () returning signed int
   signed int fnB()
   {
     return 16;
   }
+  
+  // declare __soteria_nondet__ WITH PROTO as function () returning signed int
+  signed int __soteria_nondet__();
   
   // declare __assert__ WITH PROTO as function (signed int) returning signed int
   signed int __assert__(signed int);

--- a/soteria-c/test/cram/simple.t/run.t
+++ b/soteria-c/test/cram/simple.t/run.t
@@ -329,6 +329,6 @@ Checking that code cannot branch infinitely
 Should return a single branch!
   $ soteria-c exec-main short_circuit_opt.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
   Symex terminated with the following outcomes:
-    [Ok: (IntOfBool((Not((0 Eq V|3|)) And Not((0 Eq V|1|)))),
+    [Ok: (b2i(((0 != V|3|) && (0 != V|1|))),
           { heap = [(V|0|, Freed); (V|2|, Freed)]; globs = [] })]
   Executed 4 statements

--- a/soteria-c/test/cram/simple.t/run.t
+++ b/soteria-c/test/cram/simple.t/run.t
@@ -303,7 +303,7 @@ Checking that code cannot branch infinitely
   Symex terminated with the following outcomes:
     [Ok: (1,
           { heap = [(V|0|, [TypedVal {offset = 0; ty = signed int; v = 1}])];
-            globs = [(x_483, V|0|)] })]
+            globs = [(x_484, V|0|)] })]
   Executed 5 statements
   $ soteria-c exec-main global_alias.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
   Symex terminated with the following outcomes:
@@ -311,7 +311,7 @@ Checking that code cannot branch infinitely
           { heap =
             [(V|0|, [TypedVal {offset = 0; ty = signed int; v = 0}]);
              (V|1|, [TypedVal {offset = 0; ty = signed int; v = 0}])];
-            globs = [(x_585, V|0|); (y_586, V|1|)] })]
+            globs = [(x_586, V|0|); (y_587, V|1|)] })]
   Executed 3 statements
 
   $ soteria-c exec-main structs.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
@@ -320,3 +320,15 @@ Checking that code cannot branch infinitely
           { heap = [(V|0|, Freed); (V|1|, Freed); (V|2|, Freed)]; globs = [] });
      Ok: (1, { heap = [(V|0|, Freed); (V|1|, Freed)]; globs = [] })]
   Executed 16 statements
+
+  $ soteria-c exec-main short_circuit.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
+  Symex terminated with the following outcomes:
+    [Ok: (0,
+          { heap = [(V|0|, Freed); (V|1|, Freed); (V|2|, Freed)]; globs = [] })]
+  Executed 7 statements
+Should return a single branch!
+  $ soteria-c exec-main short_circuit_opt.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
+  Symex terminated with the following outcomes:
+    [Ok: (IntOfBool((Not((0 Eq V|3|)) And Not((0 Eq V|1|)))),
+          { heap = [(V|0|, Freed); (V|2|, Freed)]; globs = [] })]
+  Executed 4 statements

--- a/soteria-c/test/cram/simple.t/short_circuit.c
+++ b/soteria-c/test/cram/simple.t/short_circuit.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+int main()
+{
+  int y = 2;
+  int *z = (int *)NULL;
+  int _ = y > 0 || (*z);
+  _ = y < 1 && (*z);
+  _ = y > 0 && y < 1;
+  return 0;
+}

--- a/soteria-c/test/cram/simple.t/short_circuit_opt.c
+++ b/soteria-c/test/cram/simple.t/short_circuit_opt.c
@@ -1,0 +1,9 @@
+// Test that we do optimise short circuit evaluation if the LHS is not side-effectful.
+
+int main()
+{
+  int x = __soteria_nondet__();
+  int y = __soteria_nondet__();
+  // If this returns a single branch, optimisation is working.
+  return x && y;
+}

--- a/soteria-c/test/cram/simple.t/sym.c
+++ b/soteria-c/test/cram/simple.t/sym.c
@@ -1,5 +1,3 @@
-int __nondet__();
-
 int simple(int x)
 {
   if (x >= 5)
@@ -18,6 +16,6 @@ int simple(int x)
 
 int main()
 {
-  int x = __nondet__();
+  int x = __soteria_nondet__();
   return simple(x);
 }

--- a/soteria-c/test/cram/simple.t/while_true.c
+++ b/soteria-c/test/cram/simple.t/while_true.c
@@ -1,10 +1,10 @@
 int *malloc(__cerbty_size_t);
-int __nondet__();
+
 int __assert__(int);
 
 int main()
 {
-  int y = __nondet__();
+  int y = __soteria_nondet__();
   if (y)
   {
     __assert__(0);

--- a/soteria-c/test/cram/simple_bi.t/run.t
+++ b/soteria-c/test/cram/simple_bi.t/run.t
@@ -41,7 +41,28 @@
       ret = (Ok V|3|); memory_leak = false }
       manifest bugs: []
   
-  Summaries for test_uninit_491:
+  Summaries for test_leak_499:
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret = (Ok 0); memory_leak = true }
+      manifest bugs: [Memory leak with trace [(manifest.c:26:1-34:2 (cursor: 26:5 - 26:14),
+                                               )]]
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret = (Ok 1); memory_leak = false }
+      manifest bugs: []
+  
+  Summaries for test_np_510:
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret = (Ok 0); memory_leak = false }
+      manifest bugs: []
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret =
+      (Error NullDereference with trace [(manifest.c:51:3-10 (cursor: 51:6),
+                                          Triggering memory operation)]);
+      memory_leak = false }
+      manifest bugs: [NullDereference with trace [(manifest.c:51:3-10 (cursor: 51:6),
+                                                   Triggering memory operation)]]
+  
+  Summaries for test_uninit_493:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret =
       (Error UninitializedMemoryAccess with trace [(manifest.c:21:3-10,
@@ -57,28 +78,7 @@
       ret = (Ok 1); memory_leak = false }
       manifest bugs: []
   
-  Summaries for test_leak_494:
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret = (Ok 0); memory_leak = true }
-      manifest bugs: [Memory leak with trace [(manifest.c:26:1-34:2 (cursor: 26:5 - 26:14),
-                                               )]]
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret = (Ok 1); memory_leak = false }
-      manifest bugs: []
-  
-  Summaries for test_np_500:
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret = (Ok 0); memory_leak = false }
-      manifest bugs: []
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret =
-      (Error NullDereference with trace [(manifest.c:51:3-10 (cursor: 51:6),
-                                          Triggering memory operation)]);
-      memory_leak = false }
-      manifest bugs: [NullDereference with trace [(manifest.c:51:3-10 (cursor: 51:6),
-                                                   Triggering memory operation)]]
-  
-  Summaries for test_ok_497:
+  Summaries for test_ok_504:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = false }
       manifest bugs: []

--- a/soteria-c/test/cram/simple_bi.t/run.t
+++ b/soteria-c/test/cram/simple_bi.t/run.t
@@ -1,6 +1,11 @@
   $ soteria-c gen-summaries load.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
+<<<<<<< HEAD
   Summaries for f_484:
     { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 == V|0|)];
+=======
+  Summaries for f_485:
+    { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 Eq V|0|)];
+>>>>>>> f8274ffd (short-circuit and tests)
       post = { heap = []; globs = [] };
       ret =
       (Error NullDereference with trace [(load.c:3:10-12 (cursor: 3:10),
@@ -21,8 +26,13 @@
   
 
   $ soteria-c gen-summaries manifest.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
+<<<<<<< HEAD
   Summaries for load_486:
     { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 == V|0|)];
+=======
+  Summaries for load_487:
+    { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 Eq V|0|)];
+>>>>>>> f8274ffd (short-circuit and tests)
       post = { heap = []; globs = [] };
       ret =
       (Error NullDereference with trace [(manifest.c:6:10-12 (cursor: 6:10),
@@ -41,7 +51,7 @@
       ret = (Ok V|3|); memory_leak = false }
       manifest bugs: []
   
-  Summaries for test_leak_499:
+  Summaries for test_leak_495:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret = (Ok 0); memory_leak = true }
       manifest bugs: [Memory leak with trace [(manifest.c:26:1-34:2 (cursor: 26:5 - 26:14),
@@ -50,43 +60,7 @@
       ret = (Ok 1); memory_leak = false }
       manifest bugs: []
   
-  Summaries for test_np_510:
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret = (Ok 0); memory_leak = false }
-      manifest bugs: []
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret =
-      (Error NullDereference with trace [(manifest.c:51:3-10 (cursor: 51:6),
-                                          Triggering memory operation)]);
-      memory_leak = false }
-      manifest bugs: [NullDereference with trace [(manifest.c:51:3-10 (cursor: 51:6),
-                                                   Triggering memory operation)]]
-  
-  Summaries for test_uninit_493:
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret =
-      (Error UninitializedMemoryAccess with trace [(manifest.c:21:3-10,
-                                                    Call trace);
-                                                   (manifest.c:6:10-12 (cursor: 6:10),
-                                                    Triggering memory operation)]);
-      memory_leak = false }
-      manifest bugs: [UninitializedMemoryAccess with trace [(manifest.c:21:3-10,
-                                                             Call trace);
-                                                            (manifest.c:6:10-12 (cursor: 6:10),
-                                                             Triggering memory operation)]]
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret = (Ok 1); memory_leak = false }
-      manifest bugs: []
-  
-  Summaries for test_ok_504:
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret = (Ok 0); memory_leak = false }
-      manifest bugs: []
-    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
-      ret = (Ok 1); memory_leak = false }
-      manifest bugs: []
-  
-  Summaries for test_np_uninit_488:
+  Summaries for test_np_uninit_489:
     { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
       ret =
       (Error UninitializedMemoryAccess with trace [(manifest.c:12:3-10,
@@ -109,10 +83,46 @@
                                                   (manifest.c:6:10-12 (cursor: 6:10),
                                                    Triggering memory operation)]]
   
+  Summaries for test_ok_498:
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret = (Ok 0); memory_leak = false }
+      manifest bugs: []
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret = (Ok 1); memory_leak = false }
+      manifest bugs: []
+  
+  Summaries for test_uninit_492:
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret =
+      (Error UninitializedMemoryAccess with trace [(manifest.c:21:3-10,
+                                                    Call trace);
+                                                   (manifest.c:6:10-12 (cursor: 6:10),
+                                                    Triggering memory operation)]);
+      memory_leak = false }
+      manifest bugs: [UninitializedMemoryAccess with trace [(manifest.c:21:3-10,
+                                                             Call trace);
+                                                            (manifest.c:6:10-12 (cursor: 6:10),
+                                                             Triggering memory operation)]]
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret = (Ok 1); memory_leak = false }
+      manifest bugs: []
+  
+  Summaries for test_np_501:
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret = (Ok 0); memory_leak = false }
+      manifest bugs: []
+    { args = []; pre = []; pc = []; post = { heap = []; globs = [] };
+      ret =
+      (Error NullDereference with trace [(manifest.c:51:3-10 (cursor: 51:6),
+                                          Triggering memory operation)]);
+      memory_leak = false }
+      manifest bugs: [NullDereference with trace [(manifest.c:51:3-10 (cursor: 51:6),
+                                                   Triggering memory operation)]]
+  
 The following test case is for regression testing.
 if%sat1 had the wrong semantics and would not correctly backtrack.
   $ soteria-c gen-summaries if_sat_one_ok.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
-  Summaries for test_485:
+  Summaries for test_486:
     { args = [V|0|; &(V|1|, V|2|)]; pre = [];
       pc =
       [(0 == V|1|); (0 < V|0|); (V|0| <= 0x7fffffff); (-0x80000000 <= V|0|)];

--- a/soteria-c/test/cram/simple_bi.t/run.t
+++ b/soteria-c/test/cram/simple_bi.t/run.t
@@ -1,11 +1,6 @@
   $ soteria-c gen-summaries load.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
-<<<<<<< HEAD
-  Summaries for f_484:
-    { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 == V|0|)];
-=======
   Summaries for f_485:
-    { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 Eq V|0|)];
->>>>>>> f8274ffd (short-circuit and tests)
+    { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 == V|0|)];
       post = { heap = []; globs = [] };
       ret =
       (Error NullDereference with trace [(load.c:3:10-12 (cursor: 3:10),
@@ -26,13 +21,8 @@
   
 
   $ soteria-c gen-summaries manifest.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
-<<<<<<< HEAD
-  Summaries for load_486:
-    { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 == V|0|)];
-=======
   Summaries for load_487:
-    { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 Eq V|0|)];
->>>>>>> f8274ffd (short-circuit and tests)
+    { args = [&(V|0|, V|1|)]; pre = []; pc = [(0 == V|0|)];
       post = { heap = []; globs = [] };
       ret =
       (Error NullDereference with trace [(manifest.c:6:10-12 (cursor: 6:10),


### PR DESCRIPTION
Note: function identifiers change when I update cerberus, I should maybe remove them from the output