### PR TITLE
Drop execution and monomorphize flag

### DIFF
--- a/soteria-rust/lib/config.ml
+++ b/soteria-rust/lib/config.ml
@@ -9,7 +9,7 @@ type t = {
       (** Ignore memory leaks *)
   ignore_aliasing : bool; [@make.default false] [@names [ "ignore-aliasing" ]]
       (** Ignore pointer aliasing rules (tree borrows) *)
-  monomorphize : bool;
+  monomorphize_experimental : bool;
       [@make.default false] [@names [ "monomorphize-experimental" ]]
       (** Use Charon's new monomorphization, which may cause unexpected results
           but resolves drops. *)

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -886,7 +886,7 @@ module Make (State : State_intf.S) = struct
         | None -> ok ())
     | Drop (place, trait_ref) -> (
         let* place_ptr = resolve_place place in
-        if not !Config.current.monomorphize then
+        if not !Config.current.monomorphize_experimental then
           let* () =
             match place.ty with
             | TAdt { id = TAdtId id; _ } -> (

--- a/soteria-rust/lib/plugin.ml
+++ b/soteria-rust/lib/plugin.ml
@@ -171,7 +171,7 @@ let default =
     let@ std_lib_path, target = with_compiled_lib "std" in
     let opaques = List.map (( ^ ) "--opaque ") known_generic_errors in
     let monomorphize_flag =
-      if !Config.current.monomorphize then "--monomorphize"
+      if !Config.current.monomorphize_experimental then "--monomorphize"
       else "--monomorphize-conservative"
     in
     Cmd.make


### PR DESCRIPTION
Drops are now executed by the interpreter. The `--monomorphize` flag in Charon needs to be set for drops to executed, so an additional `--monomorphize-experimental` flag is added to Rusteria. By default, Charon still runs with `--monomorphize-conservative`.