### PR TITLE
Support `std::intrinsics::float_to_int_unchecked`

### DIFF
--- a/soteria-rust/lib/builtins/eval.ml
+++ b/soteria-rust/lib/builtins/eval.ml
@@ -41,6 +41,7 @@ module M (Heap : Heap_intf.S) = struct
     | FloatIsSign of { positive : bool }
     | FloatMinMax of { min : bool }
     | FloatRounding of Svalue.FloatRoundingMode.t
+    | FloatToInt
     | Index
     | IsValStaticallyKnown
     | Likely
@@ -172,6 +173,7 @@ module M (Heap : Heap_intf.S) = struct
       ("core::intrinsics::fabsf128", Abs);
       ("core::intrinsics::fadd_fast", FloatFast Add);
       ("core::intrinsics::fdiv_fast", FloatFast Div);
+      ("core::intrinsics::float_to_int_unchecked", FloatToInt);
       ("core::intrinsics::floorf16", FloatRounding Floor);
       ("core::intrinsics::floorf32", FloatRounding Floor);
       ("core::intrinsics::floorf64", FloatRounding Floor);
@@ -287,6 +289,7 @@ module M (Heap : Heap_intf.S) = struct
          | FloatIsSign { positive } -> float_is_sign positive
          | FloatMinMax { min } -> float_minmax min
          | FloatRounding rm -> float_rounding rm
+         | FloatToInt -> float_to_int f.signature
          | Index -> array_index_fn f.signature
          | IsValStaticallyKnown -> is_val_statically_known
          | Likely -> likely

--- a/soteria-rust/lib/encoder.ml
+++ b/soteria-rust/lib/encoder.ml
@@ -384,12 +384,13 @@ module Make (Sptr : Sptr.S) = struct
     if from_ty = to_ty then ok v
     else
       match (from_ty, to_ty, v) with
-      | TLiteral (TFloat _), TLiteral (TInteger _), Base sv ->
+      | TLiteral (TFloat _), TLiteral (TInteger ity), Base sv ->
           let+ sv =
             of_opt_not_impl ~msg:"Unsupported: non-float in float-to-int"
             @@ Typed.cast_float sv
           in
-          let sv' = Typed.int_of_float sv in
+          let size = 8 * Layout.size_of_int_ty ity in
+          let sv' = Typed.int_of_float size sv in
           Ok (Base sv')
       | TLiteral (TInteger _), TLiteral (TFloat fp), Base sv ->
           let+ sv = cast_checked sv ~ty:Typed.t_int in

--- a/soteria/lib/c_values/smt_utils.ml
+++ b/soteria/lib/c_values/smt_utils.ml
@@ -79,10 +79,7 @@ let f16_of_bv bv = app (ifam "to_fp" [ 5; 11 ]) [ bv ]
 let f32_of_bv bv = app (ifam "to_fp" [ 8; 24 ]) [ bv ]
 let f64_of_bv bv = app (ifam "to_fp" [ 11; 53 ]) [ bv ]
 let f128_of_bv bv = app (ifam "to_fp" [ 15; 113 ]) [ bv ]
-let bv_of_f16 f = app (ifam "fp.to_sbv" [ 16 ]) [ rm; f ]
-let bv_of_f32 f = app (ifam "fp.to_sbv" [ 32 ]) [ rm; f ]
-let bv_of_f64 f = app (ifam "fp.to_sbv" [ 64 ]) [ rm; f ]
-let bv_of_f128 f = app (ifam "fp.to_sbv" [ 128 ]) [ rm; f ]
+let bv_of_float n f = app (ifam "fp.to_sbv" [ n ]) [ rm; f ]
 
 (* Int{Of,To}Bv *)
 

--- a/soteria/lib/c_values/smtlib_encoding.ml
+++ b/soteria/lib/c_values/smtlib_encoding.ml
@@ -97,12 +97,7 @@ let rec encode_value (v : Svalue.t) =
           let size = Svalue.size_of_bv v.node.ty in
           bv_of_int size v1
       | IntOfBv signed -> int_of_bv signed v1
-      | BvOfFloat -> (
-          match Svalue.precision_of_f v1_.node.ty with
-          | F16 -> bv_of_f16 v1
-          | F32 -> bv_of_f32 v1
-          | F64 -> bv_of_f64 v1
-          | F128 -> bv_of_f128 v1)
+      | BvOfFloat n -> bv_of_float n v1
       | FloatOfBv -> (
           match Svalue.precision_of_f v.node.ty with
           | F16 -> f16_of_bv v1

--- a/soteria/lib/c_values/typed.mli
+++ b/soteria/lib/c_values/typed.mli
@@ -96,7 +96,7 @@ val nonzero : int -> [> nonzero ] t
 val float : Svalue.FloatPrecision.t -> string -> [> sfloat ] t
 val int_of_bool : [< sbool ] t -> [> sint ] t
 val bool_of_int : [< sint ] t -> [> sbool ] t
-val int_of_float : [< sfloat ] t -> [> sint ] t
+val int_of_float : int -> [< sfloat ] t -> [> sint ] t
 val float_of_int : Svalue.FloatPrecision.t -> [< sint ] t -> [> sfloat ] t
 val zero : [> sint ] t
 val one : [> nonzero ] t


### PR DESCRIPTION
Support `std::intrinsics::float_to_int_unchecked`
In truth I think the implementation is still riddled with issues, since we do a half attempt at float constants, but the lack of OCaml support for f16/f32/f128 means we often have either too much or not enough precision.

The next step would probably be using https://github.com/thvnx/mlmpfr, however it seems a bit tedious to use so we'll have to make a wrapper around it; for instance, the min-max of an exponent is a global thing, so one must always `set_emin` and `set_emax` before manipulating a float of a given precision, which is.. not great. They also seem to not match IEEE exactly: 
> By convention, the radix point of the significand is just before the first digit (which is always 1 due to normalization), like in the C language, but unlike in IEEE 754 (thus, for a given number, the exponent values in MPFR and in IEEE 754 differ by 1)

For now this PR passes all *23* Miri tests for the intrinsic (did anyone say low hanging fruit?), and fixes some of the precision issues we had, so it's a bit better.