### PR TITLE
Add `eval` and `eval-diff` commands to script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,7 @@ __pycache__/
 
 ### Produced by Soteria ###
 json_dump/
+soteria-rust/scripts/*.csv
 
 # Created using: https://www.toptal.com/developers/gitignore/api/node,ocaml
 # and modified by hand afterwards

--- a/soteria-rust/scripts/test.py
+++ b/soteria-rust/scripts/test.py
@@ -4,13 +4,23 @@
 from ast import expr
 from io import TextIOWrapper
 from pathlib import Path
+from posixpath import pardir
 import time
 import datetime
 from types import FunctionType
 from typing import Callable
+import math
 
 from common import *
 from parselog import *
+
+DynFlagFn = Optional[Callable[[Path], list[str]]]
+
+
+class TestConfig(TypedDict):
+    root: Path
+    args: list[str]
+    dyn_flags: DynFlagFn
 
 
 KANI_PATH = (PWD / ".." / ".." / ".." / "kani" / "tests" / "kani").resolve()
@@ -43,69 +53,97 @@ MIRI_EXCLUSIONS = [
 ]
 
 
+def kani() -> tuple[list[Path], TestConfig]:
+    root = Path(KANI_PATH)
+    log = PWD / "kani.log"
+    tests = [
+        path
+        for path in root.rglob("*.rs")
+        if not any(exclusion in str(path) for exclusion in KANI_EXCLUSIONS)
+    ]
+    return tests, {
+        "root": root,
+        "args": ["--ignore-leaks", "--kani"],
+        "dyn_flags": None,
+    }
+
+
+def miri() -> tuple[list[Path], TestConfig]:
+    dyn_flag_cache: dict[Path, list[str]] = {}
+
+    def dyn_flags(file: Path) -> list[str]:
+        if file in dyn_flag_cache:
+            return dyn_flag_cache[file]
+        flags = []
+        # if file contains "-Zmiri-ignore-leaks", add "--ignore-leaks"
+        if "-Zmiri-ignore-leaks" in file.read_text():
+            flags.append("--ignore-leaks")
+        dyn_flag_cache[file] = flags
+        return flags
+
+    root = Path(MIRI_PATH)
+    tests = [
+        path
+        for path in root.rglob("*.rs")
+        if not any(exclusion in str(path) for exclusion in MIRI_EXCLUSIONS)
+    ]
+    return tests, {
+        "root": root,
+        "args": ["--miri"],
+        "dyn_flags": dyn_flags,
+    }
+
+
+TEST_SUITES = {
+    "kani": kani,
+    "miri": miri,
+}
+
+
+# Execute a test, return the categorisation and the elapsed time
 def exec_test(
     file: Path,
     *,
     root: Path,
-    log: TextIOWrapper,
+    log: Optional[TextIOWrapper] = None,
     args: list[str] = [],
     dyn_flags: Optional[Callable[[Path], list[str]]] = None,
-):
-    relative = file.relative_to(root)
+) -> tuple[LogCategorisation, float]:
     expect_failure = determine_failure_expect(str(file))
-
     if dyn_flags:
         args = [*args, *dyn_flags(file)]
 
-    pprint(f"Running {relative} ... ", inc=True, end="", flush=True)
-    if str(relative) in SKIPPED_TESTS:
-        (msg, clr, reason) = SKIPPED_TESTS[str(relative)]
-        print(
-            f"{clr}{msg}{RESET} {YELLOW}✦{RESET} {GRAY}{BOLD}Skipped{RESET}: {BOLD}{reason}{RESET}"
-        )
-        return (msg, clr, "Skipped")
-
-    log.write(f"[TEST] Running {file} - {datetime.datetime.now()}:\n")
+    if log:
+        log.write(f"[TEST] Running {file} - {datetime.datetime.now()}:\n")
 
     before = time.time()
-    cmd = f"soteria-rust exec-main {' '.join(args)} {file}"
+    cmd = ["soteria-rust", "exec-main", str(file)] + args
     data = subprocess.run(
         cmd,
         capture_output=True,
-        shell=True,
         text=True,
     )
     elapsed = time.time() - before
 
     full_log = f"{data.stderr}\n{data.stdout}\n\n"
-    log.write(full_log)
+    if log:
+        log.write(full_log)
 
     outcome = categorise_rusteria(full_log, expect_failure=expect_failure)
-    (msg, clr, reason) = outcome = outcome[0] if isinstance(outcome, list) else outcome
+    outcome = outcome[0] if isinstance(outcome, list) else outcome
 
-    txt = f"{clr}{msg}{RESET} in {elapsed:.3f}s"
-    if elapsed > 1:
-        txt += " 🐌"
-    if str(relative) in KNOWN_ISSUES:
-        issue = KNOWN_ISSUES[str(relative)]
-        txt += f" {YELLOW}✦{RESET} {BOLD}{issue}{RESET}"
-    print(txt)
-
-    return outcome
+    return outcome, elapsed
 
 
-def exec_tests(tests: list[Path], *, log: Path, **kwargs):
+def build():
     pprint(f"Building {BOLD}Rusteria{RESET} ... ", flush=True)
     before = time.time()
     build_rusteria()
     elapsed = time.time() - before
     pprint(f"Took {elapsed:.3f}s to build", inc=True)
 
-    flags = parse_flags()
 
-    args = kwargs.get("args", []) + flags["cmd_flags"]
-    kwargs["args"] = args
-
+def filter_tests(tests: list[Path], flags: Flags):
     tests = [
         t
         for t in tests
@@ -113,6 +151,16 @@ def exec_tests(tests: list[Path], *, log: Path, **kwargs):
         and (flags["filters"] == [] or all(f in str(t) for f in flags["filters"]))
     ]
     tests.sort()
+    return tests
+
+
+def exec_tests(tests: list[Path], test_conf: TestConfig, log: Path):
+    build()
+    flags = parse_flags(sys.argv[2:])
+
+    args = test_conf["args"] + flags["cmd_flags"]
+
+    tests = filter_tests(tests, flags)
     log.touch()
     log.write_text(f"Running {len(tests)} tests - {datetime.datetime.now()}:\n\n")
     pprint(f"{BOLD}Running {len(tests)} tests{RESET}", inc=True)
@@ -122,60 +170,215 @@ def exec_tests(tests: list[Path], *, log: Path, **kwargs):
     before = time.time()
     with log.open("a") as logfile:
         for path in tests:
-            msg, _, _ = exec_test(path, log=logfile, **kwargs)
+            relative = path.relative_to(test_conf["root"])
+            pprint(f"Running {relative} ... ", inc=True, end="", flush=True)
+
+            if str(relative) in SKIPPED_TESTS:
+                (msg, clr, reason) = SKIPPED_TESTS[str(relative)]
+                print(
+                    f"{clr}{msg}{RESET} {YELLOW}✦{RESET} {GRAY}{BOLD}Skipped{RESET}: {BOLD}{reason}{RESET}"
+                )
+            else:
+                (msg, clr, reason), elapsed = exec_test(
+                    path,
+                    root=test_conf["root"],
+                    log=logfile,
+                    args=args,
+                    dyn_flags=test_conf["dyn_flags"],
+                )
+                txt = f"{clr}{msg}{RESET} in {elapsed:.3f}s"
+                if elapsed > 1:
+                    txt += " 🐌"
+                if str(relative) in KNOWN_ISSUES:
+                    issue = KNOWN_ISSUES[str(relative)]
+                    txt += f" {YELLOW}✦{RESET} {BOLD}{issue}{RESET}"
+                print(txt)
+
             if msg == "Success":
                 oks += 1
             elif msg == "Failure":
                 errs += 1
     elapsed = time.time() - before
     pprint(
-        f"{BOLD}Finished in {elapsed:.2f}s{RESET}: {GREEN}{oks}{RESET}/{RED}{errs}{RESET}/{len(tests)}"
+        f"{BOLD}Finished in {elapsed:.3f}s{RESET}: {GREEN}{oks}{RESET}/{RED}{errs}{RESET}/{len(tests)}"
     )
 
 
-def kani():
-    root = Path(KANI_PATH)
-    log = PWD / "kani.log"
-    tests = [
-        path
-        for path in root.rglob("*.rs")
-        if not any(exclusion in str(path) for exclusion in KANI_EXCLUSIONS)
+def evaluate_perf(tests: list[Path], test_conf: TestConfig):
+    build()
+    flags = parse_flags(sys.argv[3:])
+
+    iters = flags["iterations"] or 5
+    args = test_conf["args"] + flags["cmd_flags"]
+    csv_suffix = f"{iters}-{int(time.time())}" if not flags["tag"] else flags["tag"]
+    csv_file = PWD / f"eval-{csv_suffix}.csv"
+
+    tests = filter_tests(tests, flags)
+
+    pprint(f"{BOLD}Running {len(tests)} tests, {iters} times{RESET}", inc=True)
+
+    test_times: dict[Path, list[float]] = {}
+    before = time.time()
+    for path in tests:
+        relative = path.relative_to(test_conf["root"])
+        txt = f"Running {relative} ..."
+        if str(relative) in SKIPPED_TESTS:
+            pprint(f"{txt} {GRAY}{BOLD}skipped", inc=True)
+            continue
+
+        times = test_times[relative] = []
+
+        msg, clr = "", ""
+        for i in range(iters):
+            pprint(f"{txt} {i+1}/{iters}", end="\r")
+            (msg, clr, _), t = exec_test(
+                path,
+                root=test_conf["root"],
+                args=args,
+                dyn_flags=test_conf["dyn_flags"],
+            )
+            if msg not in ["Success", "Failure"]:
+                break
+            times.append(t)
+        if msg not in ["Success", "Failure"]:
+            pprint(f"{txt} {clr}{msg}{RESET} {GRAY}(skipped){RESET}", inc=True)
+            continue
+        avg = sum(times) / iters
+        pprint(f"{txt} {clr}{msg}{RESET} took {BOLD}{avg:.3f}s{RESET}", inc=True)
+
+    elapsed = time.time() - before
+    test_times_items = [*test_times.items()]
+    test_times_items.sort(key=lambda v: sum(v[1]))
+    total_average = (
+        sum((t for v in test_times_items for t in v[1])) / len(test_times_items) / iters
+    )
+    longest_path = max(len(str(item[0])) for item in test_times_items)
+
+    pprint(
+        f"{BOLD}Finished in {elapsed:.3f}s total, {total_average:.3f}s/iter{RESET}",
+        inc=True,
+    )
+    pprint("", inc=True)
+    rows: list[list[tuple[str, Optional[str]]]] = [
+        [("File", BOLD), ("Avg", BOLD), ("Δ AllAvgs", BOLD), ("Std Dev", BOLD)]
     ]
-    exec_tests(tests, root=root, log=log, args=["--ignore-leaks", "--kani"])
+    for test, times in test_times_items:
+        if len(times) == 0:
+            continue
+        average = sum(times) / len(times)
+        delta = average / total_average
+        deviation = (
+            math.sqrt((sum(pow(x - average, 2) for x in times)) / (iters - 1))
+            if iters > 1
+            else 0
+        )
+
+        color = RESET
+        if delta > 1.5:
+            color = ORANGE
+            if delta > 2:
+                color = RED
+                if delta > 4:
+                    color = f"{RED}{BOLD}"
+        rows.append(
+            [
+                (str(test), None),
+                (f"{average:.3f}s", color),
+                (f"{delta:.2f}%", None),
+                (f"{deviation:.3f}s", None),
+            ]
+        )
+    csv_file.touch()
+    with csv_file.open("w") as csv_io:
+        csv_io.writelines(",".join(c[0] for c in row) + "\n" for row in rows)
+
+    pptable(rows)
 
 
-def miri():
-    def dyn_flags(file: Path) -> list[str]:
-        flags = []
-        # if file contains "-Zmiri-ignore-leaks", add "--ignore-leaks"
-        if "-Zmiri-ignore-leaks" in file.read_text():
-            flags.append("--ignore-leaks")
-        return flags
+def diff_evaluation(path1: Path, path2: Path):
+    def parse(path: Path) -> dict[str, float]:
+        rows = {}
+        with open(path, "r") as csv:
+            next(csv)
+            for row in csv:
+                cells = row.split(",")
+                rows[cells[0]] = float(cells[1][:-1])
+        return rows
 
-    root = Path(MIRI_PATH)
-    log = PWD / "miri.log"
-    tests = [
-        path
-        for path in root.rglob("*.rs")
-        if not any(exclusion in str(path) for exclusion in MIRI_EXCLUSIONS)
-    ]
-    exec_tests(tests, root=root, log=log, args=["--miri"], dyn_flags=dyn_flags)
+    csv1 = parse(path1)
+    csv2 = parse(path2)
+    files = set(csv1.keys())
+    files = files.union(csv2.keys())
+    csv1 = {f: t for f, t in csv1.items() if f in files}
+    csv2 = {f: t for f, t in csv2.items() if f in files}
+    total_time1 = sum(csv1.values())
+    total_time2 = sum(csv2.values())
+    delta_total = (total_time2 - total_time1) / total_time1 * 100
+    diff_clr = RED if total_time1 < total_time2 else GREEN
+    pprint(f"Diff of {path1} and {path2}", inc=True)
+    pprint(
+        f"Went from {total_time1:.3f}s to {total_time2:.3f}s ({diff_clr}{delta_total:.1f}%{RESET})"
+    )
+
+    rows: list[list[tuple[str, Optional[str]]]] = []
+    for f in files:
+        before = csv1[f]
+        after = csv2[f]
+        delta = (after - before) / before * 100
+        color = RESET
+        if delta > 5:
+            color = YELLOW
+            if delta > 10:
+                color = ORANGE
+                if delta > 30:
+                    color = RED
+        elif delta < -5:
+            color = GREEN
+            if delta < -10:
+                color = CYAN
+                if delta < -30:
+                    color = BLUE
+        rows.append(
+            [
+                (f, None),
+                (f"{before:.3f}s", None),
+                ("→", None),
+                (f"{after:.3f}s", None),
+                (f"{delta:.1f}%", color),
+            ]
+        )
+    rows.sort(key=lambda r: float(r[4][0][:-1]))
+    rows.insert(
+        0, [("File", BOLD), ("Before", BOLD), ("", None), ("After", BOLD), ("Δ%", BOLD)]
+    )
+    pptable(rows)
 
 
 if __name__ == "__main__":
     try:
         if len(sys.argv) <= 1:
             raise RuntimeError
-        if sys.argv[1] == "kani":
-            kani()
-        elif sys.argv[1] == "miri":
-            miri()
+        if sys.argv[1] in ["kani", "miri"]:
+            tests, config = TEST_SUITES[sys.argv[1]]()
+            log = PWD / f"{sys.argv[1]}.log"
+            exec_tests(tests, config, log)
+        elif sys.argv[1] == "eval":
+            if len(sys.argv) <= 2:
+                raise RuntimeError
+            if sys.argv[2] not in ["kani", "miri"]:
+                raise RuntimeError
+            tests, config = TEST_SUITES[sys.argv[2]]()
+            evaluate_perf(tests, config)
+        elif sys.argv[1] == "eval-diff":
+            if len(sys.argv) <= 3:
+                raise RuntimeError
+            diff_evaluation(Path(sys.argv[2]), Path(sys.argv[3]))
         else:
             raise RuntimeError
     except RuntimeError:
         print(
             f"{RED}Invalid command -- specify {YELLOW}kani{RED} or "
-            f"{YELLOW}mir{RED} as a first argument."
+            f"{YELLOW}miri{RED} as a first argument."
         )
     except KeyboardInterrupt:
         exit(1)


### PR DESCRIPTION
Add an `eval` command to `test.py` to repeatedly run non-erroring tests, to measure performance changes. Iteration count can be controlled with the `-i` flag. Produces a `.csv` flag with the average execution time for each test.

<img width="771" alt="image" src="https://github.com/user-attachments/assets/b2e23fa2-ec5f-44e5-976e-13a9e81131ba" />

Add an `eval-diff` command, that receives two files and prints the performance difference between the two runs.

<img width="774" alt="image" src="https://github.com/user-attachments/assets/3d841323-f22f-4d99-98fd-36b627733de2" />
