### PR TITLE
Improve `Svalue`: better BitVectors, more operations, modularise

### DIFF
--- a/soteria-c/lib/ctree_block.ml
+++ b/soteria-c/lib/ctree_block.ml
@@ -70,7 +70,7 @@ module MemVal = struct
         | Ctype.Ctype (_, Basic (Integer _)) -> Result.ok 0s
         | Ctype (_, Basic (Floating fty)) ->
             let precision = Layout.precision fty in
-            Result.ok (Typed.float precision "+0.0")
+            Result.ok (Typed.Float.mk precision "+0.0")
         | Ctype.Ctype (_, Pointer _) -> Result.ok Typed.Ptr.null
         | _ ->
             Fmt.kstr not_impl "Cannot decode Zeros for type %a" Fmt_ail.pp_ty ty

--- a/soteria-c/lib/interp.ml
+++ b/soteria-c/lib/interp.ml
@@ -513,7 +513,7 @@ module Make (State : State_intf.S) = struct
           | Bxor -> Typed.BitVec.xor
           | Bor -> Typed.BitVec.or_
           | Shl -> Typed.BitVec.shl
-          | Shr -> Typed.BitVec.shr
+          | Shr -> if signed then Typed.BitVec.ashr else Typed.BitVec.lshr
           | _ -> failwith "unreachable: bit operator is not bit operator?"
         in
         ok (op ~size:bv_size ~signed v1 v2)

--- a/soteria-c/lib/interp.ml
+++ b/soteria-c/lib/interp.ml
@@ -327,7 +327,7 @@ module Make (State : State_intf.S) = struct
                 Fmt_ail.pp_constant c Fmt_ail.pp_ty ty Fmt_ail.pp_loc
                 (get_loc ())
         in
-        let f = Typed.float precision str in
+        let f = Typed.Float.mk precision str in
         Agv.Basic f
     | ConstantInteger _ | ConstantIndeterminate _ | ConstantPredefined _
     | ConstantArray (_, _)
@@ -509,11 +509,11 @@ module Make (State : State_intf.S) = struct
         let^ v2 = cast_to_int v2 in
         let op =
           match a_op with
-          | Band -> Typed.bit_and
-          | Bxor -> Typed.bit_xor
-          | Bor -> Typed.bit_or
-          | Shl -> Typed.bit_shl
-          | Shr -> Typed.bit_shr
+          | Band -> Typed.BitVec.and_
+          | Bxor -> Typed.BitVec.xor
+          | Bor -> Typed.BitVec.or_
+          | Shl -> Typed.BitVec.shl
+          | Shr -> Typed.BitVec.shr
           | _ -> failwith "unreachable: bit operator is not bit operator?"
         in
         ok (op ~size:bv_size ~signed v1 v2)
@@ -702,7 +702,7 @@ module Make (State : State_intf.S) = struct
             let* { bv_size; signed } =
               Layout.bv_info (type_of e) |> of_opt_not_impl ~msg:"bv_info"
             in
-            let res = Typed.bit_not ~size:bv_size ~signed v in
+            let res = Typed.BitVec.not ~size:bv_size ~signed v in
             ok (Agv.Basic res)
         | AilSyntax.Plus | AilSyntax.PostfixIncr | AilSyntax.PostfixDecr ->
             Fmt.kstr not_impl "Unsupported unary operator %a" Fmt_ail.pp_unop op

--- a/soteria-rust/lib/builtins/std.ml
+++ b/soteria-rust/lib/builtins/std.ml
@@ -153,11 +153,11 @@ module M (State : State_intf.S) = struct
     let* v = of_opt_not_impl "float_is expects float" @@ Typed.cast_float v in
     let res =
       match fp with
-      | NaN -> Typed.is_nan v
-      | Normal -> Typed.is_normal v
-      | Infinite -> Typed.is_infinite v
-      | Zero -> Typed.is_zero v
-      | Subnormal -> Typed.is_subnormal v
+      | NaN -> Typed.Float.is_nan v
+      | Normal -> Typed.Float.is_normal v
+      | Infinite -> Typed.Float.is_infinite v
+      | Zero -> Typed.Float.is_zero v
+      | Subnormal -> Typed.Float.is_subnormal v
     in
     Result.ok (Base (Typed.int_of_bool res), state)
 
@@ -170,7 +170,7 @@ module M (State : State_intf.S) = struct
     let* v =
       of_opt_not_impl "float_is_finite expects float" @@ Typed.cast_float v
     in
-    let res = Typed.((not (is_nan v)) &&@ not (is_infinite v)) in
+    let res = Typed.((not (Float.is_nan v)) &&@ not (Float.is_infinite v)) in
     Result.ok (Base (Typed.int_of_bool res), state)
 
   let float_is_sign pos ~args state =
@@ -183,10 +183,10 @@ module M (State : State_intf.S) = struct
       of_opt_not_impl "float_is_sign expects float" @@ Typed.cast_float v
     in
     let res =
-      if pos then Typed.(leq_f (float_like v 0.) v)
-      else Typed.(leq_f v (float_like v (-0.)))
+      if pos then Typed.Float.(leq (like v 0.) v)
+      else Typed.Float.(leq v (like v (-0.)))
     in
-    let res = res ||@ Typed.is_nan v in
+    let res = res ||@ Typed.Float.is_nan v in
     Result.ok (Base (Typed.int_of_bool res), state)
 
   let _mk_box ptr =

--- a/soteria-rust/lib/core.ml
+++ b/soteria-rust/lib/core.ml
@@ -65,7 +65,9 @@ module M (State : State_intf.S) = struct
               let size = 8 * Layout.size_of_literal_ty ity in
               let signed = Layout.is_signed ity in
               let op =
-                match bop with Shl _ -> Typed.bit_shl | _ -> Typed.bit_shr
+                match bop with
+                | Shl _ -> Typed.BitVec.shl
+                | _ -> Typed.BitVec.shr
               in
               Result.ok (op ~size ~signed l r)
           | _ -> not_impl "Invalid binop in eval_lit_binop"
@@ -80,7 +82,7 @@ module M (State : State_intf.S) = struct
           | Mul _ -> Result.ok (l *.@ r)
           (* no such thing as division by 0 for floats -- goes to infinity *)
           | Div _ -> Result.ok (l /.@ cast r)
-          | Rem _ -> Result.ok (rem_f l (cast r))
+          | Rem _ -> Result.ok (Float.rem l (cast r))
           | _ -> not_impl "Invalid binop for float in eval_lit_binop"
         in
         Result.ok (res :> T.cval Typed.t)

--- a/soteria-rust/lib/core.ml
+++ b/soteria-rust/lib/core.ml
@@ -65,9 +65,11 @@ module M (State : State_intf.S) = struct
               let size = 8 * Layout.size_of_literal_ty ity in
               let signed = Layout.is_signed ity in
               let op =
-                match bop with
-                | Shl _ -> Typed.BitVec.shl
-                | _ -> Typed.BitVec.shr
+                match (bop, signed) with
+                | Shl _, _ -> Typed.BitVec.shl
+                | Shr _, true -> Typed.BitVec.ashr
+                | Shr _, false -> Typed.BitVec.lshr
+                | _ -> failwith "Invalid bop in shl/shr"
               in
               Result.ok (op ~size ~signed l r)
           | _ -> not_impl "Invalid binop in eval_lit_binop"

--- a/soteria-rust/lib/encoder.ml
+++ b/soteria-rust/lib/encoder.ml
@@ -440,12 +440,12 @@ module Make (Sptr : Sptr.S) = struct
             @@ Typed.cast_float sv
           in
           let size = 8 * Layout.size_of_literal_ty ity in
-          let sv' = Typed.int_of_float size sv in
+          let sv' = Typed.Float.to_int size sv in
           Ok (Base sv')
       | TLiteral (TInt _ | TUInt _), TLiteral (TFloat fp), Base sv ->
           let+ sv = cast_checked sv ~ty:Typed.t_int in
           let fp = float_precision fp in
-          let sv' = Typed.float_of_int fp sv in
+          let sv' = Typed.Float.of_int fp sv in
           Ok (Base sv')
       | TLiteral (TUInt U8), TLiteral TChar, v
       | TLiteral TBool, TLiteral (TUInt _), v

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -267,7 +267,7 @@ module Make (State : State_intf.S) = struct
     | CLiteral (VChar c) -> ok (Base (Typed.int (Uchar.to_int c)))
     | CLiteral (VFloat { float_value; float_ty }) ->
         let fp = float_precision float_ty in
-        ok (Base (Typed.float fp float_value))
+        ok (Base (Typed.Float.mk fp float_value))
     | CLiteral (VStr str) -> (
         let* ptr_opt = State.load_str_global str in
         match ptr_opt with
@@ -555,7 +555,7 @@ module Make (State : State_intf.S) = struct
             | TLiteral ((TInt _ | TUInt _) as i_ty) ->
                 let size = Layout.size_of_literal_ty i_ty * 8 in
                 let signed = Layout.is_signed i_ty in
-                let v = Typed.bit_not ~size ~signed v in
+                let v = Typed.BitVec.not ~size ~signed v in
                 ok (Base v)
             | ty ->
                 Fmt.kstr not_impl "Unexpect type in UnaryOp.Neg: %a" pp_ty ty)
@@ -569,7 +569,7 @@ module Make (State : State_intf.S) = struct
                   of_opt_not_impl "Expected a float type"
                   @@ Typed.cast_float (as_base v)
                 in
-                Base (Typed.float_like v 0.0 -.@ v)
+                Base (Typed.Float.like v 0.0 -.@ v)
             | _ -> not_impl "Invalid type for Neg")
         | PtrMetadata -> (
             match v with
@@ -648,10 +648,10 @@ module Make (State : State_intf.S) = struct
                 | TFloat _ ->
                     let op =
                       match op with
-                      | Ge -> Typed.geq_f
-                      | Gt -> Typed.gt_f
-                      | Lt -> Typed.lt_f
-                      | Le -> Typed.leq_f
+                      | Ge -> Typed.Float.geq
+                      | Gt -> Typed.Float.gt
+                      | Lt -> Typed.Float.lt
+                      | Le -> Typed.Float.leq
                       | _ -> assert false
                     in
                     let v1, v2 = (Typed.cast v1, Typed.cast v2) in
@@ -709,9 +709,9 @@ module Make (State : State_intf.S) = struct
                 let^+ v2 = cast_checked ~ty:Typed.t_int v2 in
                 let op =
                   match op with
-                  | BitOr -> Typed.bit_or
-                  | BitAnd -> Typed.bit_and
-                  | BitXor -> Typed.bit_xor
+                  | BitOr -> Typed.BitVec.or_
+                  | BitAnd -> Typed.BitVec.and_
+                  | BitXor -> Typed.BitVec.xor
                   | _ -> assert false
                 in
                 Base (op ~size ~signed v1 v2))

--- a/soteria-rust/lib/layout.ml
+++ b/soteria-rust/lib/layout.ml
@@ -453,10 +453,10 @@ and nondets tys =
 
 let zeroed_lit : Types.literal_type -> T.cval Typed.t = function
   | TInt _ | TUInt _ | TBool | TChar -> 0s
-  | TFloat F16 -> Typed.f16 0.0
-  | TFloat F32 -> Typed.f32 0.0
-  | TFloat F64 -> Typed.f64 0.0
-  | TFloat F128 -> Typed.f128 0.0
+  | TFloat F16 -> Typed.Float.f16 0.0
+  | TFloat F32 -> Typed.Float.f32 0.0
+  | TFloat F64 -> Typed.Float.f64 0.0
+  | TFloat F128 -> Typed.Float.f128 0.0
 
 let rec zeroed ~(null_ptr : 'a) : Types.ty -> 'a rust_val option =
   let zeroeds tys = Monad.OptionM.all (zeroed ~null_ptr) tys in

--- a/soteria/lib/c_values/eval.ml
+++ b/soteria/lib/c_values/eval.ml
@@ -31,7 +31,7 @@ let eval_binop : Binop.t -> t -> t -> t = function
   | BvTimes -> BitVec.Raw.times
   | BvDiv s -> BitVec.Raw.div s
   | BvRem s -> BitVec.Raw.rem s
-  | BvMod s -> BitVec.Raw.mod_ s
+  | BvMod -> BitVec.Raw.mod_
   | BvPlusOvf s -> BitVec.Raw.plus_overflows s
   | BvTimesOvf s -> BitVec.Raw.times_overflows s
   | BvLt s -> BitVec.Raw.lt s

--- a/soteria/lib/c_values/eval.ml
+++ b/soteria/lib/c_values/eval.ml
@@ -55,7 +55,7 @@ let eval_unop : Unop.t -> t -> t = function
   | IntOfBv signed -> BitVec.to_int signed
   | FloatOfBv _ -> BitVec.to_float
   | BvExtract (from, to_) -> BitVec.Raw.extract from to_
-  | BvExtend by -> BitVec.Raw.extend by
+  | BvExtend (signed, by) -> BitVec.Raw.extend signed by
   | BvNot -> BitVec.Raw.not
   | BvNegOvf -> BitVec.Raw.neg_overflows
   | FIs fc -> Float.is_floatclass fc

--- a/soteria/lib/c_values/eval.ml
+++ b/soteria/lib/c_values/eval.ml
@@ -6,6 +6,49 @@ type _ Effect.t += Eval_var : Var.t * Svalue.ty -> t Effect.t
 let eval_var (v : Var.t) (ty : Svalue.ty) : t =
   Effect.perform (Eval_var (v, ty))
 
+let eval_binop : Binop.t -> t -> t -> t = function
+  | And -> and_
+  | Or -> or_
+  | Eq -> sem_eq
+  | Leq -> leq
+  | Lt -> lt
+  | Plus -> plus
+  | Minus -> minus
+  | Times -> times
+  | Div -> div
+  | Rem -> rem
+  | Mod -> mod_
+  | FEq -> Float.eq
+  | FLeq -> Float.leq
+  | FLt -> Float.lt
+  | FPlus -> Float.plus
+  | FMinus -> Float.minus
+  | FTimes -> Float.times
+  | FDiv -> Float.div
+  | FRem -> Float.rem
+  | BvPlus -> BitVec.Raw.plus
+  | BvMinus -> BitVec.Raw.minus
+  | BitAnd -> BitVec.Raw.and_
+  | BitOr -> BitVec.Raw.or_
+  | BitXor -> BitVec.Raw.xor
+  | BitShl -> BitVec.Raw.shl
+  | BitShr -> BitVec.Raw.shr
+
+let eval_unop : Unop.t -> t -> t = function
+  | Not -> not
+  | FAbs -> Float.abs
+  | GetPtrLoc -> Ptr.loc
+  | GetPtrOfs -> Ptr.ofs
+  | IntOfBool -> int_of_bool
+  | BvOfFloat n -> BitVec.of_float n
+  | BvOfInt (s, n) -> BitVec.of_int s n
+  | IntOfBv signed -> BitVec.to_int signed
+  | FloatOfBv _ -> BitVec.to_float
+  | BvExtract (from, to_) -> BitVec.Raw.extract from to_
+  | BvExtend by -> BitVec.Raw.extend by
+  | FIs fc -> Float.is_floatclass fc
+  | FRound rm -> Float.round rm
+
 let rec eval (x : t) : t =
   match x.node.kind with
   | Var v -> eval_var v x.node.ty
@@ -14,77 +57,16 @@ let rec eval (x : t) : t =
       let nl = eval l in
       let no = eval o in
       if l == nl && o == no then x else Ptr.mk (eval l) (eval o)
-  | Unop (unop, v) -> (
+  | Unop (unop, v) ->
       let nv = eval v in
-      if v == nv then x
-      else
-        match unop with
-        | Unop.Not -> not nv
-        | FAbs -> Float.abs nv
-        | GetPtrLoc -> Ptr.loc nv
-        | GetPtrOfs -> Ptr.ofs nv
-        | IntOfBool -> int_of_bool nv
-        | BvOfFloat n -> BitVec.of_float n nv
-        | BvOfInt ->
-            let n = size_of_bv x.node.ty in
-            BitVec.of_int n nv
-        | IntOfBv signed -> BitVec.to_int signed nv
-        | FloatOfBv -> BitVec.to_float nv
-        | BvExtract (from, to_) -> BitVec.Raw.extract from to_ nv
-        | BvExtend by ->
-            let n = size_of_bv x.node.ty in
-            BitVec.Raw.extend (n + by) x
-        | FIs fc -> Float.is_floatclass fc nv
-        | FRound rm -> Float.round rm nv)
-  | Binop (binop, v1, v2) -> (
+      if v == nv then x else eval_unop unop nv
+  | Binop (binop, v1, v2) ->
       (* TODO: for binops that may short-circuit such as || or &&,
     we could do this without evaluating both sides, and deciding if any
       of either side evaluates properly to e.g. true/false *)
       let nv1 = eval v1 in
       let nv2 = eval v2 in
-      if v1 == nv1 && v2 == nv2 then x
-      else
-        match binop with
-        | Binop.And -> and_ nv1 nv2
-        | Or -> or_ nv1 nv2
-        | Eq -> sem_eq nv1 nv2
-        | Leq -> leq nv1 nv2
-        | Lt -> lt nv1 nv2
-        | Plus -> plus nv1 nv2
-        | Minus -> minus nv1 nv2
-        | Times -> times nv1 nv2
-        | Div -> div nv1 nv2
-        | Rem -> rem nv1 nv2
-        | Mod -> mod_ nv1 nv2
-        | FEq -> Float.eq nv1 nv2
-        | FLeq -> Float.leq nv1 nv2
-        | FLt -> Float.lt nv1 nv2
-        | FPlus -> Float.plus nv1 nv2
-        | FMinus -> Float.minus nv1 nv2
-        | FTimes -> Float.times nv1 nv2
-        | FDiv -> Float.div nv1 nv2
-        | FRem -> Float.rem nv1 nv2
-        | BvPlus ->
-            let n = size_of_bv x.node.ty in
-            BitVec.Raw.plus n nv1 nv2
-        | BvMinus ->
-            let n = size_of_bv x.node.ty in
-            BitVec.Raw.minus n nv1 nv2
-        | BitAnd ->
-            let n = size_of_bv x.node.ty in
-            BitVec.Raw.and_ n nv1 nv2
-        | BitOr ->
-            let n = size_of_bv x.node.ty in
-            BitVec.Raw.or_ n nv1 nv2
-        | BitXor ->
-            let n = size_of_bv x.node.ty in
-            BitVec.Raw.xor n nv1 nv2
-        | BitShl ->
-            let n = size_of_bv x.node.ty in
-            BitVec.Raw.shl n nv1 nv2
-        | BitShr ->
-            let n = size_of_bv x.node.ty in
-            BitVec.Raw.shr n nv1 nv2)
+      if v1 == nv1 && v2 == nv2 then x else eval_binop binop nv1 nv2
   | Nop (nop, l) -> (
       let l, changed = List.map_changed eval l in
       if Stdlib.not changed then x else match nop with Distinct -> distinct l)

--- a/soteria/lib/c_values/eval.ml
+++ b/soteria/lib/c_values/eval.ml
@@ -20,22 +20,22 @@ let rec eval (x : t) : t =
       else
         match unop with
         | Unop.Not -> not nv
-        | FAbs -> abs_f nv
+        | FAbs -> Float.abs nv
         | GetPtrLoc -> Ptr.loc nv
         | GetPtrOfs -> Ptr.ofs nv
         | IntOfBool -> int_of_bool nv
-        | BvOfFloat n -> bv_of_float n nv
+        | BvOfFloat n -> BitVec.of_float n nv
         | BvOfInt ->
             let n = size_of_bv x.node.ty in
-            bv_of_int n nv
-        | IntOfBv signed -> int_of_bv signed nv
-        | FloatOfBv -> float_of_bv nv
-        | BvExtract (from, to_) -> bv_extract from to_ nv
+            BitVec.of_int n nv
+        | IntOfBv signed -> BitVec.to_int signed nv
+        | FloatOfBv -> BitVec.to_float nv
+        | BvExtract (from, to_) -> BitVec.Raw.extract from to_ nv
         | BvExtend by ->
             let n = size_of_bv x.node.ty in
-            bv_extend (n + by) x
-        | FIs fc -> is_floatclass fc nv
-        | FRound rm -> float_round rm nv)
+            BitVec.Raw.extend (n + by) x
+        | FIs fc -> Float.is_floatclass fc nv
+        | FRound rm -> Float.round rm nv)
   | Binop (binop, v1, v2) -> (
       (* TODO: for binops that may short-circuit such as || or &&,
     we could do this without evaluating both sides, and deciding if any
@@ -56,35 +56,35 @@ let rec eval (x : t) : t =
         | Div -> div nv1 nv2
         | Rem -> rem nv1 nv2
         | Mod -> mod_ nv1 nv2
-        | FEq -> eq_f nv1 nv2
-        | FLeq -> leq_f nv1 nv2
-        | FLt -> lt_f nv1 nv2
-        | FPlus -> plus_f nv1 nv2
-        | FMinus -> minus_f nv1 nv2
-        | FTimes -> times_f nv1 nv2
-        | FDiv -> div_f nv1 nv2
-        | FRem -> rem_f nv1 nv2
+        | FEq -> Float.eq nv1 nv2
+        | FLeq -> Float.leq nv1 nv2
+        | FLt -> Float.lt nv1 nv2
+        | FPlus -> Float.plus nv1 nv2
+        | FMinus -> Float.minus nv1 nv2
+        | FTimes -> Float.times nv1 nv2
+        | FDiv -> Float.div nv1 nv2
+        | FRem -> Float.rem nv1 nv2
         | BvPlus ->
             let n = size_of_bv x.node.ty in
-            raw_bv_plus n nv1 nv2
+            BitVec.Raw.plus n nv1 nv2
         | BvMinus ->
             let n = size_of_bv x.node.ty in
-            raw_bv_minus n nv1 nv2
+            BitVec.Raw.minus n nv1 nv2
         | BitAnd ->
             let n = size_of_bv x.node.ty in
-            raw_bit_and n nv1 nv2
+            BitVec.Raw.and_ n nv1 nv2
         | BitOr ->
             let n = size_of_bv x.node.ty in
-            raw_bit_or n nv1 nv2
+            BitVec.Raw.or_ n nv1 nv2
         | BitXor ->
             let n = size_of_bv x.node.ty in
-            raw_bit_xor n nv1 nv2
+            BitVec.Raw.xor n nv1 nv2
         | BitShl ->
             let n = size_of_bv x.node.ty in
-            raw_bit_shl n nv1 nv2
+            BitVec.Raw.shl n nv1 nv2
         | BitShr ->
             let n = size_of_bv x.node.ty in
-            raw_bit_shr n nv1 nv2)
+            BitVec.Raw.shr n nv1 nv2)
   | Nop (nop, l) -> (
       let l, changed = List.map_changed eval l in
       if Stdlib.not changed then x else match nop with Distinct -> distinct l)

--- a/soteria/lib/c_values/eval.ml
+++ b/soteria/lib/c_values/eval.ml
@@ -28,11 +28,21 @@ let eval_binop : Binop.t -> t -> t -> t = function
   | FRem -> Float.rem
   | BvPlus -> BitVec.Raw.plus
   | BvMinus -> BitVec.Raw.minus
+  | BvTimes -> BitVec.Raw.times
+  | BvDiv s -> BitVec.Raw.div s
+  | BvRem s -> BitVec.Raw.rem s
+  | BvMod s -> BitVec.Raw.mod_ s
+  | BvPlusOvf s -> BitVec.Raw.plus_overflows s
+  | BvTimesOvf s -> BitVec.Raw.times_overflows s
+  | BvLt s -> BitVec.Raw.lt s
+  | BvLeq s -> BitVec.Raw.leq s
+  | BvConcat -> BitVec.Raw.concat
   | BitAnd -> BitVec.Raw.and_
   | BitOr -> BitVec.Raw.or_
   | BitXor -> BitVec.Raw.xor
   | BitShl -> BitVec.Raw.shl
-  | BitShr -> BitVec.Raw.shr
+  | BitLShr -> BitVec.Raw.lshr
+  | BitAShr -> BitVec.Raw.ashr
 
 let eval_unop : Unop.t -> t -> t = function
   | Not -> not
@@ -46,6 +56,8 @@ let eval_unop : Unop.t -> t -> t = function
   | FloatOfBv _ -> BitVec.to_float
   | BvExtract (from, to_) -> BitVec.Raw.extract from to_
   | BvExtend by -> BitVec.Raw.extend by
+  | BvNot -> BitVec.Raw.not
+  | BvNegOvf -> BitVec.Raw.neg_overflows
   | FIs fc -> Float.is_floatclass fc
   | FRound rm -> Float.round rm
 

--- a/soteria/lib/c_values/smt_utils.ml
+++ b/soteria/lib/c_values/smt_utils.ml
@@ -87,3 +87,11 @@ let int_of_bv signed bv =
   if signed then app_ "sbv_to_int" [ bv ] else app_ "ubv_to_int" [ bv ]
 
 let bv_of_int size n = app (ifam "int_to_bv" [ size ]) [ n ]
+
+(* BitVector overflow operators *)
+
+let bv_nego x = app_ "bvnego" [ x ]
+let bv_uaddo l r = app_ "bvuaddo" [ l; r ]
+let bv_saddo l r = app_ "bvsaddo" [ l; r ]
+let bv_umulo l r = app_ "bvumulo" [ l; r ]
+let bv_smulo l r = app_ "bvsmulo" [ l; r ]

--- a/soteria/lib/c_values/svalue.ml
+++ b/soteria/lib/c_values/svalue.ml
@@ -647,6 +647,18 @@ module BitVec = struct
       | Ite (b, l, r) -> ite b (not l) (not r)
       | _ -> Unop (BvNot, v) <| v.node.ty
 
+    let and_ v1 v2 =
+      let n = size_of_bv v1.node.ty in
+      match (v1.node.kind, v2.node.kind) with
+      | BitVec mask, _ when Z.(equal mask zero) -> v1
+      | _, BitVec mask when Z.(equal mask zero) -> v2
+      | BitVec mask, _ when covers_bitwidth n mask -> v2
+      | _, BitVec mask when covers_bitwidth n mask -> v1
+      | _, _ -> mk_commut_binop BitAnd v1 v2 <| v1.node.ty
+
+    let or_ v1 v2 = mk_commut_binop BitOr v1 v2 <| v1.node.ty
+    let xor v1 v2 = mk_commut_binop BitXor v1 v2 <| v1.node.ty
+
     let rec extract from_ to_ v =
       let size = to_ - from_ + 1 in
       match v.node.kind with
@@ -683,17 +695,6 @@ module BitVec = struct
       let n2 = size_of_bv v2.node.ty in
       Binop (BvConcat, v1, v2) <| t_bv (n1 + n2)
 
-    let and_ v1 v2 =
-      let n = size_of_bv v1.node.ty in
-      match (v1.node.kind, v2.node.kind) with
-      | BitVec mask, _ when Z.(equal mask zero) -> v1
-      | _, BitVec mask when Z.(equal mask zero) -> v2
-      | BitVec mask, _ when covers_bitwidth n mask -> v2
-      | _, BitVec mask when covers_bitwidth n mask -> v1
-      | _, _ -> mk_commut_binop BitAnd v1 v2 <| v1.node.ty
-
-    let or_ v1 v2 = mk_commut_binop BitOr v1 v2 <| v1.node.ty
-    let xor v1 v2 = mk_commut_binop BitXor v1 v2 <| v1.node.ty
     let shl v1 v2 = Binop (BitShl, v1, v2) <| v1.node.ty
     let lshr v1 v2 = Binop (BitLShr, v1, v2) <| v1.node.ty
     let ashr v1 v2 = Binop (BitAShr, v1, v2) <| v1.node.ty

--- a/soteria/lib/c_values/svalue.ml
+++ b/soteria/lib/c_values/svalue.ml
@@ -145,7 +145,7 @@ module Binop = struct
     | BvTimes
     | BvDiv of bool (* signed *)
     | BvRem of bool (* signed *)
-    | BvMod of bool (* signed *)
+    | BvMod (* only signed; unsigned mod is rem! *)
     | BvPlusOvf of bool (* signed *)
     | BvTimesOvf of bool (* signed *)
     | BvLt of bool (* signed *)
@@ -186,7 +186,7 @@ module Binop = struct
     | BvTimes -> Fmt.string ft "*b"
     | BvDiv s -> Fmt.pf ft "/%ab" pp_signed s
     | BvRem s -> Fmt.pf ft "rem%ab" pp_signed s
-    | BvMod s -> Fmt.pf ft "mod%ab" pp_signed s
+    | BvMod -> Fmt.string ft "modb"
     | BvPlusOvf s -> Fmt.pf ft "+%ab_ovf" pp_signed s
     | BvTimesOvf s -> Fmt.pf ft "*%ab_ovf" pp_signed s
     | BvLt s -> Fmt.pf ft "<%ab" pp_signed s
@@ -662,7 +662,7 @@ module BitVec = struct
 
     let div signed v1 v2 = Binop (BvDiv signed, v1, v2) <| v1.node.ty
     let rem signed v1 v2 = Binop (BvRem signed, v1, v2) <| v1.node.ty
-    let mod_ signed v1 v2 = Binop (BvMod signed, v1, v2) <| v1.node.ty
+    let mod_ v1 v2 = Binop (BvMod, v1, v2) <| v1.node.ty
 
     let rec not v =
       match v.node.kind with
@@ -1001,7 +1001,7 @@ module BitVec = struct
     | Binop (Times, l, r) -> Raw.times (of_int l) (of_int r)
     | Binop (Div, l, r) -> Raw.div s (of_int l) (of_int r)
     | Binop (Rem, l, r) -> Raw.rem s (of_int l) (of_int r)
-    | Binop (Mod, l, r) -> Raw.mod_ s (of_int l) (of_int r)
+    | Binop (Mod, l, r) -> Raw.mod_ (of_int l) (of_int r)
     | Unop (IntOfBool, v) -> Ite (v, Raw.mk n Z.one, Raw.mk n Z.zero) <| t_bv n
     | Ite (b, t, e) -> Ite (b, of_int t, of_int e) <| t_bv n
     | _ -> Unop (BvOfInt (s, n), v) <| t_bv n

--- a/soteria/lib/c_values/svalue.ml
+++ b/soteria/lib/c_values/svalue.ml
@@ -336,68 +336,6 @@ let rec subst subst_var sv =
 let v_true = Bool true <| TBool
 let v_false = Bool false <| TBool
 
-(** {2 Integers} *)
-
-let int_z z = Int z <| TInt
-let int i = int_z (Z.of_int i)
-
-let nonzero_z z =
-  if Z.equal Z.zero z then raise (Invalid_argument "nonzero_z") else int_z z
-
-let nonzero x = if x = 0 then raise (Invalid_argument "nonzero") else int x
-let zero = int_z Z.zero
-let one = int_z Z.one
-
-(** {2 Bitvectors} *)
-
-let bitvec n bv = BitVec bv <| t_bv n
-
-(** {2 Floats} *)
-
-let float fp f = Float f <| t_f fp
-let float_f fp f = Float (Float.to_string f) <| t_f fp
-let float_like v f = Float (Float.to_string f) <| v.node.ty
-
-let fp_of v =
-  match v.node.ty with
-  | TFloat fp -> fp
-  | _ -> Fmt.failwith "Unsupported float type"
-
-let f16 f = float_f F16 f
-let f32 f = float_f F32 f
-let f64 f = float_f F64 f
-let f128 f = float_f F128 f
-
-(** {2 Utils} *)
-
-let rec bv_extract from_ to_ v =
-  let size = to_ - from_ + 1 in
-  match v.node.kind with
-  | BitVec bv ->
-      let to_ = to_ + 1 in
-      let bv = Z.((bv asr from_) land pred (one lsl to_)) in
-      bitvec size bv
-  | Binop (((BitAnd | BitOr | BitXor) as bop), v1, v2) ->
-      let v1 = bv_extract from_ to_ v1 in
-      let v2 = bv_extract from_ to_ v2 in
-      mk_commut_binop bop v1 v2 <| t_bv size
-  | Unop (BvOfInt, v) when from_ = 0 -> Unop (BvOfInt, v) <| t_bv size
-  | _ -> Unop (BvExtract (from_, to_), v) <| t_bv size
-
-let bv_extend to_ v =
-  let extend_by = to_ - size_of_bv v.node.ty in
-  match v.node.kind with
-  | BitVec bv ->
-      let to_ = to_ + 1 in
-      let bv = Z.(bv land pred (one lsl to_)) in
-      bitvec to_ bv
-  (* unlike with extract, we don't want to propagate extend within the expression for &, |, ^,
-     as that will require a more expensive bit-blasting. *)
-  | Unop (BvOfInt, v) -> Unop (BvOfInt, v) <| t_bv to_
-  | _ -> Unop (BvExtend extend_by, v) <| t_bv to_
-
-(** {2 Booleans} *)
-
 let as_bool t =
   if equal t v_true then Some true
   else if equal t v_false then Some false
@@ -415,6 +353,13 @@ let and_ v1 v2 =
   | _, Bool true -> v1
   | _ -> mk_commut_binop And v1 v2 <| TBool
 
+let or_ v1 v2 =
+  match (v1.node.kind, v2.node.kind) with
+  | Bool true, _ | _, Bool true -> v_true
+  | Bool false, _ -> v2
+  | _, Bool false -> v1
+  | _ -> mk_commut_binop Or v1 v2 <| TBool
+
 let conj l = List.fold_left and_ v_true l
 
 let rec not sv =
@@ -428,75 +373,6 @@ let rec not sv =
     | Binop (Or, v1, v2) -> mk_commut_binop And (not v1) (not v2) <| TBool
     | Binop (And, v1, v2) -> mk_commut_binop Or (not v1) (not v2) <| TBool
     | _ -> Unop (Not, sv) <| TBool
-
-let rec sem_eq v1 v2 =
-  if equal v1 v2 && Stdlib.not (is_float v1.node.ty) then v_true
-  else
-    match (v1.node.kind, v2.node.kind) with
-    | Int z1, Int z2 -> bool (Z.equal z1 z2)
-    | Bool b1, Bool b2 -> bool (b1 = b2)
-    | Ptr (l1, o1), Ptr (l2, o2) -> and_ (sem_eq l1 l2) (sem_eq o1 o2)
-    | _, Binop (Plus, v2, v3) when equal v1 v2 -> sem_eq v3 zero
-    | _, Binop (Plus, v2, v3) when equal v1 v3 -> sem_eq v2 zero
-    | Binop (Plus, v1, v3), _ when equal v1 v2 -> sem_eq v3 zero
-    | Binop (Plus, v1, v3), _ when equal v3 v2 -> sem_eq v1 zero
-    | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v1 v3 ->
-        sem_eq v2 v4
-    | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v1 v4 ->
-        sem_eq v2 v3
-    | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v2 v3 ->
-        sem_eq v1 v4
-    | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v2 v4 ->
-        sem_eq v1 v3
-    | Binop (Plus, v1, { node = { kind = Int x; _ }; _ }), Int y
-    | Binop (Plus, { node = { kind = Int x; _ }; _ }, v1), Int y
-    | Int y, Binop (Plus, v1, { node = { kind = Int x; _ }; _ })
-    | Int y, Binop (Plus, { node = { kind = Int x; _ }; _ }, v1) ->
-        sem_eq v1 (int_z @@ Z.sub y x)
-    | Int y, Binop (Times, { node = { kind = Int x; _ }; _ }, v1)
-    | Int y, Binop (Times, v1, { node = { kind = Int x; _ }; _ })
-    | Binop (Times, v1, { node = { kind = Int x; _ }; _ }), Int y
-    | Binop (Times, { node = { kind = Int x; _ }; _ }, v1), Int y ->
-        if Z.equal Z.zero x then bool (Z.equal Z.zero y)
-        else if Z.(equal zero (rem y x)) then sem_eq v1 (int_z Z.(y / x))
-        else v_false
-    | Unop (IntOfBool, v1), Int z -> if Z.equal Z.zero z then not v1 else v1
-    (* Reduce  (X & #x...N) = #x...M to (X & #xN) = #xM *)
-    | Binop (BitAnd, _, _), _ | _, Binop (BitAnd, _, _) -> (
-        let rec msb_of v =
-          match v.node.kind with
-          | BitVec v when Z.(v > zero) -> Some (Z.log2up v)
-          | BitVec v when Z.(equal v zero) -> Some 0
-          | Binop (BitAnd, bv1, bv2) ->
-              Option.merge min (msb_of bv1) (msb_of bv2)
-          | _ -> None
-        in
-        let current_size = size_of_bv v1.node.ty in
-        let msb = Option.map2 max (msb_of v1) (msb_of v2) in
-        match msb with
-        | Some msb when msb <> current_size - 1 ->
-            let v1 = bv_extract 0 msb v1 in
-            let v2 = bv_extract 0 msb v2 in
-            sem_eq v1 v2
-        | _ ->
-            (* regular sem_eq *)
-            if equal v1 v2 then v_true else mk_commut_binop Eq v1 v2 <| TBool)
-    | Unop (IntOfBv _, bv1), Unop (IntOfBv _, bv2) -> sem_eq bv1 bv2
-    | Unop (IntOfBv _, bv), Int n | Int n, Unop (IntOfBv _, bv) ->
-        let size = size_of_bv bv.node.ty in
-        let n = if Z.geq n Z.zero then n else Z.neg n in
-        sem_eq bv (BitVec n <| t_bv size)
-    | _ -> mk_commut_binop Eq v1 v2 <| TBool
-
-let sem_eq_untyped v1 v2 =
-  if equal_ty v1.node.ty v2.node.ty then sem_eq v1 v2 else v_false
-
-let or_ v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | Bool true, _ | _, Bool true -> v_true
-  | Bool false, _ -> v2
-  | _, Bool false -> v1
-  | _ -> mk_commut_binop Or v1 v2 <| TBool
 
 let rec split_ands (sv : t) (f : t -> unit) : unit =
   match sv.node.kind with
@@ -524,23 +400,389 @@ let ite guard if_ else_ =
 
 (** {2 Integers} *)
 
+let int_z z = Int z <| TInt
+let int i = int_z (Z.of_int i)
+
+let nonzero_z z =
+  if Z.equal Z.zero z then raise (Invalid_argument "nonzero_z") else int_z z
+
+let nonzero x = if x = 0 then raise (Invalid_argument "nonzero") else int x
+let zero = int_z Z.zero
+let one = int_z Z.one
+
 let int_of_bool b =
   if equal v_true b then one
   else if equal v_false b then zero
   else Unop (IntOfBool, b) <| TInt
 
-(* Negates a boolean that is in integer form (i.e. 0 for false, anything else is true) *)
-let not_int_bool sv =
-  match sv.node.kind with
-  | Int z -> if Z.equal z Z.zero then one else zero
-  | Unop (IntOfBool, sv') -> int_of_bool (not sv')
-  | _ -> int_of_bool (sem_eq sv zero)
+let rec plus v1 v2 =
+  match (v1.node.kind, v2.node.kind) with
+  | _, _ when equal v1 zero -> v2
+  | _, _ when equal v2 zero -> v1
+  | Int i1, Int i2 -> int_z (Z.add i1 i2)
+  | Binop (Plus, v1, { node = { kind = Int i2; _ }; _ }), Int i3 ->
+      plus v1 (int_z (Z.add i2 i3))
+  | Binop (Plus, { node = { kind = Int i1; _ }; _ }, v2), Int i3 ->
+      plus (int_z (Z.add i1 i3)) v2
+  | Int i1, Binop (Plus, v1, { node = { kind = Int i2; _ }; _ }) ->
+      plus (int_z (Z.add i1 i2)) v1
+  | Int i1, Binop (Plus, { node = { kind = Int i2; _ }; _ }, v2) ->
+      plus (int_z (Z.add i1 i2)) v2
+  | _ -> mk_commut_binop Plus v1 v2 <| TInt
 
-let bool_of_int sv =
-  match sv.node.kind with
-  | Int z -> bool (Stdlib.not (Z.equal z Z.zero))
-  | Unop (IntOfBool, sv') -> sv'
-  | _ -> not (sem_eq sv zero)
+let rec minus v1 v2 =
+  match (v1.node.kind, v2.node.kind) with
+  | _, _ when equal v2 zero -> v1
+  | Int i1, Int i2 -> int_z (Z.sub i1 i2)
+  | Var v1, Var v2 when Var.equal v1 v2 -> zero
+  | Binop (Minus, { node = { kind = Int i2; _ }; _ }, v1), Int i1 ->
+      minus (int_z (Z.sub i2 i1)) v1
+  | Binop (Minus, v1, { node = { kind = Int i2; _ }; _ }), Int i1 ->
+      minus v1 (int_z (Z.sub i2 i1))
+  | Binop (Plus, x, y), _ when equal x v2 -> y
+  | Binop (Plus, x, y), _ when equal y v2 -> x
+  | _, Binop (Plus, x, y) when equal x v1 -> y
+  | _, Binop (Plus, x, y) when equal x v1 -> y
+  | _ -> Binop (Minus, v1, v2) <| TInt
+
+let times v1 v2 =
+  match (v1.node.kind, v2.node.kind) with
+  | _, _ when equal v1 zero || equal v2 zero -> zero
+  | _, _ when equal v1 one -> v2
+  | _, _ when equal v2 one -> v1
+  | Int i1, Int i2 -> int_z (Z.mul i1 i2)
+  | _ -> mk_commut_binop Times v1 v2 <| TInt
+
+let div v1 v2 =
+  match (v1.node.kind, v2.node.kind) with
+  | _, _ when equal v2 one -> v1
+  | Int i1, Int i2 -> int_z (Z.div i1 i2)
+  | Binop (Times, v, { node = { kind = Int i; _ }; _ }), Int j
+  | Int j, Binop (Times, v, { node = { kind = Int i; _ }; _ })
+    when Z.equal i j ->
+      v
+  | Binop (Times, { node = { kind = Int i; _ }; _ }, v), Int j
+  | Int j, Binop (Times, { node = { kind = Int i; _ }; _ }, v)
+    when Z.equal i j ->
+      v
+  | _ -> Binop (Div, v1, v2) <| TInt
+
+let rec is_mod v n =
+  match v.node.kind with
+  | Int i1 -> Z.equal (Z.( mod ) i1 n) Z.zero
+  | Binop (Plus, v2, v3) -> is_mod v2 n && is_mod v3 n
+  | Binop (Minus, v2, v3) -> is_mod v2 n && is_mod v3 n
+  | Binop (Times, v2, v3) -> is_mod v2 n || is_mod v3 n
+  | _ -> false
+
+let rec rem v1 v2 =
+  match (v1.node.kind, v2.node.kind) with
+  | _, Int i2 when is_mod v1 i2 -> zero
+  | Int i1, Int i2 -> int_z (Z.rem i1 i2)
+  | Binop (Times, v1, n), Binop (Times, v2, m) when equal n m ->
+      times n (rem v1 v2)
+  | Binop (Times, n, v1), Binop (Times, m, v2) when equal n m ->
+      times n (rem v1 v2)
+  | _ -> Binop (Rem, v1, v2) <| v1.node.ty
+
+let rec mod_ v1 v2 =
+  match (v1.node.kind, v2.node.kind) with
+  | _, _ when equal v2 one -> zero
+  | _, Int i2 when is_mod v1 i2 -> zero
+  | Int i1, Int i2 ->
+      (* OCaml's mod computes the remainer... *)
+      let rem = Z.( mod ) i1 i2 in
+      if Z.lt rem Z.zero then int_z (Z.add rem i2) else int_z rem
+  | Binop (Mod, x, { node = { kind = Int i1; _ }; _ }), Int i2
+    when Z.geq i1 i2 && Z.divisible i1 i2 ->
+      mod_ x v2
+  | _ -> Binop (Mod, v1, v2) <| TInt
+
+let neg v =
+  match (v.node.ty, v.node.kind) with
+  | TInt, Int i -> int_z (Z.neg i)
+  | _ -> minus zero v
+
+(** {2 Bit vectors}
+
+    Bit vector operations; all these expect values of type [TInt], and apply
+    bit-vector conversions under the hood as needed. This allow bit operations
+    to be seamlessly used on [TInt], without worrying about the underlying
+    representation.*)
+module BitVec = struct
+  let bool_or = or_
+  let bool_and = and_
+
+  (** Raw operations for values of type [TBitVector]; be careful when using
+      these, so as to provide properly typed values. Prefer using [BitVec]
+      directly when possible, as it may also provide more reductions. *)
+  module Raw = struct
+    let mk n bv = BitVec bv <| t_bv n
+
+    let rec extract from_ to_ v =
+      let size = to_ - from_ + 1 in
+      match v.node.kind with
+      | BitVec bv ->
+          let to_ = to_ + 1 in
+          let bv = Z.((bv asr from_) land pred (one lsl to_)) in
+          mk size bv
+      | Binop (((BitAnd | BitOr | BitXor) as bop), v1, v2) ->
+          let v1 = extract from_ to_ v1 in
+          let v2 = extract from_ to_ v2 in
+          mk_commut_binop bop v1 v2 <| t_bv size
+      | Unop (BvOfInt, v) when from_ = 0 -> Unop (BvOfInt, v) <| t_bv size
+      | _ -> Unop (BvExtract (from_, to_), v) <| t_bv size
+
+    let extend to_ v =
+      let extend_by = to_ - size_of_bv v.node.ty in
+      match v.node.kind with
+      | BitVec bv ->
+          let to_ = to_ + 1 in
+          let bv = Z.(bv land pred (one lsl to_)) in
+          mk to_ bv
+      (* unlike with extract, we don't want to propagate extend within the expression for &, |, ^,
+         as that will require a more expensive bit-blasting. *)
+      | Unop (BvOfInt, v) -> Unop (BvOfInt, v) <| t_bv to_
+      | _ -> Unop (BvExtend extend_by, v) <| t_bv to_
+
+    let and_ n v1 v2 =
+      let covers_bitwidth z =
+        Z.(z > one && popcount (succ z) = 1 && log2 (succ z) = n)
+      in
+      match (v1.node.kind, v2.node.kind) with
+      | BitVec mask, _ when Z.(equal mask zero) -> v1
+      | _, BitVec mask when Z.(equal mask zero) -> v2
+      | BitVec mask, _ when covers_bitwidth mask -> v2
+      | _, BitVec mask when covers_bitwidth mask -> v1
+      | _, _ -> mk_commut_binop BitAnd v1 v2 <| t_bv n
+
+    let or_ n v1 v2 = mk_commut_binop BitOr v1 v2 <| t_bv n
+    let xor n v1 v2 = mk_commut_binop BitXor v1 v2 <| t_bv n
+    let shl n v1 v2 = Binop (BitShl, v1, v2) <| t_bv n
+    let shr n v1 v2 = Binop (BitShr, v1, v2) <| t_bv n
+    let plus n v1 v2 = mk_commut_binop BvPlus v1 v2 <| t_bv n
+    let minus n v1 v2 = Binop (BvMinus, v1, v2) <| t_bv n
+  end
+
+  let of_float n v =
+    match (v.node.ty, v.node.kind, n) with
+    | TFloat _, Unop (FloatOfBv, v), _ -> v
+    | TFloat F32, Float f, 32 ->
+        let z = Z.of_int32 (Int32.bits_of_float (Float.of_string f)) in
+        Raw.mk n z
+    | TFloat F64, Float f, 64 ->
+        let z = Z.of_int64 (Int64.bits_of_float (Float.of_string f)) in
+        Raw.mk n z
+    | _, _, _ -> Unop (BvOfFloat n, v) <| t_bv n
+
+  let rec of_int n v =
+    let bv_of_int = of_int n in
+    let is_2pow z = Z.(z > one && popcount z = 1) in
+    match v.node.kind with
+    | Unop (IntOfBv _, v) ->
+        if size_of_bv v.node.ty = n then v
+        else if size_of_bv v.node.ty > n then Raw.extract 0 (n - 1) v
+        else Raw.extend n v
+    | Int z ->
+        let z = if Z.geq z Z.zero then z else Z.neg z in
+        (* need to mask otherwise we'll encode a value bigger than the bitwidth *)
+        let mask = Z.pred @@ Z.shift_left Z.one n in
+        let z = Z.(z land mask) in
+        Raw.mk n z
+    | Binop (Mod, v, { node = { kind = Int mask; _ }; _ }) when is_2pow mask ->
+        Raw.and_ n (bv_of_int v) (Raw.mk n (Z.pred mask))
+    | Binop (Mod, { node = { kind = Int mask; _ }; _ }, v) when is_2pow mask ->
+        Raw.and_ n (bv_of_int v) (Raw.mk n (Z.pred mask))
+    | Binop (Times, { node = { kind = Int mask; _ }; _ }, v) when is_2pow mask
+      ->
+        let fac = Raw.mk n (Z.of_int (Z.log2 mask)) in
+        Raw.shl n (bv_of_int v) fac
+    | Binop (Div, v, { node = { kind = Int mask; _ }; _ }) when is_2pow mask ->
+        let fac = Raw.mk n (Z.of_int (Z.log2 mask)) in
+        Raw.shr n (bv_of_int v) fac
+    | Binop (Plus, l, r) -> Raw.plus n (bv_of_int l) (bv_of_int r)
+    | Binop (Minus, l, r) -> Raw.minus n (bv_of_int l) (bv_of_int r)
+    | _ -> Unop (BvOfInt, v) <| t_bv n
+
+  let rec to_int signed v =
+    (* Tests if z is of the form 1+0+ *)
+    let is_left_mask z =
+      if Z.(z <= one) then false
+      else
+        let size = Z.log2up z in
+        let zeroes = size - Z.popcount z in
+        if zeroes = 0 then false
+        else if size <> size_of_bv v.node.ty then false
+        else
+          let mask = Z.pred @@ Z.shift_left Z.one zeroes in
+          Z.(Z.equal (z land mask) zero)
+    in
+    match v.node.kind with
+    | Unop (BvOfInt, v) -> v
+    | Binop (BvPlus, l, r) -> plus (to_int signed l) (to_int signed r)
+    | Binop (BvMinus, l, r) -> minus (to_int signed l) (to_int signed r)
+    | Binop (BitShl, l, { node = { kind = Int n; _ }; _ }) ->
+        let pow = int_z @@ Z.shift_left Z.one (Z.to_int n) in
+        times l pow
+    | Binop (BitShr, l, { node = { kind = Int n; _ }; _ }) ->
+        let pow = int_z @@ Z.shift_right Z.one (Z.to_int n) in
+        div l pow
+    | Binop (BitAnd, v, { node = { kind = BitVec mask; _ }; _ })
+      when is_left_mask mask ->
+        (* left mask, of the form 1+0+. e.g. for 1111 1000, this is equivalent to dividing by 2^3,
+         and then re-multiplying, avoiding the bitvector.  *)
+        let zeroes = Z.log2 mask - Z.popcount mask in
+        let pow = int_z @@ Z.shift_left Z.one zeroes in
+        let v = to_int signed v in
+        times (div v pow) pow
+    | _ -> Unop (IntOfBv signed, v) <| t_int
+
+  let to_float v =
+    match (v.node.ty, v.node.kind) with
+    | _, Unop (BvOfFloat _, v) -> v
+    | TBitVector n, _ -> Unop (FloatOfBv, v) <| t_f (FloatPrecision.of_size n)
+    | _ -> failwith "Expected a bitvector value in float_of_bv"
+
+  let and_ ~size ~signed v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | Int i1, Int i2 -> int_z (Z.( land ) i1 i2)
+    | Bool b1, Bool b2 -> bool (b1 && b2)
+    | _ ->
+        let v1_bv = of_int size v1 in
+        let v2_bv = of_int size v2 in
+        let bv = Raw.and_ size v1_bv v2_bv in
+        to_int signed bv
+
+  let or_ ~size ~signed v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | Int i1, Int i2 -> int_z (Z.( lor ) i1 i2)
+    | Bool b1, Bool b2 -> bool (b1 || b2)
+    | _ ->
+        let v1_bv = of_int size v1 in
+        let v2_bv = of_int size v2 in
+        let bv = Raw.or_ size v1_bv v2_bv in
+        to_int signed bv
+
+  let xor ~size ~signed v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | Int i1, Int i2 -> int_z (Z.( lxor ) i1 i2)
+    | Bool b1, Bool b2 -> bool (b1 <> b2)
+    | _ ->
+        let v1_bv = of_int size v1 in
+        let v2_bv = of_int size v2 in
+        let bv = Raw.xor size v1_bv v2_bv in
+        to_int signed bv
+
+  let shl ~size ~signed v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | Int i1, Int i2 ->
+        let shifted = Z.( lsl ) i1 (Z.to_int i2) in
+        let masked = Z.( land ) shifted (Z.pred (Z.( lsl ) Z.one size)) in
+        int_z masked
+    | _, Int i2 ->
+        let max = Z.( lsl ) Z.one size in
+        let shifted = times v1 (int_z (Z.( lsl ) Z.one (Z.to_int i2))) in
+        let masked = mod_ shifted (int_z max) in
+        masked
+    | _ ->
+        let v1_bv = of_int size v1 in
+        let v2_bv = of_int size v2 in
+        let bv = Raw.shl size v1_bv v2_bv in
+        to_int signed bv
+
+  let shr ~size ~signed v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | Int i1, Int i2 ->
+        let shifted = Z.( asr ) i1 (Z.to_int i2) in
+        let masked = Z.( land ) shifted (Z.pred (Z.( lsl ) Z.one size)) in
+        int_z masked
+    | _ ->
+        let v1_bv = of_int size v1 in
+        let v2_bv = of_int size v2 in
+        let bv = Raw.shr size v1_bv v2_bv in
+        to_int signed bv
+
+  let not ~size:s ~signed v =
+    if Stdlib.not signed then
+      let max = Z.(pred (one lsl s)) in
+      minus (int_z max) v
+    else minus (neg v) one
+end
+
+(** {2 Floating point} *)
+module Float = struct
+  let mk fp f = Float f <| t_f fp
+  let mk_f fp f = Float (Float.to_string f) <| t_f fp
+  let like v f = Float (Float.to_string f) <| v.node.ty
+
+  let fp_of v =
+    match v.node.ty with
+    | TFloat fp -> fp
+    | _ -> Fmt.failwith "Unsupported float type"
+
+  let f16 f = mk_f F16 f
+  let f32 f = mk_f F32 f
+  let f64 f = mk_f F64 f
+  let f128 f = mk_f F128 f
+  let eq v1 v2 = mk_commut_binop FEq v1 v2 <| TBool
+
+  let lt v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | Float f1, Float f2 -> bool (float_of_string f1 < float_of_string f2)
+    | _ -> Binop (FLt, v1, v2) <| TBool
+
+  let leq v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | Float f1, Float f2 -> bool (float_of_string f1 <= float_of_string f2)
+    | _ -> Binop (FLeq, v1, v2) <| TBool
+
+  let gt v1 v2 = lt v2 v1
+  let geq v1 v2 = leq v2 v1
+  let plus v1 v2 = mk_commut_binop FPlus v1 v2 <| v1.node.ty
+  let minus v1 v2 = Binop (FMinus, v1, v2) <| v1.node.ty
+  let div v1 v2 = Binop (FDiv, v1, v2) <| v1.node.ty
+  let times v1 v2 = mk_commut_binop FTimes v1 v2 <| v1.node.ty
+  let rem v1 v2 = Binop (FRem, v1, v2) <| v1.node.ty
+
+  let abs v =
+    match v.node.kind with
+    | Unop (FAbs, _) -> v
+    | _ -> Unop (FAbs, v) <| v.node.ty
+
+  let neg v =
+    let fp = fp_of v in
+    Binop (FMinus, mk fp "0.0", v) <| v.node.ty
+
+  (* FIXME: all of these reductions are unsound for floats that aren't F64, I think *)
+  let is_floatclass fc =
+   fun sv ->
+    match sv.node.kind with
+    | Float f ->
+        bool (FloatClass.as_fpclass fc = classify_float (float_of_string f))
+    | _ -> Unop (FIs fc, sv) <| TBool
+
+  let is_normal = is_floatclass Normal
+  let is_subnormal = is_floatclass Subnormal
+  let is_infinite = is_floatclass Infinite
+  let is_nan = is_floatclass NaN
+  let is_zero = is_floatclass Zero
+  let round rm sv = Unop (FRound rm, sv) <| sv.node.ty
+
+  let of_int fp v =
+    match (v.node.kind, fp) with
+    (* We force the integer to a float, to account for precision loss.
+     Ideally we should do this for every float precision, but we would need support for
+     f16, f32 and f128 in OCaml.  *)
+    | Int i, FloatPrecision.F64 -> mk fp (string_of_float (Z.to_float i))
+    | _ -> BitVec.to_float (BitVec.of_int (FloatPrecision.size fp) v)
+
+  let to_int n v =
+    match v.node.kind with
+    | Float f -> int_z (Z.of_float (Float.of_string f))
+    | _ -> BitVec.to_int true (BitVec.of_float n v)
+end
+
+(* {2 Equality, comparison, int-bool conversions} *)
 
 let rec lt v1 v2 =
   match (v1.node.kind, v2.node.kind) with
@@ -639,312 +881,81 @@ and leq v1 v2 =
 let geq v1 v2 = leq v2 v1
 let gt v1 v2 = lt v2 v1
 
-let rec plus v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | _, _ when equal v1 zero -> v2
-  | _, _ when equal v2 zero -> v1
-  | Int i1, Int i2 -> int_z (Z.add i1 i2)
-  | Binop (Plus, v1, { node = { kind = Int i2; _ }; _ }), Int i3 ->
-      plus v1 (int_z (Z.add i2 i3))
-  | Binop (Plus, { node = { kind = Int i1; _ }; _ }, v2), Int i3 ->
-      plus (int_z (Z.add i1 i3)) v2
-  | Int i1, Binop (Plus, v1, { node = { kind = Int i2; _ }; _ }) ->
-      plus (int_z (Z.add i1 i2)) v1
-  | Int i1, Binop (Plus, { node = { kind = Int i2; _ }; _ }, v2) ->
-      plus (int_z (Z.add i1 i2)) v2
-  | _ -> mk_commut_binop Plus v1 v2 <| TInt
+let rec sem_eq v1 v2 =
+  if equal v1 v2 && Stdlib.not (is_float v1.node.ty) then v_true
+  else
+    match (v1.node.kind, v2.node.kind) with
+    | Int z1, Int z2 -> bool (Z.equal z1 z2)
+    | Bool b1, Bool b2 -> bool (b1 = b2)
+    | Ptr (l1, o1), Ptr (l2, o2) -> and_ (sem_eq l1 l2) (sem_eq o1 o2)
+    | _, Binop (Plus, v2, v3) when equal v1 v2 -> sem_eq v3 zero
+    | _, Binop (Plus, v2, v3) when equal v1 v3 -> sem_eq v2 zero
+    | Binop (Plus, v1, v3), _ when equal v1 v2 -> sem_eq v3 zero
+    | Binop (Plus, v1, v3), _ when equal v3 v2 -> sem_eq v1 zero
+    | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v1 v3 ->
+        sem_eq v2 v4
+    | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v1 v4 ->
+        sem_eq v2 v3
+    | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v2 v3 ->
+        sem_eq v1 v4
+    | Binop (Plus, v1, v2), Binop (Plus, v3, v4) when equal v2 v4 ->
+        sem_eq v1 v3
+    | Binop (Plus, v1, { node = { kind = Int x; _ }; _ }), Int y
+    | Binop (Plus, { node = { kind = Int x; _ }; _ }, v1), Int y
+    | Int y, Binop (Plus, v1, { node = { kind = Int x; _ }; _ })
+    | Int y, Binop (Plus, { node = { kind = Int x; _ }; _ }, v1) ->
+        sem_eq v1 (int_z @@ Z.sub y x)
+    | Int y, Binop (Times, { node = { kind = Int x; _ }; _ }, v1)
+    | Int y, Binop (Times, v1, { node = { kind = Int x; _ }; _ })
+    | Binop (Times, v1, { node = { kind = Int x; _ }; _ }), Int y
+    | Binop (Times, { node = { kind = Int x; _ }; _ }, v1), Int y ->
+        if Z.equal Z.zero x then bool (Z.equal Z.zero y)
+        else if Z.(equal zero (rem y x)) then sem_eq v1 (int_z Z.(y / x))
+        else v_false
+    | Unop (IntOfBool, v1), Int z -> if Z.equal Z.zero z then not v1 else v1
+    (* Reduce  (X & #x...N) = #x...M to (X & #xN) = #xM *)
+    | Binop (BitAnd, _, _), _ | _, Binop (BitAnd, _, _) -> (
+        let rec msb_of v =
+          match v.node.kind with
+          | BitVec v when Z.(v > zero) -> Some (Z.log2up v)
+          | BitVec v when Z.(equal v zero) -> Some 0
+          | Binop (BitAnd, bv1, bv2) ->
+              Option.merge min (msb_of bv1) (msb_of bv2)
+          | _ -> None
+        in
+        let current_size = size_of_bv v1.node.ty in
+        let msb = Option.map2 max (msb_of v1) (msb_of v2) in
+        match msb with
+        | Some msb when msb <> current_size - 1 ->
+            let v1 = BitVec.Raw.extract 0 msb v1 in
+            let v2 = BitVec.Raw.extract 0 msb v2 in
+            sem_eq v1 v2
+        | _ ->
+            (* regular sem_eq *)
+            if equal v1 v2 then v_true else mk_commut_binop Eq v1 v2 <| TBool)
+    | Unop (IntOfBv _, bv1), Unop (IntOfBv _, bv2) -> sem_eq bv1 bv2
+    | Unop (IntOfBv _, bv), Int n | Int n, Unop (IntOfBv _, bv) ->
+        let size = size_of_bv bv.node.ty in
+        let n = if Z.geq n Z.zero then n else Z.neg n in
+        sem_eq bv (BitVec n <| t_bv size)
+    | _ -> mk_commut_binop Eq v1 v2 <| TBool
 
-let rec minus v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | _, _ when equal v2 zero -> v1
-  | Int i1, Int i2 -> int_z (Z.sub i1 i2)
-  | Var v1, Var v2 when Var.equal v1 v2 -> zero
-  | Binop (Minus, { node = { kind = Int i2; _ }; _ }, v1), Int i1 ->
-      minus (int_z (Z.sub i2 i1)) v1
-  | Binop (Minus, v1, { node = { kind = Int i2; _ }; _ }), Int i1 ->
-      minus v1 (int_z (Z.sub i2 i1))
-  | Binop (Plus, x, y), _ when equal x v2 -> y
-  | Binop (Plus, x, y), _ when equal y v2 -> x
-  | _, Binop (Plus, x, y) when equal x v1 -> y
-  | _, Binop (Plus, x, y) when equal x v1 -> y
-  | _ -> Binop (Minus, v1, v2) <| TInt
+let sem_eq_untyped v1 v2 =
+  if equal_ty v1.node.ty v2.node.ty then sem_eq v1 v2 else v_false
 
-let times v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | _, _ when equal v1 zero || equal v2 zero -> zero
-  | _, _ when equal v1 one -> v2
-  | _, _ when equal v2 one -> v1
-  | Int i1, Int i2 -> int_z (Z.mul i1 i2)
-  | _ -> mk_commut_binop Times v1 v2 <| TInt
-
-let div v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | _, _ when equal v2 one -> v1
-  | Int i1, Int i2 -> int_z (Z.div i1 i2)
-  | Binop (Times, v, { node = { kind = Int i; _ }; _ }), Int j
-  | Int j, Binop (Times, v, { node = { kind = Int i; _ }; _ })
-    when Z.equal i j ->
-      v
-  | Binop (Times, { node = { kind = Int i; _ }; _ }, v), Int j
-  | Int j, Binop (Times, { node = { kind = Int i; _ }; _ }, v)
-    when Z.equal i j ->
-      v
-  | _ -> Binop (Div, v1, v2) <| TInt
-
-let rec is_mod v n =
-  match v.node.kind with
-  | Int i1 -> Z.equal (Z.( mod ) i1 n) Z.zero
-  | Binop (Plus, v2, v3) -> is_mod v2 n && is_mod v3 n
-  | Binop (Minus, v2, v3) -> is_mod v2 n && is_mod v3 n
-  | Binop (Times, v2, v3) -> is_mod v2 n || is_mod v3 n
-  | _ -> false
-
-let rec rem v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | _, Int i2 when is_mod v1 i2 -> zero
-  | Int i1, Int i2 -> int_z (Z.rem i1 i2)
-  | Binop (Times, v1, n), Binop (Times, v2, m) when equal n m ->
-      times n (rem v1 v2)
-  | Binop (Times, n, v1), Binop (Times, m, v2) when equal n m ->
-      times n (rem v1 v2)
-  | _ -> Binop (Rem, v1, v2) <| v1.node.ty
-
-let rec mod_ v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | _, _ when equal v2 one -> zero
-  | _, Int i2 when is_mod v1 i2 -> zero
-  | Int i1, Int i2 ->
-      (* OCaml's mod computes the remainer... *)
-      let rem = Z.( mod ) i1 i2 in
-      if Z.lt rem Z.zero then int_z (Z.add rem i2) else int_z rem
-  | Binop (Mod, x, { node = { kind = Int i1; _ }; _ }), Int i2
-    when Z.geq i1 i2 && Z.divisible i1 i2 ->
-      mod_ x v2
-  | _ -> Binop (Mod, v1, v2) <| TInt
-
-let neg v =
-  match (v.node.ty, v.node.kind) with
-  | TInt, Int i -> int_z (Z.neg i)
-  | TFloat fp, _ -> Binop (FMinus, float fp "0.0", v) <| v.node.ty
-  | _ -> minus zero v
-
-(** {2 Bit vectors} *)
-
-let raw_bit_and n v1 v2 =
-  let covers_bitwidth z =
-    Z.(z > one && popcount (succ z) = 1 && log2 (succ z) = n)
-  in
-  match (v1.node.kind, v2.node.kind) with
-  | BitVec mask, _ when Z.(equal mask zero) -> v1
-  | _, BitVec mask when Z.(equal mask zero) -> v2
-  | BitVec mask, _ when covers_bitwidth mask -> v2
-  | _, BitVec mask when covers_bitwidth mask -> v1
-  | _, _ -> mk_commut_binop BitAnd v1 v2 <| t_bv n
-
-let raw_bit_or n v1 v2 = mk_commut_binop BitOr v1 v2 <| t_bv n
-let raw_bit_xor n v1 v2 = mk_commut_binop BitXor v1 v2 <| t_bv n
-let raw_bit_shl n v1 v2 = Binop (BitShl, v1, v2) <| t_bv n
-let raw_bit_shr n v1 v2 = Binop (BitShr, v1, v2) <| t_bv n
-let raw_bv_plus n v1 v2 = mk_commut_binop BvPlus v1 v2 <| t_bv n
-let raw_bv_minus n v1 v2 = Binop (BvMinus, v1, v2) <| t_bv n
-
-let bv_of_float n v =
-  match (v.node.ty, v.node.kind, n) with
-  | TFloat _, Unop (FloatOfBv, v), _ -> v
-  | TFloat F32, Float f, 32 ->
-      let z = Z.of_int32 (Int32.bits_of_float (Float.of_string f)) in
-      bitvec n z
-  | TFloat F64, Float f, 64 ->
-      let z = Z.of_int64 (Int64.bits_of_float (Float.of_string f)) in
-      bitvec n z
-  | _, _, _ -> Unop (BvOfFloat n, v) <| t_bv n
-
-let rec bv_of_int n v =
-  let bv_of_int = bv_of_int n in
-  let is_2pow z = Z.(z > one && popcount z = 1) in
-  match v.node.kind with
-  | Unop (IntOfBv _, v) ->
-      if size_of_bv v.node.ty = n then v
-      else if size_of_bv v.node.ty > n then bv_extract 0 (n - 1) v
-      else bv_extend n v
-  | Int z ->
-      let z = if Z.geq z Z.zero then z else Z.neg z in
-      (* need to mask otherwise we'll encode a value bigger than the bitwidth *)
-      let mask = Z.pred @@ Z.shift_left Z.one n in
-      let z = Z.(z land mask) in
-      bitvec n z
-  | Binop (Mod, v, { node = { kind = Int mask; _ }; _ }) when is_2pow mask ->
-      raw_bit_and n (bv_of_int v) (bitvec n (Z.pred mask))
-  | Binop (Mod, { node = { kind = Int mask; _ }; _ }, v) when is_2pow mask ->
-      raw_bit_and n (bv_of_int v) (bitvec n (Z.pred mask))
-  | Binop (Times, { node = { kind = Int mask; _ }; _ }, v) when is_2pow mask ->
-      let fac = bitvec n (Z.of_int (Z.log2 mask)) in
-      raw_bit_shl n (bv_of_int v) fac
-  | Binop (Div, v, { node = { kind = Int mask; _ }; _ }) when is_2pow mask ->
-      let fac = bitvec n (Z.of_int (Z.log2 mask)) in
-      raw_bit_shr n (bv_of_int v) fac
-  | Binop (Plus, l, r) -> raw_bv_plus n (bv_of_int l) (bv_of_int r)
-  | Binop (Minus, l, r) -> raw_bv_minus n (bv_of_int l) (bv_of_int r)
-  | _ -> Unop (BvOfInt, v) <| t_bv n
-
-let rec int_of_bv signed v =
-  (* Tests if z is of the form 1+0+ *)
-  let is_left_mask z =
-    if Z.(z <= one) then false
-    else
-      let size = Z.log2up z in
-      let zeroes = size - Z.popcount z in
-      if zeroes = 0 then false
-      else if size <> size_of_bv v.node.ty then false
-      else
-        let mask = Z.pred @@ Z.shift_left Z.one zeroes in
-        Z.(Z.equal (z land mask) zero)
-  in
-  match v.node.kind with
-  | Unop (BvOfInt, v) -> v
-  | Binop (BvPlus, l, r) -> plus (int_of_bv signed l) (int_of_bv signed r)
-  | Binop (BvMinus, l, r) -> minus (int_of_bv signed l) (int_of_bv signed r)
-  | Binop (BitShl, l, { node = { kind = Int n; _ }; _ }) ->
-      let pow = int_z @@ Z.shift_left Z.one (Z.to_int n) in
-      times l pow
-  | Binop (BitShr, l, { node = { kind = Int n; _ }; _ }) ->
-      let pow = int_z @@ Z.shift_right Z.one (Z.to_int n) in
-      div l pow
-  | Binop (BitAnd, v, { node = { kind = BitVec mask; _ }; _ })
-    when is_left_mask mask ->
-      (* left mask, of the form 1+0+. e.g. for 1111 1000, this is equivalent to dividing by 2^3,
-         and then re-multiplying, avoiding the bitvector.  *)
-      let zeroes = Z.log2 mask - Z.popcount mask in
-      let pow = int_z @@ Z.shift_left Z.one zeroes in
-      let v = int_of_bv signed v in
-      times (div v pow) pow
-  | _ -> Unop (IntOfBv signed, v) <| t_int
-
-let float_of_bv v =
-  match (v.node.ty, v.node.kind) with
-  | _, Unop (BvOfFloat _, v) -> v
-  | TBitVector n, _ -> Unop (FloatOfBv, v) <| t_f (FloatPrecision.of_size n)
-  | _ -> failwith "Expected a bitvector value in float_of_bv"
-
-let float_of_int fp v =
-  match (v.node.kind, fp) with
-  (* We force the integer to a float, to account for precision loss.
-     Ideally we should do this for every float precision, but we would need support for
-     f16, f32 and f128 in OCaml.  *)
-  | Int i, FloatPrecision.F64 -> float fp (string_of_float (Z.to_float i))
-  | _ -> float_of_bv (bv_of_int (FloatPrecision.size fp) v)
-
-let int_of_float n v =
-  match v.node.kind with
-  | Float f -> int_z (Z.of_float (Float.of_string f))
-  | _ -> int_of_bv true (bv_of_float n v)
-
-let bit_and ~size ~signed v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | Int i1, Int i2 -> int_z (Z.( land ) i1 i2)
-  | Bool b1, Bool b2 -> bool (b1 && b2)
-  | _ ->
-      let v1_bv = bv_of_int size v1 in
-      let v2_bv = bv_of_int size v2 in
-      let bv = raw_bit_and size v1_bv v2_bv in
-      int_of_bv signed bv
-
-let bit_or ~size ~signed v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | Int i1, Int i2 -> int_z (Z.( lor ) i1 i2)
-  | Bool b1, Bool b2 -> bool (b1 || b2)
-  | _ ->
-      let v1_bv = bv_of_int size v1 in
-      let v2_bv = bv_of_int size v2 in
-      let bv = raw_bit_or size v1_bv v2_bv in
-      int_of_bv signed bv
-
-let bit_xor ~size ~signed v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | Int i1, Int i2 -> int_z (Z.( lxor ) i1 i2)
-  | Bool b1, Bool b2 -> bool (b1 <> b2)
-  | _ ->
-      let v1_bv = bv_of_int size v1 in
-      let v2_bv = bv_of_int size v2 in
-      let bv = raw_bit_xor size v1_bv v2_bv in
-      int_of_bv signed bv
-
-let bit_shl ~size ~signed v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | Int i1, Int i2 ->
-      let shifted = Z.( lsl ) i1 (Z.to_int i2) in
-      let masked = Z.( land ) shifted (Z.pred (Z.( lsl ) Z.one size)) in
-      int_z masked
-  | _, Int i2 ->
-      let max = Z.( lsl ) Z.one size in
-      let shifted = times v1 (int_z (Z.( lsl ) Z.one (Z.to_int i2))) in
-      let masked = mod_ shifted (int_z max) in
-      masked
-  | _ ->
-      let v1_bv = bv_of_int size v1 in
-      let v2_bv = bv_of_int size v2 in
-      let bv = raw_bit_shl size v1_bv v2_bv in
-      int_of_bv signed bv
-
-let bit_shr ~size ~signed v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | Int i1, Int i2 ->
-      let shifted = Z.( asr ) i1 (Z.to_int i2) in
-      let masked = Z.( land ) shifted (Z.pred (Z.( lsl ) Z.one size)) in
-      int_z masked
-  | _ ->
-      let v1_bv = bv_of_int size v1 in
-      let v2_bv = bv_of_int size v2 in
-      let bv = raw_bit_shr size v1_bv v2_bv in
-      int_of_bv signed bv
-
-let bit_not ~size:s ~signed v =
-  if Stdlib.not signed then
-    let max = Z.(pred (one lsl s)) in
-    minus (int_z max) v
-  else minus (neg v) one
-
-(** {2 Floating point ops} *)
-
-let eq_f v1 v2 = mk_commut_binop FEq v1 v2 <| TBool
-
-let lt_f v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | Float f1, Float f2 -> bool (float_of_string f1 < float_of_string f2)
-  | _ -> Binop (FLt, v1, v2) <| TBool
-
-let leq_f v1 v2 =
-  match (v1.node.kind, v2.node.kind) with
-  | Float f1, Float f2 -> bool (float_of_string f1 <= float_of_string f2)
-  | _ -> Binop (FLeq, v1, v2) <| TBool
-
-let gt_f v1 v2 = lt_f v2 v1
-let geq_f v1 v2 = leq_f v2 v1
-let plus_f v1 v2 = mk_commut_binop FPlus v1 v2 <| v1.node.ty
-let minus_f v1 v2 = Binop (FMinus, v1, v2) <| v1.node.ty
-let div_f v1 v2 = Binop (FDiv, v1, v2) <| v1.node.ty
-let times_f v1 v2 = mk_commut_binop FTimes v1 v2 <| v1.node.ty
-let rem_f v1 v2 = Binop (FRem, v1, v2) <| v1.node.ty
-
-let abs_f v =
-  match v.node.kind with
-  | Unop (FAbs, _) -> v
-  | _ -> Unop (FAbs, v) <| v.node.ty
-
-(* FIXME: all of these reductions are unsound for floats that aren't F64, I think *)
-let is_floatclass fc =
- fun sv ->
+(** Negates a boolean that is in integer form (i.e. 0 for false, anything else
+    is true) *)
+let not_int_bool sv =
   match sv.node.kind with
-  | Float f ->
-      bool (FloatClass.as_fpclass fc = classify_float (float_of_string f))
-  | _ -> Unop (FIs fc, sv) <| TBool
+  | Int z -> if Z.equal z Z.zero then one else zero
+  | Unop (IntOfBool, sv') -> int_of_bool (not sv')
+  | _ -> int_of_bool (sem_eq sv zero)
 
-let is_normal = is_floatclass Normal
-let is_subnormal = is_floatclass Subnormal
-let is_infinite = is_floatclass Infinite
-let is_nan = is_floatclass NaN
-let is_zero = is_floatclass Zero
-let float_round rm sv = Unop (FRound rm, sv) <| sv.node.ty
+let bool_of_int sv =
+  match sv.node.kind with
+  | Int z -> bool (Stdlib.not (Z.equal z Z.zero))
+  | Unop (IntOfBool, sv') -> sv'
+  | _ -> not (sem_eq sv zero)
 
 (** {2 Pointers} *)
 
@@ -1004,15 +1015,15 @@ module Infix = struct
   let ( *@ ) = times
   let ( /@ ) = div
   let ( %@ ) = mod_
-  let ( ==.@ ) = eq_f
-  let ( >.@ ) = gt_f
-  let ( >=.@ ) = geq_f
-  let ( <.@ ) = lt_f
-  let ( <=.@ ) = leq_f
-  let ( +.@ ) = plus_f
-  let ( -.@ ) = minus_f
-  let ( *.@ ) = times_f
-  let ( /.@ ) = div_f
+  let ( ==.@ ) = Float.eq
+  let ( >.@ ) = Float.gt
+  let ( >=.@ ) = Float.geq
+  let ( <.@ ) = Float.lt
+  let ( <=.@ ) = Float.leq
+  let ( +.@ ) = Float.plus
+  let ( -.@ ) = Float.minus
+  let ( *.@ ) = Float.times
+  let ( /.@ ) = Float.div
 end
 
 module Syntax = struct

--- a/soteria/lib/c_values/typed.mli
+++ b/soteria/lib/c_values/typed.mli
@@ -121,7 +121,13 @@ module BitVec : sig
   val or_ : size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
   val xor : size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
   val shl : size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
-  val shr : size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+
+  val ashr :
+    size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+
+  val lshr :
+    size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+
   val not : size:int -> signed:bool -> [< sint ] t -> [> sint ] t
 end
 

--- a/soteria/lib/c_values/typed.mli
+++ b/soteria/lib/c_values/typed.mli
@@ -129,6 +129,24 @@ module BitVec : sig
     size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
 
   val not : size:int -> signed:bool -> [< sint ] t -> [> sint ] t
+
+  val wrap_plus :
+    size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+
+  val wrap_minus :
+    size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+
+  val wrap_times :
+    size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+
+  val plus_overflows :
+    size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
+
+  val minus_overflows :
+    size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
+
+  val times_overflows :
+    size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
 end
 
 (** Floating point *)

--- a/soteria/lib/c_values/typed.mli
+++ b/soteria/lib/c_values/typed.mli
@@ -94,19 +94,10 @@ val int_z : Z.t -> [> sint ] t
 val int : int -> [> sint ] t
 val nonzero_z : Z.t -> [> nonzero ] t
 val nonzero : int -> [> nonzero ] t
-val float : Svalue.FloatPrecision.t -> string -> [> sfloat ] t
 val int_of_bool : [< sbool ] t -> [> sint ] t
 val bool_of_int : [< sint ] t -> [> sbool ] t
-val int_of_float : int -> [< sfloat ] t -> [> sint ] t
-val float_of_int : Svalue.FloatPrecision.t -> [< sint ] t -> [> sfloat ] t
 val zero : [> sint ] t
 val one : [> nonzero ] t
-val f16 : float -> [> sfloat ] t
-val f32 : float -> [> sfloat ] t
-val f64 : float -> [> sfloat ] t
-val f128 : float -> [> sfloat ] t
-val float_like : [> sfloat ] t -> float -> [> sfloat ] t
-val fp_of : [< sfloat ] t -> Svalue.FloatPrecision.t
 
 (** Integer operations *)
 
@@ -120,44 +111,50 @@ val times : [< sint ] t -> [< sint ] t -> [> sint ] t
 val div : [< sint ] t -> [< nonzero ] t -> [> sint ] t
 val rem : [< sint ] t -> [< nonzero ] t -> [> sint ] t
 val mod_ : [< sint ] t -> nonzero t -> [> sint ] t
-val neg : ([< sint | sfloat ] as 'a) t -> 'a t
+val neg : [< sint ] t -> [> sint ] t
 
-val bit_and :
-  size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+(** BitVector operations *)
+module BitVec : sig
+  val and_ :
+    size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
 
-val bit_or :
-  size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+  val or_ : size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+  val xor : size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+  val shl : size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+  val shr : size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+  val not : size:int -> signed:bool -> [< sint ] t -> [> sint ] t
+end
 
-val bit_xor :
-  size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
-
-val bit_shl :
-  size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
-
-val bit_shr :
-  size:int -> signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
-
-val bit_not : size:int -> signed:bool -> [< sint ] t -> [> sint ] t
-
-(** Floating point operations *)
-
-val eq_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
-val geq_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
-val gt_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
-val leq_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
-val lt_f : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
-val plus_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
-val minus_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
-val times_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
-val div_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
-val rem_f : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
-val abs_f : [< sfloat ] t -> [> sfloat ] t
-val is_normal : [< sfloat ] t -> [> sbool ] t
-val is_subnormal : [< sfloat ] t -> [> sbool ] t
-val is_zero : [< sfloat ] t -> [> sbool ] t
-val is_infinite : [< sfloat ] t -> [> sbool ] t
-val is_nan : [< sfloat ] t -> [> sbool ] t
-val float_round : Svalue.FloatRoundingMode.t -> [< sfloat ] t -> [> sfloat ] t
+(** Floating point *)
+module Float : sig
+  val mk : Svalue.FloatPrecision.t -> string -> [> sfloat ] t
+  val f16 : float -> [> sfloat ] t
+  val f32 : float -> [> sfloat ] t
+  val f64 : float -> [> sfloat ] t
+  val f128 : float -> [> sfloat ] t
+  val like : [> sfloat ] t -> float -> [> sfloat ] t
+  val fp_of : [< sfloat ] t -> Svalue.FloatPrecision.t
+  val eq : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val geq : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val gt : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val leq : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val lt : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val plus : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val minus : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val times : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val div : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val rem : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val abs : [< sfloat ] t -> [> sfloat ] t
+  val neg : [< sfloat ] t -> [> sfloat ] t
+  val is_normal : [< sfloat ] t -> [> sbool ] t
+  val is_subnormal : [< sfloat ] t -> [> sbool ] t
+  val is_zero : [< sfloat ] t -> [> sbool ] t
+  val is_infinite : [< sfloat ] t -> [> sbool ] t
+  val is_nan : [< sfloat ] t -> [> sbool ] t
+  val round : Svalue.FloatRoundingMode.t -> [< sfloat ] t -> [> sfloat ] t
+  val to_int : int -> [< sfloat ] t -> [> sint ] t
+  val of_int : Svalue.FloatPrecision.t -> [< sint ] t -> [> sfloat ] t
+end
 
 module Ptr : sig
   val mk : [< sloc ] t -> [< sint ] t -> [> sptr ] t

--- a/soteria/lib/c_values/z3_exe.ml
+++ b/soteria/lib/c_values/z3_exe.ml
@@ -111,8 +111,7 @@ module Encoding = struct
     | BvDiv false -> bv_udiv
     | BvRem true -> bv_srem
     | BvRem false -> bv_urem
-    | BvMod true -> bv_smod
-    | BvMod false -> bv_urem
+    | BvMod -> bv_smod
     | BvPlusOvf true -> bv_saddo
     | BvPlusOvf false -> bv_uaddo
     | BvTimesOvf true -> bv_smulo

--- a/soteria/lib/c_values/z3_exe.ml
+++ b/soteria/lib/c_values/z3_exe.ml
@@ -71,7 +71,8 @@ module Encoding = struct
     | FloatOfBv F64 -> f64_of_bv
     | FloatOfBv F128 -> f128_of_bv
     | BvExtract (from_, to_) -> bv_extract to_ from_
-    | BvExtend by -> bv_zero_extend by
+    | BvExtend (true, by) -> bv_sign_extend by
+    | BvExtend (false, by) -> bv_zero_extend by
     | BvNot -> bv_not
     | BvNegOvf -> bv_nego
     | FIs fc -> fp_is fc

--- a/soteria/lib/c_values/z3_exe.ml
+++ b/soteria/lib/c_values/z3_exe.ml
@@ -72,6 +72,8 @@ module Encoding = struct
     | FloatOfBv F128 -> f128_of_bv
     | BvExtract (from_, to_) -> bv_extract to_ from_
     | BvExtend by -> bv_zero_extend by
+    | BvNot -> bv_not
+    | BvNegOvf -> bv_nego
     | FIs fc -> fp_is fc
     | FRound rm -> fp_round rm
 
@@ -99,9 +101,26 @@ module Encoding = struct
     | BitOr -> bv_or
     | BitXor -> bv_xor
     | BitShl -> bv_shl
-    | BitShr -> bv_lshr
+    | BitLShr -> bv_lshr
+    | BitAShr -> bv_ashr
     | BvPlus -> bv_add
     | BvMinus -> bv_sub
+    | BvTimes -> bv_mul
+    | BvDiv true -> bv_sdiv
+    | BvDiv false -> bv_udiv
+    | BvRem true -> bv_srem
+    | BvRem false -> bv_urem
+    | BvMod true -> bv_smod
+    | BvMod false -> bv_urem
+    | BvPlusOvf true -> bv_saddo
+    | BvPlusOvf false -> bv_uaddo
+    | BvTimesOvf true -> bv_smulo
+    | BvTimesOvf false -> bv_umulo
+    | BvLt true -> bv_slt
+    | BvLt false -> bv_ult
+    | BvLeq true -> bv_sleq
+    | BvLeq false -> bv_uleq
+    | BvConcat -> bv_concat
 
   let rec encode_value (v : Svalue.t) =
     match v.node.kind with

--- a/soteria/lib/c_values/z3_exe.ml
+++ b/soteria/lib/c_values/z3_exe.ml
@@ -57,6 +57,52 @@ module Encoding = struct
 
   let memo_encode_value_tbl : sexp Hashtbl.Hint.t = Hashtbl.Hint.create 1023
 
+  let smt_of_unop : Svalue.Unop.t -> sexp -> sexp = function
+    | Not -> bool_not
+    | FAbs -> fp_abs
+    | GetPtrLoc -> get_loc
+    | GetPtrOfs -> get_ofs
+    | IntOfBool -> fun b -> ite b (int_k 1) (int_k 0)
+    | BvOfInt (_, size) -> bv_of_int size
+    | IntOfBv signed -> int_of_bv signed
+    | BvOfFloat n -> bv_of_float n
+    | FloatOfBv F16 -> f16_of_bv
+    | FloatOfBv F32 -> f32_of_bv
+    | FloatOfBv F64 -> f64_of_bv
+    | FloatOfBv F128 -> f128_of_bv
+    | BvExtract (from_, to_) -> bv_extract to_ from_
+    | BvExtend by -> bv_zero_extend by
+    | FIs fc -> fp_is fc
+    | FRound rm -> fp_round rm
+
+  let smt_of_binop : Svalue.Binop.t -> sexp -> sexp -> sexp = function
+    | Eq -> eq
+    | Leq -> num_leq
+    | Lt -> num_lt
+    | And -> bool_and
+    | Or -> bool_or
+    | Plus -> num_add
+    | Minus -> num_sub
+    | Times -> num_mul
+    | Div -> num_div
+    | Rem -> num_rem
+    | Mod -> num_mod
+    | FEq -> fp_eq
+    | FLeq -> fp_leq
+    | FLt -> fp_lt
+    | FPlus -> fp_add
+    | FMinus -> fp_sub
+    | FTimes -> fp_mul
+    | FDiv -> fp_div
+    | FRem -> fp_rem
+    | BitAnd -> bv_and
+    | BitOr -> bv_or
+    | BitXor -> bv_xor
+    | BitShl -> bv_shl
+    | BitShr -> bv_lshr
+    | BvPlus -> bv_add
+    | BvMinus -> bv_sub
+
   let rec encode_value (v : Svalue.t) =
     match v.node.kind with
     | Var v -> atom (Svalue.Var.to_string v)
@@ -80,59 +126,13 @@ module Encoding = struct
         )
     | Ite (c, t, e) ->
         ite (encode_value_memo c) (encode_value_memo t) (encode_value_memo e)
-    | Unop (unop, v1_) -> (
-        let v1 = encode_value_memo v1_ in
-        match unop with
-        | Not -> bool_not v1
-        | FAbs -> fp_abs v1
-        | GetPtrLoc -> get_loc v1
-        | GetPtrOfs -> get_ofs v1
-        | IntOfBool -> ite v1 (int_k 1) (int_k 0)
-        | BvOfInt ->
-            let size = Svalue.size_of_bv v.node.ty in
-            bv_of_int size v1
-        | IntOfBv signed -> int_of_bv signed v1
-        | BvOfFloat n -> bv_of_float n v1
-        | FloatOfBv -> (
-            match Svalue.precision_of_f v.node.ty with
-            | F16 -> f16_of_bv v1
-            | F32 -> f32_of_bv v1
-            | F64 -> f64_of_bv v1
-            | F128 -> f128_of_bv v1)
-        | BvExtract (from_, to_) -> bv_extract to_ from_ v1
-        | BvExtend by -> bv_zero_extend by v1
-        | FIs fc -> fp_is fc v1
-        | FRound rm -> fp_round rm v1)
-    | Binop (binop, v1, v2) -> (
+    | Unop (unop, v1) ->
+        let v1 = encode_value_memo v1 in
+        smt_of_unop unop v1
+    | Binop (binop, v1, v2) ->
         let v1 = encode_value_memo v1 in
         let v2 = encode_value_memo v2 in
-        match binop with
-        | Eq -> eq v1 v2
-        | Leq -> num_leq v1 v2
-        | Lt -> num_lt v1 v2
-        | And -> bool_and v1 v2
-        | Or -> bool_or v1 v2
-        | Plus -> num_add v1 v2
-        | Minus -> num_sub v1 v2
-        | Times -> num_mul v1 v2
-        | Div -> num_div v1 v2
-        | Rem -> num_rem v1 v2
-        | Mod -> num_mod v1 v2
-        | FEq -> fp_eq v1 v2
-        | FLeq -> fp_leq v1 v2
-        | FLt -> fp_lt v1 v2
-        | FPlus -> fp_add v1 v2
-        | FMinus -> fp_sub v1 v2
-        | FTimes -> fp_mul v1 v2
-        | FDiv -> fp_div v1 v2
-        | FRem -> fp_rem v1 v2
-        | BitAnd -> bv_and v1 v2
-        | BitOr -> bv_or v1 v2
-        | BitXor -> bv_xor v1 v2
-        | BitShl -> bv_shl v1 v2
-        | BitShr -> bv_lshr v1 v2
-        | BvPlus -> bv_add v1 v2
-        | BvMinus -> bv_sub v1 v2)
+        smt_of_binop binop v1 v2
     | Nop (Distinct, vs) ->
         let vs = List.map encode_value_memo vs in
         distinct vs


### PR DESCRIPTION
I did all the commits in a way that should be super easy to follow; I also marked in the commit name if the commit doesn't change anything and only does code moving / renaming.

This is the first in a long series of improving BitVectors and the Z3 solver, culminating in full BitVector reasoning in Rusteria.

- Add modules `Float` and `BitVec` to `Svalue` to separate these functions from the integer/bool functions. 
  `BitVec` functions expect integers as input, and output integers; there is a hidden int-bv-int conversion inside. All bitvector functions that actually operate on bitvectors are in `BitVec.Raw`, and shouldn't be used in interpreters, since bitvector values aren't exposed in `Typed`.
- Encode enough information in `Binop`/`Unop` to allow `Eval` and `Z3_exe.Encoding` to derive analogous functions without information about the operators. This allows e.g. having `smt_of_binop : Svalue.Binop.t -> sexp -> sexp -> sexp` as a `function` over `Binop` only!
- Add `BvNot`, `BvNegOvf` to `Unop`, `BvTimes` `BvDiv` `BvRem`, `BvMod`, `BvPlusOvf`, `BvTimesOvf`, `BvLt`, `BvLeq`, `BvConcat` to `Binop`
- Remove `BitShr`, add `BitAShr` (arithmetic shift; extends sign) and `BitLShr` (logical shift, adds 0s)
- Add lots and lots and lots of reductions to `BitVec.Raw`, `BitVec`, and existing operations.
  The main reduction consists in converting all `l < r`, `l <= r` and `l == r` operations containing bitvectors inside the value into an equivalent `BitVec.of_int l <bv BitVec.of_int r`, etc. Usually, the integer expression can be converted relatively well into a bitvector, and this avoids an expensive int-bv-int round-trip (instead just having int-bv)