### PR TITLE
Remove Make_seq, adjust documentation

### DIFF
--- a/soteria-c/lib/csymex.ml
+++ b/soteria-c/lib/csymex.ml
@@ -1,4 +1,4 @@
-module SYMEX = Soteria_symex.Symex.Make_iter (C_solver.Z3_solver)
+module SYMEX = Soteria_symex.Symex.Make (C_solver.Z3_solver)
 include SYMEX
 include Syntaxes.FunctionWrap
 

--- a/soteria-rust/lib/rustsymex.ml
+++ b/soteria-rust/lib/rustsymex.ml
@@ -1,4 +1,4 @@
-module SYMEX = Soteria_symex.Symex.Make_iter (C_solver.Z3_solver)
+module SYMEX = Soteria_symex.Symex.Make (C_solver.Z3_solver)
 include SYMEX
 include Syntaxes.FunctionWrap
 

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -11,26 +11,29 @@ let is_unsat (result : Solver.result) =
 
 module type Base = sig
   module Value : Value.S
-  module MONAD : Monad.Base
+
+  type 'a t
+
+  module MONAD : Monad.Base with type 'a t = 'a t
 
   type 'a v := 'a Value.t
   type 'a vt := 'a Value.ty
   type sbool := Value.sbool
 
-  val assume : sbool v list -> unit MONAD.t
-  val vanish : unit -> 'a MONAD.t
-  val assert_ : sbool v -> bool MONAD.t
-  val assert_ox : sbool v -> bool MONAD.t
-  val nondet : 'a vt -> 'a v MONAD.t
-  val fresh_var : 'a vt -> Var.t MONAD.t
+  val assume : sbool v list -> unit t
+  val vanish : unit -> 'a t
+  val assert_ : sbool v -> bool t
+  val assert_ox : sbool v -> bool t
+  val nondet : 'a vt -> 'a v t
+  val fresh_var : 'a vt -> Var.t t
 
   val branch_on :
     ?left_branch_name:string ->
     ?right_branch_name:string ->
     sbool v ->
-    then_:(unit -> 'a MONAD.t) ->
-    else_:(unit -> 'a MONAD.t) ->
-    'a MONAD.t
+    then_:(unit -> 'a t) ->
+    else_:(unit -> 'a t) ->
+    'a t
 
   (** Branches on value, and takes at most one branch, starting with the [then]
       branch. This means that if the [then_] branch is SAT, it is taken and the
@@ -40,33 +43,33 @@ module type Base = sig
     ?left_branch_name:string ->
     ?right_branch_name:string ->
     sbool v ->
-    then_:(unit -> 'a MONAD.t) ->
-    else_:(unit -> 'a MONAD.t) ->
-    'a MONAD.t
+    then_:(unit -> 'a t) ->
+    else_:(unit -> 'a t) ->
+    'a t
 
-  val branches : (unit -> 'a MONAD.t) list -> 'a MONAD.t
+  val branches : (unit -> 'a t) list -> 'a t
 
   (** {2 Fuel} *)
 
-  val consume_fuel_steps : int -> unit MONAD.t
+  val consume_fuel_steps : int -> unit t
 
   (** [run] p actually performs symbolic execution and returns a list of
       obtained branches which capture the outcome together with a path condition
       that is a list of boolean symbolic values *)
-  val run : fuel:Fuel_gauge.t -> 'a MONAD.t -> ('a * sbool v list) list
+  val run : fuel:Fuel_gauge.t -> 'a t -> ('a * sbool v list) list
 end
 
 module type S = sig
   include Base
-  include Monad.Base with type 'a t = 'a MONAD.t
+  include Monad.Base with type 'a t := 'a t
 
   val all : ('a -> 'b t) -> 'a list -> 'b list t
-  val fold_list : ('a, 'b) Monad.FoldM(MONAD)(Foldable.List).folder
-  val fold_iter : ('a, 'b) Monad.FoldM(MONAD)(Foldable.Iter).folder
-  val fold_seq : ('a, 'b) Monad.FoldM(MONAD)(Foldable.Seq).folder
+  val fold_list : 'a list -> init:'b -> f:('b -> 'a -> 'b t) -> 'b t
+  val fold_iter : 'a Iter.t -> init:'b -> f:('b -> 'a -> 'b t) -> 'b t
+  val fold_seq : 'a Seq.t -> init:'b -> f:('b -> 'a -> 'b t) -> 'b t
 
   module rec Result : sig
-    type ('ok, 'err, 'fix) t = ('ok, 'err, 'fix) Compo_res.t MONAD.t
+    type nonrec ('ok, 'err, 'fix) t = ('ok, 'err, 'fix) Compo_res.t t
 
     val ok : 'ok -> ('ok, 'err, 'fix) t
     val error : 'err -> ('ok, 'err, 'fix) t
@@ -91,12 +94,13 @@ module type S = sig
     val map_missing : ('ok, 'err, 'fix) t -> ('fix -> 'a) -> ('ok, 'err, 'a) t
 
     val fold_list :
-      ('elem, 'a, 'b, 'c) Monad.FoldM3(Result)(Foldable.List).folder
+      'a list -> init:'b -> f:('b -> 'a -> ('b, 'c, 'd) t) -> ('b, 'c, 'd) t
 
     val fold_iter :
-      ('elem, 'a, 'b, 'c) Monad.FoldM3(Result)(Foldable.Iter).folder
+      'a Iter.t -> init:'b -> f:('b -> 'a -> ('b, 'c, 'd) t) -> ('b, 'c, 'd) t
 
-    val fold_seq : ('elem, 'a, 'b, 'c) Monad.FoldM3(Result)(Foldable.Seq).folder
+    val fold_seq :
+      'a Seq.t -> init:'b -> f:('b -> 'a -> ('b, 'c, 'd) t) -> ('b, 'c, 'd) t
   end
 
   module Syntax : sig
@@ -182,182 +186,7 @@ module Extend (Base : Base) = struct
   end
 end
 
-module Make_seq (Sol : Solver.Mutable_incremental) :
-  S with module Value = Sol.Value = Extend (struct
-  module Solver = Solver.Mutable_to_in_place (Sol)
-
-  module Fuel = struct
-    include Reversible.Effectful (Fuel_gauge)
-
-    let consume_branching n = wrap (Fuel_gauge.consume_branching n) ()
-    let consume_fuel_steps n = wrap (Fuel_gauge.consume_fuel_steps n) ()
-    let take_branches list = wrap (Fuel_gauge.take_branches list) ()
-  end
-
-  module Value = Solver.Value
-  module MONAD = Monad.SeqM
-
-  module Symex_state : Reversible.In_place = struct
-    let backtrack_n n =
-      Solver.backtrack_n n;
-      Fuel.backtrack_n n
-
-    let save () =
-      Solver.save ();
-      Fuel.save ()
-
-    let reset () = Solver.reset ()
-  end
-
-  let consume_fuel_steps n () =
-    match Fuel.consume_fuel_steps n with
-    | Exhausted -> Seq.Nil
-    | Not_exhausted -> Seq.Cons ((), Seq.empty)
-
-  let assume learned () =
-    let rec aux acc learned =
-      match learned with
-      | [] ->
-          Solver.add_constraints acc;
-          Seq.Cons ((), Seq.empty)
-      | l :: ls -> (
-          let l = Solver.simplify l in
-          match Value.as_bool l with
-          | Some true -> aux acc ls
-          | Some false -> Nil
-          | None -> aux (l :: acc) ls)
-    in
-    aux [] learned
-
-  (** Assert is [if%sat (not value) then error else ok]. In UX, assert only
-      returns false if (not value) is *really* satisfiable. *)
-  let assert_ value () =
-    let value = Solver.simplify value in
-    match Value.as_bool value with
-    | Some true -> Seq.Cons (true, Seq.empty)
-    | Some false -> Seq.Cons (false, Seq.empty)
-    | None ->
-        Symex_state.save ();
-        Solver.add_constraints [ Value.(not value) ];
-        let sat = is_sat (Solver.sat ()) in
-        Symex_state.backtrack_n 1;
-        Seq.Cons (not sat, Seq.empty)
-
-  (** TODO: is this correct? *)
-  let assert_ox value () =
-    let value = Solver.simplify value in
-    match Value.as_bool value with
-    | Some true -> Seq.Cons (true, Seq.empty)
-    | Some false -> Seq.Cons (false, Seq.empty)
-    | None ->
-        Symex_state.save ();
-        Solver.add_constraints [ Value.(not value) ];
-        let unsat = is_unsat (Solver.sat ()) in
-        Symex_state.backtrack_n 1;
-        Seq.Cons (unsat, Seq.empty)
-
-  let nondet ty () =
-    let v = Solver.fresh_var ty in
-    let v = Value.mk_var v ty in
-    Seq.Cons (v, Seq.empty)
-
-  let fresh_var ty = Seq.return (Solver.fresh_var ty)
-
-  let branch_on ?left_branch_name:_ ?right_branch_name:_ guard ~then_ ~else_ :
-      'a Seq.t =
-   fun () ->
-    let guard = Solver.simplify guard in
-    match Value.as_bool guard with
-    (* [then_] and [else_] could be ['a t] instead of [unit -> 'a t],
-       if we remove the Some true and Some false optimisation. *)
-    | Some true -> then_ () ()
-    | Some false -> else_ () ()
-    | None ->
-        Symex_state.save ();
-        Solver.add_constraints ~simplified:true [ guard ];
-        let left_sat = Solver.sat () in
-        Seq.append
-          (fun () -> if is_sat left_sat then then_ () () else Seq.Nil)
-          (fun () ->
-            Symex_state.backtrack_n 1;
-            Solver.add_constraints [ Value.(not guard) ];
-            if is_unsat left_sat then
-              (* Right must be sat since left was not! We didn't branch so we don't consume the counter. *)
-              else_ () ()
-            else
-              match Fuel.consume_branching 1 with
-              | Exhausted -> Seq.Nil
-              | Not_exhausted ->
-                  if is_sat (Solver.sat ()) then else_ () () else Seq.Nil)
-          ()
-
-  let branch_on_take_one ?left_branch_name:_ ?right_branch_name:_ guard ~then_
-      ~else_ : 'a Seq.t =
-   fun () ->
-    let guard = Solver.simplify guard in
-    match Value.as_bool guard with
-    | Some true -> then_ () ()
-    | Some false -> else_ () ()
-    | None ->
-        Symex_state.save ();
-        Solver.add_constraints ~simplified:true [ guard ];
-        let left_sat = is_sat (Solver.sat ()) in
-        Seq.append
-          (fun () -> if left_sat then then_ () () else Seq.Nil)
-          (fun () ->
-            Symex_state.backtrack_n 1;
-            if left_sat then Seq.Nil
-            else (
-              Solver.add_constraints [ Value.(not guard) ];
-              else_ () ()))
-          ()
-
-  let branches (brs : (unit -> 'a Seq.t) list) : 'a Seq.t =
-   fun () ->
-    let brs = Fuel.take_branches brs in
-    match brs with
-    | [] -> Seq.Nil
-    | [ a ] -> a () ()
-    | a :: (_ :: _ as r) ->
-        (* First branch should not backtrack and last branch should not save *)
-        let rec loop brs =
-          match brs with
-          | [ x ] ->
-              fun () ->
-                Symex_state.backtrack_n 1;
-                x () ()
-          | x :: r ->
-              Seq.append
-                (fun () ->
-                  Symex_state.backtrack_n 1;
-                  Symex_state.save ();
-                  x () ())
-                (loop r)
-          | [] -> failwith "unreachable"
-        in
-        Symex_state.save ();
-        Seq.append (fun () -> a () ()) (loop r) ()
-
-  let vanish () = Seq.empty
-
-  let[@tail_mod_cons] rec run seq =
-    match seq () with
-    | Seq.Nil -> []
-    | Seq.Cons (x1, seq) -> (
-        let pc1 = Solver.as_values () in
-        match seq () with
-        | Seq.Nil -> [ (x1, pc1) ]
-        | Seq.Cons (x2, seq) ->
-            let pc2 = Solver.as_values () in
-            (x1, pc1) :: (x2, pc2) :: run seq)
-
-  let run ~fuel s =
-    Symex_state.reset ();
-    let@ () = Fuel.run ~init:fuel in
-    run s
-end)
-
-module Make_iter (Sol : Solver.Mutable_incremental) :
+module Make (Sol : Solver.Mutable_incremental) :
   S with module Value = Sol.Value = Extend (struct
   module Solver = Solver.Mutable_to_in_place (Sol)
 
@@ -371,6 +200,8 @@ module Make_iter (Sol : Solver.Mutable_incremental) :
 
   module Value = Solver.Value
   module MONAD = Monad.IterM
+
+  type 'a t = 'a Iter.t
 
   module Symex_state : Reversible.In_place = struct
     let backtrack_n n =

--- a/soteria/lib/tutorial/core_symex.mld
+++ b/soteria/lib/tutorial/core_symex.mld
@@ -3,22 +3,21 @@
 Welcome to the Soteria tutorial! This tutorial will guide you through the basics of writing a symbolic execution engine.
 
 Today you'll be learning how to:
-- {{!instantiate}Instantiate} the {{!Soteria_symex.Symex.Make_iter}Symex} functor
+- {{!instantiate}Instantiate} the {{!Soteria_symex.Symex.Make}Symex} functor
 - {!return}
 - {!nondet}
 - {!bind}
 - {!branching}
 
-{2:instantiate Instantiating the Symex functor}
+{2:instantiate Instantiating the [Symex.Make] functor}
 
-The main utility of the Soteria library is the [Symex] functor, which provides the necessary infrastructure to define and run a symbolic execution engine.
+The main utility of the Soteria library is the {{!Soteria_symex.Symex.Make} Symex.Make} functor, which provides the necessary infrastructure to define and run a symbolic execution engine.
 To instantiate it, you need to provide a {{!Soteria_symex.Solver.Mutable_incremental} Solver} module, which defines {e symbolic values} and the solver interface to decide whether a symbolic expression of type {{!Soteria_symex.Value.S.sbool}Value.sbool} is satisfiable.
 
 {@ocaml[
-module Symex = Symex.Make_iter (C_solver.Z3_solver)
+module Symex = Symex.Make (C_solver.Z3_solver)
 ]}
 
-Here, we use {{!Soteria_symex.Symex.Make_iter} Make_iter} to create a symbolic execution monad where the base monad is {{:https://ocaml.org/p/iter/latest/doc/iter/Iter/index.html#type-t}Iter.t}. The alternative is {{!Soteria_symex.Symex.Make_seq}Make_seq}, which uses {{:https://ocaml.org/manual/latest/api/Stdlib.Seq.html}Seq.t} as the base monad. Soteria offers both monads, though we have not found significant differences in performance.
 
 {2:return Write your first symbolic process}
 


### PR DESCRIPTION
I removed Make_seq entirely and adjusted the tutorial accordingly.

I also took  the occasion to adjust signatures in the documentation. Specifically, I made sure that things of the type Symex are printed as `'a t` instead of `'a MONAD.t` which was a pain, and also that the horrible Fold signatures are written as-is.

Before:
<img width="426" height="318" alt="image" src="https://github.com/user-attachments/assets/c6ba997f-723a-4f82-9c07-c391562818e7" />
<img width="726" height="74" alt="image" src="https://github.com/user-attachments/assets/f5e9a573-eb8a-455e-b544-f6961374755b" />

After
<img width="449" height="313" alt="image" src="https://github.com/user-attachments/assets/fb5d7ea5-362e-4c8e-ab34-0048da16cca7" />
<img width="722" height="119" alt="image" src="https://github.com/user-attachments/assets/e2ab7061-1e72-441a-815c-db985f850bd8" />

