### PR TITLE
More SValues !

### DIFF
--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -427,21 +427,34 @@ module Make (Heap : Heap_intf.S) = struct
         match (v1, v2) with
         | Base v1, Base v2 -> (
             match op with
-            | Ge | Gt | Lt | Le ->
-                let op =
-                  match op with
-                  | Ge -> Typed.geq
-                  | Gt -> Typed.gt
-                  | Lt -> Typed.lt
-                  | Le -> Typed.leq
-                  | _ -> assert false
-                in
+            | Ge | Gt | Lt | Le -> (
                 let* v1, v2, ty = cast_checked2 v1 v2 in
-                if Typed.equal_ty ty Typed.t_ptr then
-                  Heap.error `UBPointerComparison state
-                else
-                  let v = op v1 v2 |> Typed.int_of_bool in
-                  Result.ok (Base v, state)
+                match Typed.untype_type ty with
+                | Svalue.TInt ->
+                    let op =
+                      match op with
+                      | Ge -> Typed.geq
+                      | Gt -> Typed.gt
+                      | Lt -> Typed.lt
+                      | Le -> Typed.leq
+                      | _ -> assert false
+                    in
+                    let v = op v1 v2 |> Typed.int_of_bool in
+                    Result.ok (Base v, state)
+                | TFloat _ ->
+                    let op =
+                      match op with
+                      | Ge -> Typed.geq_f
+                      | Gt -> Typed.gt_f
+                      | Lt -> Typed.lt_f
+                      | Le -> Typed.leq_f
+                      | _ -> assert false
+                    in
+                    let v1, v2 = (Typed.cast v1, Typed.cast v2) in
+                    let v = op v1 v2 |> Typed.int_of_bool in
+                    Result.ok (Base v, state)
+                | TPointer -> Heap.error `UBPointerComparison state
+                | _ -> assert false)
             | Eq | Ne ->
                 let* v1, v2, _ = cast_checked2 v1 v2 in
                 let++ res = Core.equality_check v1 v2 state in

--- a/soteria/lib/c_values/typed.mli
+++ b/soteria/lib/c_values/typed.mli
@@ -8,7 +8,6 @@ module T : sig
   type sptr = [ `Ptr ]
   type sloc = [ `Loc ]
   type 'a sseq = [ `List of 'a ]
-  type cnum = [ sint | sfloat ]
   type cval = [ sint | sptr | sfloat ]
 
   type any =
@@ -89,6 +88,7 @@ val or_ : [< sbool ] t -> [< sbool ] t -> [> sbool ] t
 val not : sbool t -> sbool t
 val not_int_bool : [< sint ] t -> [> sint ] t
 val distinct : 'a t list -> [> sbool ] t
+val ite : [< sbool ] t -> 'a t -> 'a t -> 'a t
 val int_z : Z.t -> [> sint ] t
 val int : int -> [> sint ] t
 val nonzero_z : Z.t -> [> nonzero ] t
@@ -106,18 +106,20 @@ val f64 : float -> [> sfloat ] t
 val f128 : float -> [> sfloat ] t
 val float_like : [> sfloat ] t -> float -> [> sfloat ] t
 val fp_of : [< sfloat ] t -> Svalue.FloatPrecision.t
-val geq : ([< cnum ] as 'a) t -> 'a t -> [> sbool ] t
-val gt : ([< cnum ] as 'a) t -> 'a t -> [> sbool ] t
-val leq : ([< cnum ] as 'a) t -> 'a t -> [> sbool ] t
-val lt : ([< cnum ] as 'a) t -> 'a t -> [> sbool ] t
-val plus : ([< cnum ] as 'a) t -> 'a t -> 'a t
-val minus : ([< cnum ] as 'a) t -> 'a t -> 'a t
-val times : ([< cnum ] as 'a) t -> 'a t -> 'a t
-val div : ([< cnum ] as 'a) t -> [< nonzero ] t -> 'a t
-val rem : ([< cnum ] as 'a) t -> [< nonzero ] t -> 'a t
+
+(** Integer operations *)
+
+val geq : [< sint ] t -> [< sint ] t -> [> sbool ] t
+val gt : [< sint ] t -> [< sint ] t -> [> sbool ] t
+val leq : [< sint ] t -> [< sint ] t -> [> sbool ] t
+val lt : [< sint ] t -> [< sint ] t -> [> sbool ] t
+val plus : [< sint ] t -> [< sint ] t -> [> sint ] t
+val minus : [< sint ] t -> [< sint ] t -> [> sint ] t
+val times : [< sint ] t -> [< sint ] t -> [> sint ] t
+val div : [< sint ] t -> [< nonzero ] t -> [> sint ] t
+val rem : [< sint ] t -> [< nonzero ] t -> [> sint ] t
 val mod_ : [< sint ] t -> nonzero t -> [> sint ] t
-val abs : ([< cnum ] as 'a) t -> 'a t
-val neg : ([< cnum ] as 'a) t -> 'a t
+val neg : ([< sint | sfloat ] as 'a) t -> 'a t
 
 val bit_and :
   size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
@@ -133,6 +135,25 @@ val bit_shl :
 
 val bit_shr :
   size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+
+(** Floating point operations *)
+
+val eq_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+val geq_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+val gt_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+val leq_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+val lt_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+val plus_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+val minus_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+val times_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+val div_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+val rem_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+val abs_f : [< sfloat ] t -> [> sfloat ] t
+val is_normal : [< sfloat ] t -> [> sbool ] t
+val is_subnormal : [< sfloat ] t -> [> sbool ] t
+val is_zero : [< sfloat ] t -> [> sbool ] t
+val is_infinite : [< sfloat ] t -> [> sbool ] t
+val is_nan : [< sfloat ] t -> [> sbool ] t
 
 module Ptr : sig
   val mk : [< sloc ] t -> [< sint ] t -> [> sptr ] t
@@ -159,19 +180,23 @@ module Infix : sig
   val ( >=@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
   val ( <@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
   val ( <=@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
-  val ( &&@ ) : [< sbool ] t -> [< sbool ] t -> [< sbool ] t
-  val ( ||@ ) : [< sbool ] t -> [< sbool ] t -> [< sbool ] t
+  val ( &&@ ) : [< sbool ] t -> [< sbool ] t -> [> sbool ] t
+  val ( ||@ ) : [< sbool ] t -> [< sbool ] t -> [> sbool ] t
   val ( +@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
   val ( -@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
   val ( ~- ) : [< sint ] t -> [> sint ] t
   val ( *@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
   val ( /@ ) : [< sint ] t -> [< nonzero ] t -> [> sint ] t
   val ( %@ ) : [< sint ] t -> [< nonzero ] t -> [> sint ] t
+  val ( ==.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val ( >.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val ( >=.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val ( <.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val ( <=.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
   val ( +.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
   val ( -.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
   val ( *.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
-  val ( /.@ ) : [< sfloat ] t -> [< nonzero ] t -> [> sfloat ] t
-  val ( %.@ ) : [< sfloat ] t -> [< nonzero ] t -> [> sfloat ] t
+  val ( /.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
 end
 
 module Syntax : sig

--- a/soteria/lib/c_values/z3solver.ml
+++ b/soteria/lib/c_values/z3solver.ml
@@ -285,19 +285,14 @@ let rec encode_value (v : Svalue.t) =
   | Var v -> atom (Svalue.Var.to_string v)
   | Int z -> int_zk z
   | Float f -> (
-      match v.node.ty with
-      | TFloat F16 -> f16_k @@ Float.of_string f
-      | TFloat F32 -> f32_k @@ Float.of_string f
-      | TFloat F64 -> f64_k @@ Float.of_string f
-      | TFloat F128 -> f128_k @@ Float.of_string f
-      | _ -> failwith "Non-float type given")
+      match Svalue.precision_of_f v.node.ty with
+      | F16 -> f16_k @@ Float.of_string f
+      | F32 -> f32_k @@ Float.of_string f
+      | F64 -> f64_k @@ Float.of_string f
+      | F128 -> f128_k @@ Float.of_string f)
   | Bool b -> bool_k b
   | BitVec z ->
-      let n =
-        match v.node.ty with
-        | TBitVector n -> n
-        | _ -> failwith "Non-bitvector type given"
-      in
+      let n = Svalue.size_of_bv v.node.ty in
       bv_k n z
   | Ptr (l, o) -> mk_ptr (encode_value_memo l) (encode_value_memo o)
   | Seq vs -> (
@@ -311,56 +306,58 @@ let rec encode_value (v : Svalue.t) =
       let v1 = encode_value_memo v1_ in
       match unop with
       | Not -> bool_not v1
+      | FAbs -> fp_abs v1
       | GetPtrLoc -> get_loc v1
       | GetPtrOfs -> get_ofs v1
       | IntOfBool -> ite v1 (int_k 1) (int_k 0)
       | BvOfInt ->
-          let size =
-            match v.node.ty with
-            | TBitVector n -> n
-            | _ -> failwith "Non-bitvector type given"
-          in
+          let size = Svalue.size_of_bv v.node.ty in
           bv_of_int size v1
       | IntOfBv signed -> int_of_bv signed v1
       | BvOfFloat -> (
-          match v1_.node.ty with
-          | TFloat F16 -> bv_of_f16 v1
-          | TFloat F32 -> bv_of_f32 v1
-          | TFloat F64 -> bv_of_f64 v1
-          | TFloat F128 -> bv_of_f128 v1
-          | _ -> failwith "Non-float type given")
+          match Svalue.precision_of_f v.node.ty with
+          | F16 -> bv_of_f16 v1
+          | F32 -> bv_of_f32 v1
+          | F64 -> bv_of_f64 v1
+          | F128 -> bv_of_f128 v1)
       | FloatOfBv -> (
-          match v.node.ty with
-          | TFloat F16 -> f16_of_bv v1
-          | TFloat F32 -> f32_of_bv v1
-          | TFloat F64 -> f64_of_bv v1
-          | TFloat F128 -> f128_of_bv v1
-          | _ -> failwith "Non-float type given")
-      | BvExtract (from_, to_) -> bv_extract to_ from_ v1)
+          match Svalue.precision_of_f v.node.ty with
+          | F16 -> f16_of_bv v1
+          | F32 -> f32_of_bv v1
+          | F64 -> f64_of_bv v1
+          | F128 -> f128_of_bv v1)
+      | BvExtract (from_, to_) -> bv_extract to_ from_ v1
+      | FIs fc -> fp_is fc v1)
   | Binop (binop, v1, v2) -> (
-      let ty = v1.node.ty in
       let v1 = encode_value_memo v1 in
       let v2 = encode_value_memo v2 in
       match binop with
       | Eq -> eq v1 v2
-      | Leq -> (if Svalue.is_float ty then fp_leq else num_leq) v1 v2
-      | Lt -> (if Svalue.is_float ty then fp_lt else num_lt) v1 v2
+      | Leq -> num_leq v1 v2
+      | Lt -> num_lt v1 v2
       | And -> bool_and v1 v2
       | Or -> bool_or v1 v2
-      | Plus -> (if Svalue.is_float ty then fp_add else num_add) v1 v2
-      | Minus -> (if Svalue.is_float ty then fp_sub else num_sub) v1 v2
-      | Times -> (if Svalue.is_float ty then fp_mul else num_mul) v1 v2
-      | Div -> (if Svalue.is_float ty then fp_div else num_div) v1 v2
-      | Rem -> (if Svalue.is_float ty then fp_rem else num_rem) v1 v2
-      | Mod ->
-          if Svalue.is_float ty then
-            failwith "mod not implemented for floating points"
-          else num_mod v1 v2
+      | Plus -> num_add v1 v2
+      | Minus -> num_sub v1 v2
+      | Times -> num_mul v1 v2
+      | Div -> num_div v1 v2
+      | Rem -> num_rem v1 v2
+      | Mod -> num_mod v1 v2
+      | FEq -> fp_eq v1 v2
+      | FLeq -> fp_leq v1 v2
+      | FLt -> fp_lt v1 v2
+      | FPlus -> fp_add v1 v2
+      | FMinus -> fp_sub v1 v2
+      | FTimes -> fp_mul v1 v2
+      | FDiv -> fp_div v1 v2
+      | FRem -> fp_rem v1 v2
       | BitAnd -> bv_and v1 v2
       | BitOr -> bv_or v1 v2
       | BitXor -> bv_xor v1 v2
       | BitShl -> bv_shl v1 v2
-      | BitShr -> bv_ashr v1 v2)
+      | BitShr -> bv_lshr v1 v2
+      | BvPlus -> bv_add v1 v2
+      | BvMinus -> bv_sub v1 v2)
   | Nop (Distinct, vs) ->
       let vs = List.map encode_value_memo vs in
       distinct vs

--- a/soteria/lib/c_values/z3utils.ml
+++ b/soteria/lib/c_values/z3utils.ml
@@ -57,6 +57,14 @@ let fp_mul f1 f2 = app_ "fp.mul" [ rm; f1; f2 ]
 let fp_div f1 f2 = app_ "fp.div" [ rm; f1; f2 ]
 let fp_rem f1 f2 = app_ "fp.rem" [ f1; f2 ]
 
+let fp_is fc f =
+  match fc with
+  | FP_normal -> app_ "fp.isNormal" [ f ]
+  | FP_subnormal -> app_ "fp.isSubnormal" [ f ]
+  | FP_zero -> app_ "fp.isZero" [ f ]
+  | FP_infinite -> app_ "fp.isInfinite" [ f ]
+  | FP_nan -> app_ "fp.isNaN" [ f ]
+
 (* Float{Of,To}Bv *)
 
 let f16_of_bv bv = app (ifam "to_fp" [ 5; 11 ]) [ bv ]


### PR DESCRIPTION
- Type operators for floats: `==`, `<`, `<=`, `+`, `-`, `*`, `/`, `rem`, `abs`
- Add floating-point class unop: `FIs {NaN,Inf,Normal,Subnormal,Zero}` -- Rust has functions that do this with bitwise operations but that's 1. super slow and 2. broken, for some reason
- Add bitvector `+` and `-`, which allows usually deeper conversions in `bv_of_int`
- Make most functions in `SValue` recursive and chain them with `and`
  This is just because they often end up calling each other and having to move them to make things work was getting annoying so yeah...
