### PR TITLE
Minor C stuff

### DIFF
--- a/soteria-c/bin/soteria_c.ml
+++ b/soteria-c/bin/soteria_c.ml
@@ -57,11 +57,22 @@ module Config = struct
       & opt (some string) None
       & info [ "dump-summaries"; "dump-summaries-to" ] ~env ~doc ~docv)
 
+  let show_manifest_summaries_arg =
+    let doc =
+      "Print a corresponding manifest summary after the bug report if a bug is \
+       found"
+    in
+    let env =
+      Cmdliner.Cmd.Env.info ~doc "SOTERIA_SHOW_MANIFEST_BUG_SUMMARIES"
+    in
+    Arg.(value & flag & info [ "show-manifest-summaries" ] ~env ~doc)
+
   let make_from_args auto_include_path dump_unsupported_file
       no_ignore_parse_failures no_ignore_duplicate_symbols parse_only
-      dump_summaries_file =
+      dump_summaries_file show_manifest_summaries =
     make ~auto_include_path ~dump_unsupported_file ~no_ignore_parse_failures
-      ~no_ignore_duplicate_symbols ~parse_only ~dump_summaries_file ()
+      ~no_ignore_duplicate_symbols ~parse_only ~dump_summaries_file
+      ~show_manifest_summaries ()
 
   let term =
     Cmdliner.Term.(
@@ -71,7 +82,8 @@ module Config = struct
       $ no_ignore_parse_failures_arg
       $ no_ignore_duplicate_symbols_arg
       $ parse_only_arg
-      $ dump_summaries_file_arg)
+      $ dump_summaries_file_arg
+      $ show_manifest_summaries_arg)
 end
 
 let files_arg =

--- a/soteria-c/lib/config.ml
+++ b/soteria-c/lib/config.ml
@@ -10,6 +10,7 @@ type t = {
   no_ignore_duplicate_symbols : bool; [@default false]
   parse_only : bool; [@default false]
   dump_summaries_file : string option; [@default None]
+  show_manifest_summaries : bool; [@default false]
 }
 [@@deriving make]
 

--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -343,15 +343,12 @@ let generate_summaries ~functions_to_analyse prog =
       List.filter (fun b -> not (List.mem b !already_signaled)) manifest_bugs
     in
     already_signaled := remaining_to_signal @ !already_signaled;
-    if not (List.is_empty remaining_to_signal) then (
-      found_bugs := true;
-      List.iter
-        (fun (error, call_trace) ->
-          Error.Diagnostic.print_diagnostic ~fid ~call_trace ~error;
-          if !Config.current.show_manifest_summaries then
-            Fmt.pr "@\n@[Corresponding summary:@ %a@]" Summary.pp_raw raw;
-          Fmt.pr "@\n@?")
-        remaining_to_signal)
+    let@ error, call_trace = list_iter remaining_to_signal in
+    found_bugs := true;
+    Error.Diagnostic.print_diagnostic ~fid ~call_trace ~error;
+    if !Config.current.show_manifest_summaries then
+      Fmt.pr "@\n@[Corresponding summary:@ %a@]" Summary.pp_raw raw;
+    Fmt.pr "@\n@?"
   in
   if not !found_bugs then
     Fmt.pr "%a@.@?" Soteria_terminal.Color.pp_ok "No bugs found"

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -3,9 +3,9 @@ open Syntaxes.FunctionWrap
 module T = Typed.T
 module Var = Soteria_symex.Var
 
-type after_exec = |
-type pruned = |
-type analysed = |
+type after_exec = [ `After_exec ]
+type pruned = [ `Pruned ]
+type analysed = [ `Analysed ]
 
 type raw = {
   args : T.cval Typed.t list;
@@ -217,8 +217,12 @@ let rec analyse : type a. fid:Ail_tys.sym -> a t -> analysed t =
           L.trace (fun m ->
               m "Results: %a" (Fmt.Dump.list (Fmt.pair Fmt.bool Fmt.nop)) result);
           (* The bug is manifest if the assert passed in every branch. *)
+          (* FIXME: the non-empty check is a bit of a hack.
+             We need to somehow be able to run production and assert in OX mode.
+             Right now, if production vanishes in one case but not all, we get a false positive. *)
           let is_manifest =
-            List.for_all (function true, _ -> true | _ -> false) result
+            (not (List.is_empty result))
+            && List.for_all (function true, _ -> true | _ -> false) result
           in
           let manifest_bugs = if is_manifest then [ error ] else [] in
           Analysed { raw = summary; manifest_bugs })

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -221,8 +221,7 @@ let rec analyse : type a. fid:Ail_tys.sym -> a t -> analysed t =
              We need to somehow be able to run production and assert in OX mode.
              Right now, if production vanishes in one case but not all, we get a false positive. *)
           let is_manifest =
-            (not (List.is_empty result))
-            && List.for_all (function true, _ -> true | _ -> false) result
+            (not (List.is_empty result)) && List.for_all fst result
           in
           let manifest_bugs = if is_manifest then [ error ] else [] in
           Analysed { raw = summary; manifest_bugs })

--- a/soteria-c/test/cram/simple_bi.t/run.t
+++ b/soteria-c/test/cram/simple_bi.t/run.t
@@ -45,7 +45,7 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
       │ ╰──
    35 │    
   
-  error: Null pointer dereference in test_np_uninit
+  error: Accessing uninitialized memory in test_np_uninit
       ┌─ manifest.c:6:10
     6 │    return *x;
       │           ^^ Triggering memory operation
@@ -57,7 +57,7 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
    12 │    load(x);
       │    ------- 1: Called from here
   
-  error: Accessing uninitialized memory in test_np_uninit
+  error: Null pointer dereference in test_np_uninit
       ┌─ manifest.c:6:10
     6 │    return *x;
       │           ^^ Triggering memory operation

--- a/soteria/lib/c_values/svalue.ml
+++ b/soteria/lib/c_values/svalue.ml
@@ -569,6 +569,7 @@ and leq v1 v2 =
   | Int i1, Int i2 -> bool (Z.leq i1 i2)
   | _, _ when equal v1 v2 -> v_true
   | _, Binop (Plus, v2, v3) when equal v1 v2 -> leq zero v3
+  | _, Binop (Plus, v2, v3) when equal v1 v3 -> leq zero v2
   | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v1 v3 -> leq v2 v4
   | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v2 v3 -> leq v1 v4
   | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v1 v4 -> leq v2 v3


### PR DESCRIPTION
- adds `--show-manifest-summaries`, which doesn't print all summaries but does print a summary for each manifest bug found
- improve false positive filtering (we might still have false positives in some very niche cases...)
- adds a single reduction that was missing
- fix GADT stuff