### PR TITLE
Iterate and substitute variables in rust_val

### DIFF
--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -57,6 +57,9 @@ module type S = sig
 
   (** Get the allocation info for this pointer: its size and alignment *)
   val allocation_info : t -> T.sint Typed.t * T.nonzero Typed.t
+
+  val iter_vars : t -> (Svalue.Var.t * 'b ty -> unit) -> unit
+  val subst : (Svalue.Var.t -> Svalue.Var.t) -> t -> t
 end
 
 type arithptr_t = {
@@ -164,4 +167,17 @@ module ArithPtr : S with type t = arithptr_t = struct
 
   let as_id { ptr; _ } = Typed.cast @@ Typed.Ptr.loc ptr
   let allocation_info { size; align; _ } = (size, align)
+
+  (* FIXME: Tree borrows data being ignored *)
+  let iter_vars { ptr; align; size; _ } f =
+    Typed.iter_vars ptr f;
+    Typed.iter_vars align f;
+    Typed.iter_vars size f
+
+  (* FIXME: Tree borrows data being ignored *)
+  let subst subst_var p =
+    let ptr = Typed.subst subst_var p.ptr in
+    let align = Typed.subst subst_var p.align in
+    let size = Typed.subst subst_var p.size in
+    { p with ptr; align; size }
 end

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -168,13 +168,11 @@ module ArithPtr : S with type t = arithptr_t = struct
   let as_id { ptr; _ } = Typed.cast @@ Typed.Ptr.loc ptr
   let allocation_info { size; align; _ } = (size, align)
 
-  (* FIXME: Tree borrows data being ignored *)
   let iter_vars { ptr; align; size; _ } f =
     Typed.iter_vars ptr f;
     Typed.iter_vars align f;
     Typed.iter_vars size f
 
-  (* FIXME: Tree borrows data being ignored *)
   let subst subst_var p =
     let ptr = Typed.subst subst_var p.ptr in
     let align = Typed.subst subst_var p.align in

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -168,7 +168,7 @@ module ArithPtr : S with type t = arithptr_t = struct
   let as_id { ptr; _ } = Typed.cast @@ Typed.Ptr.loc ptr
   let allocation_info { size; align; _ } = (size, align)
 
-  let iter_vars { ptr; align; size; _ } f =
+  let iter_vars { ptr; align; size; tag = _ } f =
     Typed.iter_vars ptr f;
     Typed.iter_vars align f;
     Typed.iter_vars size f

--- a/soteria-rust/lib/tree_block.ml
+++ b/soteria-rust/lib/tree_block.ml
@@ -806,9 +806,9 @@ let tb_access ofs size tag tb t =
 let subst_serialized subst_var (serialized : serialized) =
   let v_subst v = Typed.subst subst_var v in
   let subst_atom = function
-    | TypedVal _ ->
-        failwith "not_impl: subst_serialized TypedVal"
-        (* TypedVal { offset = v_subst offset; ty; v = v_subst v } *)
+    | TypedVal { offset; ty; v } ->
+        let v = Charon_util.subst Sptr.ArithPtr.subst subst_var v in
+        TypedVal { offset = v_subst offset; ty; v }
     | Bound v -> Bound (v_subst v)
     | Uninit { offset; len } ->
         Uninit { offset = v_subst offset; len = v_subst len }
@@ -822,10 +822,9 @@ let iter_vars_serialized serialized (f : Svalue.Var.t * [< T.cval ] ty -> unit)
     =
   List.iter
     (function
-      | TypedVal { offset; _ } ->
+      | TypedVal { offset; v; _ } ->
           Typed.iter_vars offset f;
-          failwith "not_impl: iter_vars_serialized TypedVal"
-          (* Typed.iter_vars v f *)
+          Charon_util.iter_vars Sptr.ArithPtr.iter_vars v f
       | Bound v -> Typed.iter_vars v f
       | Uninit { offset; len } ->
           Typed.iter_vars offset f;

--- a/soteria-rust/lib/tree_block.ml
+++ b/soteria-rust/lib/tree_block.ml
@@ -822,7 +822,7 @@ let iter_vars_serialized serialized (f : Svalue.Var.t * [< T.cval ] ty -> unit)
     =
   List.iter
     (function
-      | TypedVal { offset; v; _ } ->
+      | TypedVal { offset; v; ty = _ } ->
           Typed.iter_vars offset f;
           Charon_util.iter_vars Sptr.ArithPtr.iter_vars v f
       | Bound v -> Typed.iter_vars v f


### PR DESCRIPTION
Implement `iter_vars` and `subst` for `rust_val`. This allows the same functions to be implemented for serialized `Tree_block`s. The `Sptr` interface also requires these functions now.