### PR TITLE
Add `Bv_values`

### DIFF
--- a/soteria-rust/lib/builtins/intrinsics_impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics_impl.ml
@@ -398,7 +398,8 @@ module M (State : State_intf.S) = struct
       (* we use min-1 and max+1, to be able to have a strict inequality, which avoids
              issues in cases of float precision loss (I think?) *)
       if%sat min <.@ f &&@ (f <.@ max) then
-        let v = Typed.Float.to_int n f in
+        let signed = Layout.is_signed ity in
+        let v = Typed.Float.to_int signed n f in
         Result.ok (Base v, state)
       else State.error (`StdErr "float_to_int_unchecked out of int range") state
 

--- a/soteria-rust/lib/encoder.ml
+++ b/soteria-rust/lib/encoder.ml
@@ -440,12 +440,14 @@ module Make (Sptr : Sptr.S) = struct
             @@ Typed.cast_float sv
           in
           let size = 8 * Layout.size_of_literal_ty ity in
-          let sv' = Typed.Float.to_int size sv in
+          let signed = Layout.is_signed ity in
+          let sv' = Typed.Float.to_int signed size sv in
           Ok (Base sv')
-      | TLiteral (TInt _ | TUInt _), TLiteral (TFloat fp), Base sv ->
+      | TLiteral ((TInt _ | TUInt _) as ity), TLiteral (TFloat fp), Base sv ->
           let+ sv = cast_checked sv ~ty:Typed.t_int in
           let fp = float_precision fp in
-          let sv' = Typed.Float.of_int fp sv in
+          let signed = Layout.is_signed ity in
+          let sv' = Typed.Float.of_int signed fp sv in
           Ok (Base sv')
       | TLiteral (TUInt U8), TLiteral TChar, v
       | TLiteral TBool, TLiteral (TUInt _), v

--- a/soteria/lib/bv_values/analyses.ml
+++ b/soteria/lib/bv_values/analyses.ml
@@ -1,0 +1,52 @@
+open Soteria_symex
+
+(* let log = Soteria.Logging.Logs.L.warn *)
+let log _ = ()
+
+module type S = sig
+  include Soteria_std.Reversible.Mutable
+
+  val simplify : t -> Svalue.t -> Svalue.t
+  val add_constraint : t -> Svalue.t -> Svalue.t * Var.Set.t
+  val encode : ?vars:Var.Hashset.t -> t -> Typed.sbool Typed.t Iter.t
+end
+
+module Merge (A1 : S) (A2 : S) : S = struct
+  type t = A1.t * A2.t
+
+  let init () = (A1.init (), A2.init ())
+
+  let backtrack_n (a1, a2) n =
+    A1.backtrack_n a1 n;
+    A2.backtrack_n a2 n
+
+  let save (a1, a2) =
+    A1.save a1;
+    A2.save a2
+
+  let reset (a1, a2) =
+    A1.reset a1;
+    A2.reset a2
+
+  let simplify (a1, a2) v = v |> A1.simplify a1 |> A2.simplify a2
+
+  let add_constraint (a1, a2) v =
+    let v', vars1 = A1.add_constraint a1 v in
+    let v'', vars2 = A2.add_constraint a2 v' in
+    (v'', Var.Set.union vars1 vars2)
+
+  let encode ?vars (a1, a2) : Typed.sbool Typed.t Iter.t =
+    Iter.append (A1.encode ?vars a1) (A2.encode ?vars a2)
+end
+
+module None : S = struct
+  type t = unit
+
+  let init () = ()
+  let backtrack_n () _ = ()
+  let save () = ()
+  let reset () = ()
+  let simplify () v = v
+  let add_constraint () v = (v, Var.Set.empty)
+  let encode ?vars:_ () = Iter.empty
+end

--- a/soteria/lib/bv_values/analyses.ml
+++ b/soteria/lib/bv_values/analyses.ml
@@ -1,4 +1,4 @@
-open Soteria_symex
+open Symex
 
 (* let log = Soteria.Logging.Logs.L.warn *)
 let log _ = ()

--- a/soteria/lib/bv_values/bv_solver.ml
+++ b/soteria/lib/bv_values/bv_solver.ml
@@ -1,0 +1,555 @@
+open Soteria_std
+module Var = Svalue.Var
+module L = Logging.Logs.L
+
+let rec simplify ~trivial_truthiness ~fallback (v : Svalue.t) =
+  let simplify = simplify ~trivial_truthiness ~fallback in
+  match v.node.kind with
+  | Bool _ | BitVec _ | Float _ -> v
+  | _ -> (
+      match trivial_truthiness (Typed.type_ v) with
+      | Some true -> Svalue.Bool.v_true
+      | Some false -> Svalue.Bool.v_false
+      | None -> (
+          match v.node.kind with
+          | Unop (Not, e) ->
+              let e' = simplify e in
+              if Svalue.equal e e' then v else Svalue.Bool.not e'
+          | Binop (Eq, e1, e2) ->
+              if Svalue.equal e1 e2 then Svalue.Bool.v_true
+              else if Svalue.sure_neq e1 e2 then Svalue.Bool.v_false
+              else v
+          | Binop (And, e1, e2) ->
+              let se1 = simplify e1 in
+              let se2 = simplify e2 in
+              if Svalue.equal se1 e1 && Svalue.equal se2 e2 then v
+              else Svalue.Bool.and_ se1 se2
+          | Binop (Or, e1, e2) ->
+              let se1 = simplify e1 in
+              let se2 = simplify e2 in
+              if Svalue.equal se1 e1 && Svalue.equal se2 e2 then v
+              else Svalue.Bool.or_ se1 se2
+          | Ite (g, e1, e2) ->
+              let sg = simplify g in
+              let se1 = simplify e1 in
+              let se2 = simplify e2 in
+              if Svalue.equal sg g && Svalue.equal se1 e1 && Svalue.equal se2 e2
+              then v
+              else Svalue.Bool.ite sg se1 se2
+          | _ -> fallback v))
+
+module Make_incremental
+    (Analysis : Analyses.S)
+    (Intf :
+      Solvers.Solver_interface.S
+        with type value = Svalue.t
+         and type ty = Svalue.ty) =
+struct
+  module Value = Typed
+
+  module Var_counter = Var.Incr_counter_mut (struct
+    let start_at = 0
+  end)
+
+  module Solver_state = struct
+    type t = Typed.sbool Typed.t Dynarray.t Dynarray.t
+
+    let init () =
+      let t = Dynarray.create () in
+      Dynarray.add_last t (Dynarray.create ());
+      t
+
+    let reset t =
+      Dynarray.clear t;
+      Dynarray.add_last t (Dynarray.create ())
+
+    let save t = Dynarray.add_last t (Dynarray.create ())
+    let backtrack_n t n = Dynarray.truncate t (Dynarray.length t - n)
+
+    let add_constraint (t : t) v =
+      if Typed.equal v Typed.v_true then ()
+      else
+        match Dynarray.find_last t with
+        | None -> failwith "add_constraint: empty array"
+        | Some last ->
+            if Typed.equal v Typed.v_false then (
+              Dynarray.clear last;
+              Dynarray.add_last last Typed.v_false)
+            else Dynarray.add_last last v
+
+    (** This function returns [Some b] if the solver state is trivially [b]
+        (true or false). We maintain solver state such that trivial truths are
+        never added to the state, and false is false erases everything else.
+        Therefore, it is enough to check either for emptyness of the topmost
+        layer or falseness of the latest element. *)
+    let trivial_truthiness (t : t) =
+      match Dynarray.find_last t with
+      | None -> Some true
+      | Some last -> (
+          match Dynarray.find_last last with
+          | None -> Some true
+          | Some v when Typed.equal v Typed.v_false -> Some false
+          | _ -> None)
+
+    let iter (t : t) f = Dynarray.iter (fun t -> Dynarray.iter f t) t
+
+    let trivial_truthiness_of (t : t) (v : Typed.sbool Typed.t) =
+      let neg_v = Typed.not v in
+      Dynarray.find_map
+        (Dynarray.find_map (fun value ->
+             if Typed.equal value v then Some true
+             else if Typed.equal value neg_v then Some false
+             else None))
+        t
+  end
+
+  type t = {
+    z3_exe : Intf.t;
+    save_counter : Save_counter.t;
+    var_counter : Var_counter.t;
+    state : Solver_state.t;
+    analysis : Analysis.t;
+  }
+
+  let init () =
+    let z3_exe = Intf.init () in
+    Intf.push z3_exe 1;
+    {
+      z3_exe;
+      save_counter = Save_counter.init ();
+      var_counter = Var_counter.init ();
+      state = Solver_state.init ();
+      analysis = Analysis.init ();
+    }
+
+  let save solver =
+    Var_counter.save solver.var_counter;
+    Save_counter.save solver.save_counter;
+    Solver_state.save solver.state;
+    Analysis.save solver.analysis;
+    Intf.push solver.z3_exe 1
+
+  let backtrack_n solver n =
+    Var_counter.backtrack_n solver.var_counter n;
+    Solver_state.backtrack_n solver.state n;
+    Save_counter.backtrack_n solver.save_counter n;
+    Analysis.backtrack_n solver.analysis n;
+    Intf.pop solver.z3_exe n
+
+  (* Initialise and reset *)
+
+  let reset solver =
+    (* We want to go back to 1, meaning after the first push which saved the declarations *)
+    let save_counter = !(solver.save_counter) in
+    if save_counter < 0 then failwith "Solver reset: save_counter < 0???";
+    Save_counter.reset solver.save_counter;
+    Var_counter.reset solver.var_counter;
+    Solver_state.reset solver.state;
+    Analysis.reset solver.analysis;
+    (* We need to pop the initial push, so we go back to the state before the first push *)
+    Intf.pop solver.z3_exe (save_counter + 1);
+    (* Make sure the basic definitions are saved again *)
+    Intf.pop solver.z3_exe 1
+
+  let fresh_var solver ty =
+    let v_id = Var_counter.get_next solver.var_counter in
+    Intf.declare_var solver.z3_exe v_id (Typed.untype_type ty);
+    v_id
+
+  let simplify solver (v : 'a Typed.t) : 'a Typed.t =
+    v
+    |> Typed.untyped
+    |> simplify
+         ~trivial_truthiness:(Solver_state.trivial_truthiness_of solver.state)
+         ~fallback:(Analysis.simplify solver.analysis)
+    |> Typed.type_
+
+  let add_constraints solver ?(simplified = false) vs =
+    let iter = vs |> Iter.of_list |> Iter.flat_map Typed.split_ands in
+    iter @@ fun v ->
+    let v = if simplified then v else simplify solver v in
+    (* the incremental solver doesn't need to dirty variables *)
+    let v, _ = Analysis.add_constraint solver.analysis (Typed.untyped v) in
+    Solver_state.add_constraint solver.state (Typed.type_ v);
+    Intf.add_constraint solver.z3_exe v
+
+  (* Incremental doesn't allow for caching queries... *)
+  let sat solver =
+    match Solver_state.trivial_truthiness solver.state with
+    | Some true -> Soteria_symex.Solver_result.Sat
+    | Some false -> Unsat
+    | None -> (
+        let answer = Intf.check_sat solver.z3_exe in
+        match answer with
+        | Sat -> Sat
+        | Unsat -> Unsat
+        | Unknown ->
+            L.info (fun m -> m "Solver returned unknown");
+            Unknown)
+
+  let as_values solver =
+    Iter.append
+      (Solver_state.iter solver.state)
+      (Analysis.encode solver.analysis)
+    |> Iter.to_list
+end
+
+module Make
+    (Analysis : Analyses.S)
+    (Intf :
+      Solvers.Solver_interface.S
+        with type value = Svalue.t
+         and type ty = Svalue.ty) =
+struct
+  module Value = Typed
+
+  module Var_counter = Var.Incr_counter_mut (struct
+    let start_at = 1
+  end)
+
+  module Solver_state = struct
+    (** Inside a slot, we either have an assertion, or a marker indicating that
+        all assertions relating to a variable may need to be rechecked -- for
+        instance because an auxiliary analysis has new information about it that
+        is not directly in the PC. *)
+    type slot_content =
+      | Asrt of Typed.sbool Typed.t [@printer Typed.ppa]
+      | Dirty of Var.Set.t [@printer Fmt.(iter ~sep:comma) Var.Set.iter Var.pp]
+    [@@deriving show]
+
+    (** Each slot holds a symbolic boolean, as well a boolean indicating if it
+        was checked to be satisfiable. The boolean is mutable and can be mutated
+        even by future branches! If a branch downstream is satisfiable, then so
+        is any element on the path condition. *)
+    type slot = { value : slot_content; mutable checked : bool }
+    [@@deriving show]
+
+    (* Invariants: the PC only has checked things, and then only unchecked things. *)
+
+    type t = slot Dynarray.t Dynarray.t [@@deriving show]
+
+    let init () =
+      let t = Dynarray.create () in
+      Dynarray.add_last t (Dynarray.create ());
+      t
+
+    let reset t =
+      Dynarray.clear t;
+      Dynarray.add_last t (Dynarray.create ())
+
+    let save t = Dynarray.add_last t (Dynarray.create ())
+    let backtrack_n t n = Dynarray.truncate t (Dynarray.length t - n)
+
+    let add_constraint (t : t) v =
+      if Typed.equal v Typed.v_true then ()
+      else
+        match Dynarray.find_last t with
+        | None -> failwith "add_constraint: empty array"
+        | Some last ->
+            if Typed.equal v Typed.v_false then (
+              Dynarray.clear last;
+              (* We mark false as unchecked to make sure trivial_truthiness doesn't infer the wrong thing. *)
+              Dynarray.add_last last
+                { value = Asrt Typed.v_false; checked = false })
+            else Dynarray.add_last last { value = Asrt v; checked = false }
+
+    let dirty_variable (t : t) v =
+      match Dynarray.find_last t with
+      | None -> failwith "dirty_variable: empty array"
+      | Some last -> Dynarray.add_last last { value = Dirty v; checked = false }
+
+    let to_seq_rev (t : t) =
+      Seq.concat_map Dynarray.to_seq_rev (Dynarray.to_seq_rev t)
+
+    (** This function returns [Some b] if the solver state is trivially [b]
+        (true or false). We maintain solver state such that trivial truths are
+        never added to the state, and false is false erases everything else.
+        Therefore, it is enough to check either for emptyness of the topmost
+        layer or falseness of the latest element. *)
+    let trivial_truthiness (t : t) =
+      match to_seq_rev t () with
+      | Nil -> Some true (* The empty constraint is satisfiable *)
+      | Cons ({ checked = true; _ }, _) ->
+          Some true (* All constraints have been checked to be sat *)
+      | Cons ({ value = Asrt value; _ }, _) when Typed.(equal value v_false) ->
+          Some false
+      | _ -> None
+
+    (* We check if the thing contains the value itself, or its negation. *)
+    let trivial_truthiness_of (t : t) (v : Typed.sbool Typed.t) =
+      let neg_v = Typed.not v in
+      Dynarray.find_map
+        (Dynarray.find_map (function
+          | { value = Asrt value; _ } ->
+              if Typed.equal value v then Some true
+              else if Typed.equal value neg_v then Some false
+              else None
+          | _ -> None))
+        t
+
+    (** Iterate over the assertions in the PC. *)
+    let iter (t : t) f =
+      Dynarray.iter
+        (Dynarray.iter (function
+          | { value = Asrt value; _ } -> f value
+          | { value = Dirty _; _ } -> ()))
+        t
+
+    (** If we have checked sat and obtaied SAT, we can mark all elements of the
+        list as checked! *)
+    let mark_checked (t : t) =
+      let rec aux seq =
+        match seq () with
+        | Seq.Cons (({ checked = false; _ } as slot), rest) ->
+            (* If we see something unchecked we mark as checked and continue *)
+            slot.checked <- true;
+            aux rest
+        | _ ->
+            (* Otherwise we stop *)
+            ()
+      in
+      aux (to_seq_rev t)
+
+    (** We aggregate the unchecked constraints. We start from the right and
+        collect all constraints marked as unchecked. We also aggregate all
+        variables contained by the unchecked assertions, and fetch, All
+        assertions (even checked) that also contain these variables. In the end,
+        we need to fetch the closure from these variables.
+
+        The function returns the list to encode, as well the set of all
+        variables required. *)
+    let unchecked_constraints t =
+      let changed = ref false in
+      let var_set = Var.Hashset.with_capacity 8 in
+      let vars value = Value.iter_vars value |> Iter.map fst in
+      let to_encode = Dynarray.create () in
+      let add_vars_raw vars = Var.Hashset.add_iter var_set vars in
+      let add_vars vars =
+        vars @@ fun v ->
+        let prev_size = Var.Hashset.cardinal var_set in
+        Var.Hashset.add var_set v;
+        if Var.Hashset.cardinal var_set <> prev_size then changed := true
+      in
+      let relevant = Iter.exists (Var.Hashset.mem var_set) in
+      (* We need to reach some kind of fixpoint *)
+      let rec aux_checked others seq =
+        match seq () with
+        | Seq.Nil ->
+            if !changed then (
+              changed := false;
+              aux_checked Seq.empty others)
+            else ()
+        | Seq.Cons (({ value = Asrt value; _ } as slot), rest) ->
+            let vars = vars value in
+            if relevant vars then (
+              add_vars vars;
+              Dynarray.add_last to_encode value;
+              aux_checked others rest)
+            else
+              let others = fun () -> Seq.Cons (slot, others) in
+              aux_checked others rest
+        | Seq.Cons ({ value = Dirty _; _ }, rest) ->
+            (* A dirty checked variable can be ignored *)
+            aux_checked others rest
+      in
+      let rec aux seq =
+        match seq () with
+        | Seq.Nil -> ()
+        | Cons ({ value = Asrt value; checked = false }, rest) ->
+            Dynarray.add_last to_encode value;
+            add_vars_raw (vars value);
+            aux rest
+        | Cons ({ value = Dirty vars; checked = false }, rest) ->
+            add_vars_raw (fun f -> Var.Set.iter f vars);
+            aux rest
+        | Cons ({ checked = true; _ }, _) -> aux_checked Seq.empty seq
+      in
+      let () = aux (to_seq_rev t) in
+      (to_encode, var_set)
+  end
+
+  module Declared_vars = struct
+    module Var_counter = Var.Incr_counter_mut (struct
+      let start_at = 1
+    end)
+
+    (* Since we start addresses at one to improve trivial model hits, we need to offset to obtain an index. *)
+    let var_to_index v = Var.to_int v - 1
+
+    type t = {
+      counter : Var_counter.t;
+      types : Svalue.ty Dynarray.t;
+          (** The var_counter is keeping track of how many variables we actually
+              have in the context. We don't need to separate each bit of that
+              array by saved branch, we just fetch at the index for each
+              variable, and override when we change branch. *)
+    }
+
+    let init () = { counter = Var_counter.init (); types = Dynarray.create () }
+    let save t = Var_counter.save t.counter
+    let backtrack_n t n = Var_counter.backtrack_n t.counter n
+    let reset t = Var_counter.reset t.counter
+
+    let fresh t ty =
+      let next = Var_counter.get_next t.counter in
+      let next_i = var_to_index next in
+      let () =
+        if Dynarray.length t.types == next_i then Dynarray.add_last t.types ty
+        else if Dynarray.length t.types > next_i then
+          Dynarray.set t.types next_i ty
+        else failwith "Broke var-counter/declared-types invariant"
+      in
+      next
+
+    let get_ty t var = Dynarray.get t.types (var_to_index var)
+  end
+
+  type t = {
+    z3_exe : Intf.t;
+    vars : Declared_vars.t;
+    save_counter : Save_counter.t;
+    state : Solver_state.t;
+    analysis : Analysis.t;
+  }
+
+  let init () =
+    let z3_exe = Intf.init () in
+    (* Before every check-sat we pop then push again. *)
+    {
+      z3_exe;
+      save_counter = Save_counter.init ();
+      vars = Declared_vars.init ();
+      state = Solver_state.init ();
+      analysis = Analysis.init ();
+    }
+
+  let save solver =
+    Declared_vars.save solver.vars;
+    Save_counter.save solver.save_counter;
+    Solver_state.save solver.state;
+    Analysis.save solver.analysis
+
+  let backtrack_n solver n =
+    Declared_vars.backtrack_n solver.vars n;
+    Solver_state.backtrack_n solver.state n;
+    Save_counter.backtrack_n solver.save_counter n;
+    Analysis.backtrack_n solver.analysis n
+
+  (* Initialise and reset *)
+
+  let reset solver =
+    (* We want to go back to 1, meaning after the first push which saved the declarations *)
+    let save_counter = !(solver.save_counter) in
+    if save_counter < 0 then failwith "Solver reset: save_counter < 0???";
+    Save_counter.reset solver.save_counter;
+    Declared_vars.reset solver.vars;
+    Solver_state.reset solver.state;
+    Analysis.reset solver.analysis
+
+  let fresh_var solver ty =
+    Declared_vars.fresh solver.vars (Typed.untype_type ty)
+
+  let simplify solver v : 'a Typed.t =
+    v
+    |> Typed.untyped
+    |> simplify
+         ~trivial_truthiness:(Solver_state.trivial_truthiness_of solver.state)
+         ~fallback:(Analysis.simplify solver.analysis)
+    |> Typed.type_
+
+  let add_constraints solver ?(simplified = false) vs =
+    let iter = vs |> Iter.of_list |> Iter.flat_map Typed.split_ands in
+    iter @@ fun v ->
+    let v = if simplified then v else simplify solver v in
+    let v, vars = Analysis.add_constraint solver.analysis (Typed.untyped v) in
+    Solver_state.add_constraint solver.state (Typed.type_ v);
+    if not (Var.Set.is_empty vars) then
+      Solver_state.dirty_variable solver.state vars
+
+  let memo_sat_check_tbl : Soteria_symex.Solver_result.t Hashtbl.Hint.t =
+    Hashtbl.Hint.create 1023
+
+  let trivial_model_works to_check =
+    (* We try a trivial model where replacing each variable with name
+    [|n|] with the corresponding integer [n]; except if an assertion
+    [|n| == v] exists, in which case we replace it with the value [v].
+    If the constraint evaluates to true, then it is satisfiable. *)
+    let v_eqs = Var.Hashtbl.create 8 in
+    Svalue.Bool.split_ands to_check (fun v ->
+        match v.node.kind with
+        | Binop
+            ( Eq,
+              { node = { kind = Var n; _ }; _ },
+              ({ node = { kind = BitVec _; _ }; _ } as x) )
+        | Binop
+            ( Eq,
+              ({ node = { kind = BitVec _; _ }; _ } as x),
+              { node = { kind = Var n; _ }; _ } ) ->
+            Var.Hashtbl.add v_eqs n x
+        | _ -> ());
+    let eval_var v (ty : Svalue.ty) =
+      match ty with
+      | TBitVector n | TLoc n -> (
+          let i = Var.to_int v in
+          try Var.Hashtbl.find v_eqs v
+          with Not_found -> Svalue.BitVec.mk_masked n (Z.of_int i))
+      | _ -> Svalue.mk_var v ty
+    in
+    let res = Eval.eval ~eval_var to_check in
+    Svalue.equal res Svalue.Bool.v_true
+
+  let check_sat_raw solver relevant_vars to_check =
+    (* TODO: we shouldn't wait for ack for each command individually... *)
+    if trivial_model_works to_check then Soteria_symex.Solver_result.Sat
+    else (
+      (* We need to reset the state, so we can push the new constraints *)
+      Intf.reset solver.z3_exe;
+
+      (* Declare all relevant variables *)
+      Var.Hashset.iter
+        (fun v ->
+          let ty = Declared_vars.get_ty solver.vars v in
+          Intf.declare_var solver.z3_exe v ty)
+        relevant_vars;
+      (* Declare the constraint *)
+      Intf.add_constraint solver.z3_exe to_check;
+      (* Actually check sat *)
+      Intf.check_sat solver.z3_exe)
+
+  let check_sat_raw_memo solver relevant_vars to_check =
+    let to_check = Typed.untyped to_check in
+    match Hashtbl.Hint.find_opt memo_sat_check_tbl to_check.Hc.tag with
+    | Some result -> result
+    | None ->
+        let result = check_sat_raw solver relevant_vars to_check in
+        Hashtbl.Hint.add memo_sat_check_tbl to_check.Hc.tag result;
+        result
+
+  let sat solver =
+    match Solver_state.trivial_truthiness solver.state with
+    | Some true -> Soteria_symex.Solver_result.Sat
+    | Some false -> Unsat
+    | None ->
+        let to_check, relevant_vars =
+          Solver_state.unchecked_constraints solver.state
+        in
+        (* This will put the check in a somewhat-normal form, to increase cache hits. *)
+        let to_check = Dynarray.fold_left Typed.and_ Typed.v_true to_check in
+        let to_check =
+          Iter.fold Typed.and_ to_check
+            (Analysis.encode ~vars:relevant_vars solver.analysis)
+        in
+        let answer = check_sat_raw_memo solver relevant_vars to_check in
+        if answer = Sat then Solver_state.mark_checked solver.state;
+        answer
+
+  let as_values solver =
+    Iter.append
+      (Solver_state.iter solver.state)
+      (Analysis.encode solver.analysis)
+    |> Iter.to_list
+end
+
+module Z3 = Solvers.Z3.Make (Encoding)
+module Z3_incremental_solver = Make_incremental (Analyses.None) (Z3)
+module Z3_solver = Make (Analyses.None) (Z3)

--- a/soteria/lib/bv_values/bv_solver.ml
+++ b/soteria/lib/bv_values/bv_solver.ml
@@ -176,7 +176,7 @@ struct
   (* Incremental doesn't allow for caching queries... *)
   let sat solver =
     match Solver_state.trivial_truthiness solver.state with
-    | Some true -> Soteria_symex.Solver_result.Sat
+    | Some true -> Symex.Solver_result.Sat
     | Some false -> Unsat
     | None -> (
         let answer = Intf.check_sat solver.z3_exe in
@@ -466,7 +466,7 @@ struct
     if not (Var.Set.is_empty vars) then
       Solver_state.dirty_variable solver.state vars
 
-  let memo_sat_check_tbl : Soteria_symex.Solver_result.t Hashtbl.Hint.t =
+  let memo_sat_check_tbl : Symex.Solver_result.t Hashtbl.Hint.t =
     Hashtbl.Hint.create 1023
 
   let trivial_model_works to_check =
@@ -500,7 +500,7 @@ struct
 
   let check_sat_raw solver relevant_vars to_check =
     (* TODO: we shouldn't wait for ack for each command individually... *)
-    if trivial_model_works to_check then Soteria_symex.Solver_result.Sat
+    if trivial_model_works to_check then Symex.Solver_result.Sat
     else (
       (* We need to reset the state, so we can push the new constraints *)
       Intf.reset solver.z3_exe;
@@ -527,7 +527,7 @@ struct
 
   let sat solver =
     match Solver_state.trivial_truthiness solver.state with
-    | Some true -> Soteria_symex.Solver_result.Sat
+    | Some true -> Symex.Solver_result.Sat
     | Some false -> Unsat
     | None ->
         let to_check, relevant_vars =

--- a/soteria/lib/bv_values/bv_solver.mli
+++ b/soteria/lib/bv_values/bv_solver.mli
@@ -1,0 +1,5 @@
+module Z3_solver :
+  Soteria_symex.Solver.Mutable_incremental with module Value = Typed
+
+module Z3_incremental_solver :
+  Soteria_symex.Solver.Mutable_incremental with module Value = Typed

--- a/soteria/lib/bv_values/bv_solver.mli
+++ b/soteria/lib/bv_values/bv_solver.mli
@@ -1,5 +1,4 @@
-module Z3_solver :
-  Soteria_symex.Solver.Mutable_incremental with module Value = Typed
+module Z3_solver : Symex.Solver.Mutable_incremental with module Value = Typed
 
 module Z3_incremental_solver :
-  Soteria_symex.Solver.Mutable_incremental with module Value = Typed
+  Symex.Solver.Mutable_incremental with module Value = Typed

--- a/soteria/lib/bv_values/encoding.ml
+++ b/soteria/lib/bv_values/encoding.ml
@@ -1,0 +1,130 @@
+open Soteria_std
+open Simple_smt
+open Solvers.Smt_utils
+
+let pointers_not_supported () =
+  failwith "Encoding of pointers is not supported in Bv_values"
+
+type t = Svalue.t
+type ty = Svalue.ty
+
+let ( $$ ) = app
+let ( $ ) f v = f $$ [ v ]
+let t_seq = atom "Seq"
+let seq_singl t = atom "seq.unit" $$ [ t ]
+let seq_concat ts = atom "seq.++" $$ ts
+
+let rec sort_of_ty : Svalue.ty -> sexp = function
+  | TBool -> t_bool
+  | TLoc n -> t_bits n
+  | TFloat F16 -> t_f16
+  | TFloat F32 -> t_f32
+  | TFloat F64 -> t_f64
+  | TFloat F128 -> t_f128
+  | TSeq ty -> t_seq $ sort_of_ty ty
+  | TPointer _ -> pointers_not_supported ()
+  | TBitVector n -> t_bits n
+
+let memo_encode_value_tbl : sexp Hashtbl.Hint.t = Hashtbl.Hint.create 1023
+
+let smt_of_unop : Svalue.Unop.t -> sexp -> sexp = function
+  | Not -> bool_not
+  | FAbs -> fp_abs
+  | GetPtrLoc -> pointers_not_supported ()
+  | GetPtrOfs -> pointers_not_supported ()
+  | BvOfBool n -> fun b -> ite b (bv_k n Z.one) (bv_k n Z.zero)
+  | BvOfFloat (true, n) -> sbv_of_float n
+  | BvOfFloat (false, n) -> ubv_of_float n
+  | FloatOfBv (true, fp) -> float_of_sbv (Svalue.FloatPrecision.size fp)
+  | FloatOfBv (false, fp) -> float_of_ubv (Svalue.FloatPrecision.size fp)
+  | BvExtract (from_, to_) -> bv_extract to_ from_
+  | BvExtend (true, by) -> bv_sign_extend by
+  | BvExtend (false, by) -> bv_zero_extend by
+  | BvNot -> bv_not
+  | Neg -> bv_neg
+  | NegOvf -> bv_nego
+  | FIs fc -> fp_is (Svalue.FloatClass.as_fpclass fc)
+  | FRound Ceil -> fp_round Ceil
+  | FRound Floor -> fp_round Floor
+  | FRound NearestTiesToAway -> fp_round NearestTiesToAway
+  | FRound NearestTiesToEven -> fp_round NearestTiesToEven
+  | FRound Truncate -> fp_round Truncate
+
+let smt_of_binop : Svalue.Binop.t -> sexp -> sexp -> sexp = function
+  | Eq -> eq
+  | And -> bool_and
+  | Or -> bool_or
+  | FEq -> fp_eq
+  | FLeq -> fp_leq
+  | FLt -> fp_lt
+  | FAdd -> fp_add
+  | FSub -> fp_sub
+  | FMul -> fp_mul
+  | FDiv -> fp_div
+  | FRem -> fp_rem
+  | BitAnd -> bv_and
+  | BitOr -> bv_or
+  | BitXor -> bv_xor
+  | Shl -> bv_shl
+  | LShr -> bv_lshr
+  | AShr -> bv_ashr
+  | Add -> bv_add
+  | Sub -> bv_sub
+  | Mul -> bv_mul
+  | Div true -> bv_sdiv
+  | Div false -> bv_udiv
+  | Rem true -> bv_srem
+  | Rem false -> bv_urem
+  | Mod -> bv_smod
+  | AddOvf true -> bv_saddo
+  | AddOvf false -> bv_uaddo
+  | MulOvf true -> bv_smulo
+  | MulOvf false -> bv_umulo
+  | Lt true -> bv_slt
+  | Lt false -> bv_ult
+  | Leq true -> bv_sleq
+  | Leq false -> bv_uleq
+  | BvConcat -> bv_concat
+
+let rec encode_value (v : Svalue.t) =
+  match v.node.kind with
+  | Var v -> atom (Svalue.Var.to_string v)
+  | Float f -> (
+      match Svalue.precision_of_f v.node.ty with
+      | F16 -> f16_k @@ Float.of_string f
+      | F32 -> f32_k @@ Float.of_string f
+      | F64 -> f64_k @@ Float.of_string f
+      | F128 -> f128_k @@ Float.of_string f)
+  | Bool b -> bool_k b
+  | BitVec z ->
+      let n = Svalue.size_of v.node.ty in
+      bv_k n z
+  | Ptr _ -> pointers_not_supported ()
+  | Seq vs -> (
+      match vs with
+      | [] -> failwith "need type to encode empty lists"
+      | _ :: _ ->
+          List.map (fun v -> seq_singl (encode_value_memo v)) vs |> seq_concat)
+  | Ite (c, t, e) ->
+      ite (encode_value_memo c) (encode_value_memo t) (encode_value_memo e)
+  | Unop (unop, v1) ->
+      let v1 = encode_value_memo v1 in
+      smt_of_unop unop v1
+  | Binop (binop, v1, v2) ->
+      let v1 = encode_value_memo v1 in
+      let v2 = encode_value_memo v2 in
+      smt_of_binop binop v1 v2
+  | Nop (Distinct, vs) ->
+      let vs = List.map encode_value_memo vs in
+      distinct vs
+
+and encode_value_memo v =
+  match Hashtbl.Hint.find_opt memo_encode_value_tbl v.Hc.tag with
+  | Some k -> k
+  | None ->
+      let k = encode_value v in
+      Hashtbl.Hint.add memo_encode_value_tbl v.Hc.tag k;
+      k
+
+let encode_value v = encode_value_memo v
+let init_commands = []

--- a/soteria/lib/bv_values/eval.ml
+++ b/soteria/lib/bv_values/eval.ml
@@ -1,0 +1,86 @@
+open Svalue
+open Soteria_std
+
+let eval_binop : Binop.t -> t -> t -> t = function
+  | And -> Bool.and_
+  | Or -> Bool.or_
+  | Eq -> Bool.sem_eq
+  | FEq -> Float.eq
+  | FLeq -> Float.leq
+  | FLt -> Float.lt
+  | FAdd -> Float.add
+  | FSub -> Float.sub
+  | FMul -> Float.mul
+  | FDiv -> Float.div
+  | FRem -> Float.rem
+  | Add -> BitVec.add
+  | Sub -> BitVec.sub
+  | Mul -> BitVec.mul
+  | Div signed -> BitVec.div ~signed
+  | Rem signed -> BitVec.rem ~signed
+  | Mod -> BitVec.mod_
+  | AddOvf signed -> BitVec.add_overflows ~signed
+  | MulOvf signed -> BitVec.mul_overflows ~signed
+  | Lt signed -> BitVec.lt ~signed
+  | Leq signed -> BitVec.leq ~signed
+  | BvConcat -> BitVec.concat
+  | BitAnd -> BitVec.and_
+  | BitOr -> BitVec.or_
+  | BitXor -> BitVec.xor
+  | Shl -> BitVec.shl
+  | LShr -> BitVec.lshr
+  | AShr -> BitVec.ashr
+
+let eval_unop : Unop.t -> t -> t = function
+  | Not -> Bool.not
+  | FAbs -> Float.abs
+  | GetPtrLoc -> Ptr.loc
+  | GetPtrOfs -> Ptr.ofs
+  | BvOfBool n -> BitVec.of_bool n
+  | BvOfFloat (signed, _) -> BitVec.of_float ~signed
+  | FloatOfBv (signed, _) -> BitVec.to_float ~signed
+  | BvExtract (from, to_) -> BitVec.extract from to_
+  | BvExtend (signed, by) -> BitVec.extend ~signed by
+  | BvNot -> BitVec.not
+  | Neg -> BitVec.neg
+  | NegOvf -> BitVec.neg_overflows
+  | FIs fc -> Float.is_floatclass fc
+  | FRound rm -> Float.round rm
+
+let rec eval ~eval_var (x : t) : t =
+  let eval = eval ~eval_var in
+  match x.node.kind with
+  | Var v -> eval_var v x.node.ty
+  | Bool _ | Float _ | BitVec _ -> x
+  | Ptr (l, o) ->
+      let nl = eval l in
+      let no = eval o in
+      if l == nl && o == no then x else Ptr.mk (eval l) (eval o)
+  | Unop (unop, v) ->
+      let nv = eval v in
+      if v == nv then x else eval_unop unop nv
+  | Binop (binop, v1, v2) ->
+      (* TODO: for binops that may short-circuit such as || or &&,
+    we could do this without evaluating both sides, and deciding if any
+      of either side evaluates properly to e.g. true/false *)
+      let nv1 = eval v1 in
+      let nv2 = eval v2 in
+      if v1 == nv1 && v2 == nv2 then x else eval_binop binop nv1 nv2
+  | Nop (nop, l) -> (
+      let l, changed = List.map_changed eval l in
+      if Stdlib.not changed then x
+      else match nop with Distinct -> Bool.distinct l)
+  | Ite (guard, then_, else_) ->
+      let guard = eval guard in
+      if equal guard Bool.v_true then eval then_
+      else if equal guard Bool.v_false then eval else_
+      else Bool.ite guard (eval then_) (eval else_)
+  | Seq l ->
+      let l, changed = List.map_changed eval l in
+      if Stdlib.not changed then x else Svalue.SSeq.mk ~seq_ty:x.node.ty l
+
+(** Evaluates an expression; will call [eval_var] on each [Var] encountered. If
+    evaluation errors (e.g. from a division by zero), gives up and returns the
+    original expression. *)
+let eval ?(eval_var : Var.t -> Svalue.ty -> t = Svalue.mk_var) (x : t) : t =
+  try eval ~eval_var x with Division_by_zero -> x

--- a/soteria/lib/bv_values/save_counter.ml
+++ b/soteria/lib/bv_values/save_counter.ml
@@ -1,0 +1,6 @@
+type t = int ref
+
+let init () = ref 0
+let reset t = t := 0
+let save t = incr t
+let backtrack_n t n = t := !t - n

--- a/soteria/lib/bv_values/save_counter.mli
+++ b/soteria/lib/bv_values/save_counter.mli
@@ -1,0 +1,2 @@
+open Soteria_std
+include Reversible.Mutable with type t = int ref

--- a/soteria/lib/bv_values/svalue.ml
+++ b/soteria/lib/bv_values/svalue.ml
@@ -1,0 +1,1262 @@
+open Hc
+open Soteria_std
+module Var = Soteria_symex.Var
+
+module FloatPrecision = struct
+  type t = F16 | F32 | F64 | F128
+  [@@deriving eq, show { with_path = false }, ord]
+
+  let size = function F16 -> 16 | F32 -> 32 | F64 -> 64 | F128 -> 128
+
+  let of_size = function
+    | 16 -> F16
+    | 32 -> F32
+    | 64 -> F64
+    | 128 -> F128
+    | _ -> failwith "Invalid float size"
+end
+
+module FloatClass = struct
+  type t = Normal | Subnormal | Zero | Infinite | NaN
+  [@@deriving eq, show { with_path = false }, ord]
+
+  let as_fpclass = function
+    | Normal -> FP_normal
+    | Subnormal -> FP_subnormal
+    | Zero -> FP_zero
+    | Infinite -> FP_infinite
+    | NaN -> FP_nan
+end
+
+module FloatRoundingMode = struct
+  type t = NearestTiesToEven | NearestTiesToAway | Ceil | Floor | Truncate
+  [@@deriving eq, show { with_path = false }, ord]
+end
+
+type ty =
+  | TBool
+  | TFloat of FloatPrecision.t
+  | TLoc of int
+  | TPointer of int (* size of location and offset *)
+  | TSeq of ty
+  | TBitVector of int
+[@@deriving eq, show { with_path = false }, ord]
+
+let t_bool = TBool
+let t_f fp = TFloat fp
+let t_f16 = t_f F16
+let t_f32 = t_f F32
+let t_f64 = t_f F64
+let t_f128 = t_f F128
+let t_loc n = TLoc n
+let t_ptr n = TPointer n
+let t_seq ty = TSeq ty
+let t_bv n = TBitVector n
+let is_float = function TFloat _ -> true | _ -> false
+let is_bv = function TBitVector _ -> true | _ -> false
+
+let precision_of_f = function
+  | TFloat p -> p
+  | ty -> Fmt.failwith "Not a float: %a" pp_ty ty
+
+let size_of = function
+  | TBitVector n -> n
+  | TPointer n -> n
+  | TLoc n -> n
+  | ty -> Fmt.failwith "Not a bit value: %a" pp_ty ty
+
+module Nop = struct
+  type t = Distinct [@@deriving eq, show { with_path = false }, ord]
+end
+
+module Unop = struct
+  let equal_fpclass = ( = )
+  let compare_fpclass = compare
+
+  type t =
+    | Not
+    | GetPtrLoc
+    | GetPtrOfs
+    | BvOfBool of int (* target bitvec size *)
+    | BvOfFloat of bool * int (* signed * target bitvec size *)
+    | FloatOfBv of bool * FloatPrecision.t (* signed * precision *)
+    | BvExtract of int * int (* from idx (incl) * to idx (incl) *)
+    | BvExtend of bool * int (* signed * by N bits *)
+    | BvNot
+    | Neg
+    | NegOvf
+    | FAbs
+    | FIs of FloatClass.t
+    | FRound of FloatRoundingMode.t
+  [@@deriving eq, ord]
+
+  let pp_signed ft b = Fmt.string ft (if b then "s" else "u")
+
+  let pp ft = function
+    | Not -> Fmt.string ft "!"
+    | FAbs -> Fmt.string ft "abs."
+    | GetPtrLoc -> Fmt.string ft "loc"
+    | GetPtrOfs -> Fmt.string ft "ofs"
+    | BvOfBool n -> Fmt.pf ft "b2bv[%d]" n
+    | BvOfFloat (signed, n) -> Fmt.pf ft "f2%abv[%d]" pp_signed signed n
+    | FloatOfBv (signed, p) ->
+        Fmt.pf ft "%abv2f[%a]" pp_signed signed FloatPrecision.pp p
+    | BvExtract (from, to_) -> Fmt.pf ft "extract[%d-%d]" from to_
+    | BvExtend (signed, by) -> Fmt.pf ft "extend[%a%d]" pp_signed signed by
+    | BvNot -> Fmt.string ft "!bv"
+    | Neg -> Fmt.string ft "-bv"
+    | NegOvf -> Fmt.string ft "-bv_ovf"
+    | FIs fc -> Fmt.pf ft "fis(%a)" FloatClass.pp fc
+    | FRound mode -> Fmt.pf ft "fround(%a)" FloatRoundingMode.pp mode
+end
+
+module Binop = struct
+  type t =
+    (* Bool *)
+    | And
+    | Or
+    (* Comparison *)
+    | Eq
+    (* Float comparison *)
+    | FEq
+    | FLeq
+    | FLt
+    (* Float arith *)
+    | FAdd
+    | FSub
+    | FMul
+    | FDiv
+    | FRem
+    (* BitVector arithmetic *)
+    | Add
+    | Sub
+    | Mul
+    | Div of bool (* signed *)
+    | Rem of bool (* signed *)
+    | Mod
+    | AddOvf of bool (* signed *)
+    | MulOvf of bool (* signed *)
+    | Lt of bool (* signed *)
+    | Leq of bool (* signed *)
+    (* Bitvector bit operations *)
+    | BvConcat
+    | BitAnd
+    | BitOr
+    | BitXor
+    | Shl
+    | LShr
+    | AShr
+  [@@deriving eq, show { with_path = false }, ord]
+
+  let pp_signed ft b = Fmt.string ft (if b then "s" else "u")
+
+  let pp ft = function
+    | And -> Fmt.string ft "&&"
+    | Or -> Fmt.string ft "||"
+    | Eq -> Fmt.string ft "=="
+    | FEq -> Fmt.string ft "==."
+    | FLeq -> Fmt.string ft "<=."
+    | FLt -> Fmt.string ft "<."
+    | FAdd -> Fmt.string ft "+."
+    | FSub -> Fmt.string ft "-."
+    | FMul -> Fmt.string ft "*."
+    | FDiv -> Fmt.string ft "/."
+    | FRem -> Fmt.string ft "rem."
+    | Add -> Fmt.string ft "+"
+    | Sub -> Fmt.string ft "-"
+    | Mul -> Fmt.string ft "*"
+    | Div s -> Fmt.pf ft "/%a" pp_signed s
+    | Rem s -> Fmt.pf ft "rem%a" pp_signed s
+    | Mod -> Fmt.string ft "mod"
+    | AddOvf s -> Fmt.pf ft "+%a_ovf" pp_signed s
+    | MulOvf s -> Fmt.pf ft "*%a_ovf" pp_signed s
+    | Lt s -> Fmt.pf ft "<%a" pp_signed s
+    | Leq s -> Fmt.pf ft "<=%a" pp_signed s
+    | BvConcat -> Fmt.string ft "++"
+    | BitAnd -> Fmt.string ft "&"
+    | BitOr -> Fmt.string ft "|"
+    | BitXor -> Fmt.string ft "^"
+    | Shl -> Fmt.string ft "<<"
+    | LShr -> Fmt.string ft "l>>"
+    | AShr -> Fmt.string ft "a>>"
+end
+
+let pp_hash_consed pp_node ft t = pp_node ft t.node
+let equal_hash_consed _ t1 t2 = Int.equal t1.tag t2.tag
+let compare_hash_consed _ t1 t2 = Int.compare t1.tag t2.tag
+
+type t_kind =
+  | Var of Var.t
+  | Bool of bool
+  | Float of string
+  | Ptr of t * t
+  | BitVec of Z.t [@printer Fmt.of_to_string (Z.format "%#x")]
+  | Seq of t list
+  | Unop of Unop.t * t
+  | Binop of Binop.t * t * t
+  | Nop of Nop.t * t list
+  | Ite of t * t * t
+
+and t_node = { kind : t_kind; ty : ty }
+and t = t_node hash_consed [@@deriving show { with_path = false }, eq, ord]
+
+let hash t = t.tag
+let kind t = t.node.kind
+
+let iter =
+  let rec aux (f : t -> unit) (sv : t) : unit =
+    f sv;
+    match sv.node.kind with
+    | Var _ | Bool _ | Float _ | BitVec _ -> ()
+    | Ptr (l, r) | Binop (_, l, r) ->
+        aux f l;
+        aux f r
+    | Unop (_, sv) -> aux f sv
+    | Nop (_, l) | Seq l -> List.iter (aux f) l
+    | Ite (c, t, e) ->
+        aux f c;
+        aux f t;
+        aux f e
+  in
+  Fun.flip aux
+
+let iter_vars (sv : t) (f : Var.t * ty -> unit) : unit =
+  iter sv @@ fun sv ->
+  match sv.node.kind with Var v -> f (v, sv.node.ty) | _ -> ()
+
+let pp_full ft t = pp_t_node ft t.node
+
+let rec pp ft t =
+  let open Fmt in
+  match t.node.kind with
+  | Var v -> pf ft "V%a" Var.pp v
+  | Bool b -> pf ft "%b" b
+  | Float f -> pf ft "%sf" f
+  | BitVec bv ->
+      let size = size_of t.node.ty in
+      pf ft "0x%s" (Z.format ("0" ^ string_of_int (size / 4) ^ "x") bv)
+  | Ptr (l, o) -> pf ft "&(%a, %a)" pp l pp o
+  | Seq l -> pf ft "%a" (brackets (list ~sep:comma pp)) l
+  | Ite (c, t, e) -> pf ft "(%a ? %a : %a)" pp c pp t pp e
+  | Unop (Not, { node = { kind = Binop (Eq, v1, v2); _ }; _ }) ->
+      pf ft "(%a != %a)" pp v1 pp v2
+  | Unop (op, v) -> pf ft "%a(%a)" Unop.pp op pp v
+  | Binop (op, v1, v2) -> pf ft "(%a %a %a)" pp v1 Binop.pp op pp v2
+  | Nop (op, l) -> (
+      let rec aux = function
+        | acc, [] -> acc
+        | Some l, { node = { kind = Var v; _ }; _ } :: rest ->
+            aux (Some (Var.to_int v :: l), rest)
+        | _, _ -> None
+      in
+      let range = aux (Some [], l) in
+      let range =
+        Option.bind range (fun l ->
+            let l = List.sort Int.compare l in
+            let min = List.hd l in
+            let max = List.hd @@ List.rev l in
+            if max - min + 1 = List.length l then Some (min, max) else None)
+      in
+      match range with
+      | Some (min, max) -> pf ft "%a(V|%d-%d|)" Nop.pp op min max
+      | None -> pf ft "%a(%a)" Nop.pp op (list ~sep:comma pp) l)
+
+let[@inline] equal a b = Int.equal a.tag b.tag
+let[@inline] compare a b = Int.compare a.tag b.tag
+
+let rec sure_neq a b =
+  (not (equal_ty a.node.ty b.node.ty))
+  ||
+  match (a.node.kind, b.node.kind) with
+  | BitVec a, BitVec b -> not (Z.equal a b)
+  | Bool a, Bool b -> a <> b
+  | Ptr (la, oa), Ptr (lb, ob) -> sure_neq la lb || sure_neq oa ob
+  | _ -> false
+
+module Hcons = Hc.Make (struct
+  type t = t_node
+
+  let equal = equal_t_node
+
+  (* We could do a lot more efficient in terms of hashing probably,
+     if this ever becomes a bottleneck. *)
+  let hash { kind; ty } =
+    let hty = Hashtbl.hash ty in
+    match kind with
+    | Var _ | Bool _ | Float _ | BitVec _ -> Hashtbl.hash (kind, hty)
+    | Ptr (l, r) -> Hashtbl.hash (l.tag, r.tag, hty)
+    | Seq l -> Hashtbl.hash (List.map (fun sv -> sv.tag) l, hty)
+    | Unop (op, v) -> Hashtbl.hash (op, v.tag, hty)
+    | Binop (op, l, r) -> Hashtbl.hash (op, l.tag, r.tag, hty)
+    | Nop (op, l) -> Hashtbl.hash (op, List.map (fun sv -> sv.tag) l, hty)
+    | Ite (c, t, e) -> Hashtbl.hash (c.tag, t.tag, e.tag, hty)
+end)
+
+let ( <| ) kind ty : t = Hcons.hashcons { kind; ty }
+let mk_var v ty = Var v <| ty
+
+(** We put commutative binary operators in some sort of normal form where
+    element with the smallest id is on the LHS, to increase cache hits. *)
+let mk_commut_binop op l r =
+  if l.tag <= r.tag then Binop (op, l, r) else Binop (op, r, l)
+
+(* TODO: substitution will break normal forms. *)
+let rec subst subst_var sv =
+  match sv.node.kind with
+  | Var v -> mk_var (subst_var v) sv.node.ty
+  | Bool _ | Float _ | BitVec _ -> sv
+  | Ptr (l, r) ->
+      let l' = subst subst_var l in
+      let r' = subst subst_var r in
+      if equal l l' && equal r r' then sv else Ptr (l', r') <| sv.node.ty
+  | Seq l ->
+      let changed = ref false in
+      let l' =
+        List.map
+          (fun sv ->
+            let new_sv = subst subst_var sv in
+            if not (equal new_sv sv) then changed := true;
+            new_sv)
+          l
+      in
+      if !changed then Seq l' <| sv.node.ty else sv
+  | Unop (op, v) ->
+      let v' = subst subst_var v in
+      if equal v v' then sv else Unop (op, v') <| sv.node.ty
+  | Binop (op, l, r) ->
+      let l' = subst subst_var l in
+      let r' = subst subst_var r in
+      if equal l l' && equal r r' then sv else Binop (op, l', r') <| sv.node.ty
+  | Nop (op, l) ->
+      let changed = ref false in
+      let l' =
+        List.map
+          (fun sv ->
+            let new_sv = subst subst_var sv in
+            if not (equal new_sv sv) then changed := true;
+            new_sv)
+          l
+      in
+      if !changed then Nop (op, l') <| sv.node.ty else sv
+  | Ite (c, t, e) ->
+      let c' = subst subst_var c in
+      let t' = subst subst_var t in
+      let e' = subst subst_var e in
+      if equal c c' && equal t t' && equal e e' then sv
+      else Ite (c', t', e') <| sv.node.ty
+
+(** {2 Operator declarations} *)
+
+module type Bool = sig
+  val v_true : t
+  val v_false : t
+  val as_bool : t -> bool option
+  val bool : bool -> t
+  val and_ : t -> t -> t
+  val or_ : t -> t -> t
+  val conj : t list -> t
+  val not : t -> t
+  val split_ands : t -> t Iter.t
+  val distinct : t list -> t
+  val ite : t -> t -> t -> t
+  val sem_eq : t -> t -> t
+  val sem_eq_untyped : t -> t -> t
+end
+
+module type BitVec = sig
+  (* constructor *)
+  val mk : int -> Z.t -> t
+  val mk_masked : int -> Z.t -> t
+  val mki : int -> int -> t
+  val zero : int -> t
+  val one : int -> t
+  val bv_to_z : bool -> int -> Z.t -> Z.t
+
+  (* arithmetic *)
+  val add : t -> t -> t
+  val sub : t -> t -> t
+  val mul : t -> t -> t
+  val div : signed:bool -> t -> t -> t
+  val rem : signed:bool -> t -> t -> t
+  val mod_ : t -> t -> t
+  val neg : t -> t
+
+  (* overflow checks *)
+  val add_overflows : signed:bool -> t -> t -> t
+  val sub_overflows : signed:bool -> t -> t -> t
+  val mul_overflows : signed:bool -> t -> t -> t
+  val neg_overflows : t -> t
+
+  (* inequalities *)
+  val lt : signed:bool -> t -> t -> t
+  val leq : signed:bool -> t -> t -> t
+  val gt : signed:bool -> t -> t -> t
+  val geq : signed:bool -> t -> t -> t
+
+  (* bitvec manipulation *)
+  val concat : t -> t -> t
+  val extend : signed:bool -> int -> t -> t
+  val extract : int -> int -> t -> t
+
+  (* bitwise operations *)
+  val and_ : t -> t -> t
+  val or_ : t -> t -> t
+  val xor : t -> t -> t
+  val shl : t -> t -> t
+  val lshr : t -> t -> t
+  val ashr : t -> t -> t
+  val not : t -> t
+
+  (* bool-bv conversions *)
+  val of_bool : int -> t -> t
+  val to_bool : t -> t
+  val not_bool : t -> t
+
+  (* float-bv conversions *)
+  val of_float : signed:bool -> t -> t
+  val to_float : signed:bool -> t -> t
+end
+
+module type Float = sig
+  (* constructors *)
+  val mk : FloatPrecision.t -> string -> t
+  val f16 : float -> t
+  val f32 : float -> t
+  val f64 : float -> t
+  val f128 : float -> t
+  val like : t -> float -> t
+  val fp_of : t -> FloatPrecision.t
+
+  (* arithmetic *)
+  val add : t -> t -> t
+  val sub : t -> t -> t
+  val mul : t -> t -> t
+  val div : t -> t -> t
+  val rem : t -> t -> t
+  val abs : t -> t
+  val neg : t -> t
+  val round : FloatRoundingMode.t -> t -> t
+
+  (* comparisons *)
+  val eq : t -> t -> t
+  val lt : t -> t -> t
+  val leq : t -> t -> t
+  val gt : t -> t -> t
+  val geq : t -> t -> t
+
+  (* classification *)
+  val is_floatclass : FloatClass.t -> t -> t
+  val is_normal : t -> t
+  val is_subnormal : t -> t
+  val is_zero : t -> t
+  val is_infinite : t -> t
+  val is_nan : t -> t
+end
+
+(** {2 Booleans} *)
+
+module rec Bool : Bool = struct
+  let v_true = Bool true <| TBool
+  let v_false = Bool false <| TBool
+
+  let as_bool t =
+    if equal t v_true then Some true
+    else if equal t v_false then Some false
+    else None
+
+  let bool b =
+    (* avoid re-alloc and re-hashconsing *)
+    if b then v_true else v_false
+
+  let and_ v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | _, _ when equal v1 v2 -> v1
+    | Bool false, _ | _, Bool false -> v_false
+    | Bool true, _ -> v2
+    | _, Bool true -> v1
+    | _ -> mk_commut_binop And v1 v2 <| TBool
+
+  let or_ v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | _, _ when equal v1 v2 -> v1
+    | Bool true, _ | _, Bool true -> v_true
+    | Bool false, _ -> v2
+    | _, Bool false -> v1
+    | Binop (Or, v1, v1'), _ when equal v1 v2 || equal v1' v2 -> v1
+    | _, Binop (Or, v2, v2') when equal v1 v2 || equal v1 v2' -> v2
+    | _ -> mk_commut_binop Or v1 v2 <| TBool
+
+  let conj l = List.fold_left and_ v_true l
+
+  let rec not sv =
+    if equal sv v_true then v_false
+    else if equal sv v_false then v_true
+    else
+      match sv.node.kind with
+      | Unop (Not, sv) -> sv
+      | Binop (Lt s, v1, v2) -> Binop (Leq s, v2, v1) <| TBool
+      | Binop (Leq s, v1, v2) -> Binop (Lt s, v2, v1) <| TBool
+      | Binop (Or, v1, v2) -> and_ (not v1) (not v2)
+      | Binop (And, v1, v2) -> or_ (not v1) (not v2)
+      | _ -> Unop (Not, sv) <| TBool
+
+  let rec split_ands (sv : t) (f : t -> unit) : unit =
+    match sv.node.kind with
+    | Binop (And, s1, s2) ->
+        split_ands s1 f;
+        split_ands s2 f
+    | _ -> f sv
+
+  let distinct l =
+    (* [Distinct l] when l is empty or of size 1 is always true *)
+    match l with
+    | [] | [ _ ] -> v_true
+    | l ->
+        let cross_product = List.to_seq l |> Seq.self_cross_product in
+        let sure_distinct =
+          Seq.for_all (fun (a, b) -> sure_neq a b) cross_product
+        in
+        if sure_distinct then v_true else Nop (Distinct, l) <| TBool
+
+  let ite guard if_ else_ =
+    match (guard.node.kind, if_.node.kind, else_.node.kind) with
+    | Bool true, _, _ -> if_
+    | Bool false, _, _ -> else_
+    | _, Bool true, Bool false -> guard
+    | _, Bool false, Bool true -> not guard
+    | _, BitVec o, BitVec z when Z.(equal o one) && Z.equal z Z.zero ->
+        BitVec.of_bool (size_of if_.node.ty) guard
+    | _ when equal if_ else_ -> if_
+    | _ -> Ite (guard, if_, else_) <| if_.node.ty
+
+  let rec sem_eq v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | _ when equal v1 v2 -> v_true
+    | Bool b1, Bool b2 -> bool (b1 = b2)
+    | Ptr (l1, o1), Ptr (l2, o2) -> and_ (sem_eq l1 l2) (sem_eq o1 o2)
+    | BitVec b1, BitVec b2 -> bool (Z.equal b1 b2)
+    (* Arithmetics *)
+    | BitVec _, Unop (Neg, v2) -> sem_eq (BitVec.neg v1) v2
+    | Unop (Neg, v1), BitVec _ -> sem_eq v1 (BitVec.neg v2)
+    | BitVec _, Binop (Add, ({ node = { kind = BitVec _; _ }; _ } as l), r)
+    | BitVec _, Binop (Add, r, ({ node = { kind = BitVec _; _ }; _ } as l)) ->
+        sem_eq (BitVec.sub v1 l) r
+    | Binop (Add, ({ node = { kind = BitVec _; _ }; _ } as l), r), BitVec _
+    | Binop (Add, r, ({ node = { kind = BitVec _; _ }; _ } as l)), BitVec _ ->
+        sem_eq (BitVec.sub v2 l) r
+    | BitVec _, Binop (Sub, l, ({ node = { kind = BitVec _; _ }; _ } as r)) ->
+        sem_eq (BitVec.add v1 r) l
+    | BitVec _, Binop (Sub, ({ node = { kind = BitVec _; _ }; _ } as l), r) ->
+        sem_eq (BitVec.sub l v1) r
+    | Binop (Sub, l, ({ node = { kind = BitVec _; _ }; _ } as r)), BitVec _ ->
+        sem_eq (BitVec.add v2 r) l
+    | Binop (Sub, ({ node = { kind = BitVec _; _ }; _ } as l), r), BitVec _ ->
+        sem_eq (BitVec.sub l v2) r
+    (* Bitvectors *)
+    (* Reduce  (X & #x...N) = #x...M to (X & #xN) = #xM *)
+    | Binop (BitAnd, _, _), _ | _, Binop (BitAnd, _, _) -> (
+        let rec msb_of v =
+          match v.node.kind with
+          | BitVec v when Z.(v > zero) -> Some (Z.log2up v)
+          | BitVec v when Z.(equal v zero) -> Some 0
+          | Binop (BitAnd, bv1, bv2) ->
+              Option.merge min (msb_of bv1) (msb_of bv2)
+          | Unop (BvNot, bv) -> msb_of bv
+          | Ite (_, l, r) -> Option.map2 max (msb_of l) (msb_of r)
+          | _ -> None
+        in
+        let current_size = size_of v1.node.ty in
+        let msb = Option.map2 max (msb_of v1) (msb_of v2) in
+        match msb with
+        | Some msb when 0 < msb && msb < current_size - 1 ->
+            let v1 = BitVec.extract 0 (msb - 1) v1 in
+            let v2 = BitVec.extract 0 (msb - 1) v2 in
+            sem_eq v1 v2
+        | _ ->
+            (* regular sem_eq *)
+            mk_commut_binop Eq v1 v2 <| TBool)
+    | (BitVec _ as z), Binop (BvConcat, l, r)
+    | Binop (BvConcat, l, r), (BitVec _ as z) ->
+        let z = z <| v1.node.ty in
+        let size_r = size_of r.node.ty in
+        let size_l = size_of l.node.ty in
+        let z_r = BitVec.extract 0 (size_r - 1) z in
+        let z_l = BitVec.extract size_r (size_r + size_l - 1) z in
+        and_ (sem_eq l z_l) (sem_eq r z_r)
+    (* ite(b, A::B, C::D) == l :: r <=> ite(b, A, C) == l && ite(b, B, D) == r *)
+    | ( Ite
+          ( b,
+            ({ node = { kind = BitVec _; _ }; _ } as t),
+            ({ node = { kind = BitVec _; _ }; _ } as e) ),
+        Binop (BvConcat, l, r) )
+    | ( Binop (BvConcat, l, r),
+        Ite
+          ( b,
+            ({ node = { kind = BitVec _; _ }; _ } as t),
+            ({ node = { kind = BitVec _; _ }; _ } as e) ) ) ->
+        let size_r = size_of r.node.ty in
+        let size_l = size_of l.node.ty in
+        let t_r = BitVec.extract 0 (size_r - 1) t in
+        let t_l = BitVec.extract size_r (size_r + size_l - 1) t in
+        let e_r = BitVec.extract 0 (size_r - 1) e in
+        let e_l = BitVec.extract size_r (size_r + size_l - 1) e in
+        and_ (sem_eq (ite b t_l e_l) l) (sem_eq (ite b t_r e_r) r)
+    | Binop (BvConcat, l1, r1), Binop (BvConcat, l2, r2)
+      when size_of l1.node.ty = size_of l2.node.ty ->
+        and_ (sem_eq l1 l2) (sem_eq r1 r2)
+    (* BvOfBool and If-then-elses *)
+    | Ite (b, l, t), (BitVec _ | Bool _) -> ite b (sem_eq l v2) (sem_eq t v2)
+    | (BitVec _ | Bool _), Ite (b, l, t) -> ite b (sem_eq v1 l) (sem_eq v1 t)
+    | Unop (BvOfBool _, b), BitVec z | BitVec z, Unop (BvOfBool _, b) ->
+        if Z.equal z Z.one then b
+        else if Z.equal z Z.zero then not b
+        else v_false
+    | _ -> mk_commut_binop Eq v1 v2 <| TBool
+
+  let sem_eq_untyped v1 v2 =
+    if equal_ty v1.node.ty v2.node.ty then sem_eq v1 v2 else v_false
+end
+
+(** {2 Bit vectors} *)
+and BitVec : BitVec = struct
+  let mk n bv =
+    assert (Z.(zero <= bv && bv <= one lsl n));
+    BitVec bv <| t_bv n
+
+  let mk_masked n bv = mk n Z.(bv land pred (one lsl n))
+  let mki n i = mk n (Z.of_int i)
+  let zero n = mk n Z.zero
+  let one n = mk n Z.one
+
+  (** [bv_to_z signed bits z] parses a BitVector [z], for a given bitwidth
+      [bits], with [signed], into an integer. *)
+  let bv_to_z signed bits z =
+    let z = Z.(z land pred (one lsl bits)) in
+    if signed then
+      let bits_m_1 = bits - 1 in
+      let max = Z.(pred (one lsl bits_m_1)) in
+      if Z.leq z max then z else Z.(z - (one lsl bits))
+    else z
+
+  (** [max_for signed n] is the inclusive maximum for a bitvector of size [n]
+      when it is [signed] *)
+  let max_for signed n =
+    let n = if signed then n - 1 else n in
+    Z.(pred (one lsl n))
+
+  (** [min_for signed n] is the inclusive minimum for a bitvector of size [n]
+      when it is [signed] *)
+  let min_for signed n =
+    if signed then Z.(neg (one lsl Stdlib.( - ) n 1)) else Z.zero
+
+  (** [is_right_mask z] is true if [z] is of the form [0*1+] *)
+  let is_right_mask z = Z.(z > zero && popcount (succ z) = 1)
+
+  (** [right_mask_size z] is, for a [z] of the form [0*1{n}], [n]. If [z] is not
+      of the form [0*1{n}], the result is undefined, so use [is_right_mask]
+      before. *)
+  let right_mask_size z = Z.(log2 (succ z))
+
+  (** [covers_bitwidth bits z] is true if [z] is of the form [1+] and covers the
+      whole bitwidth of size [bits]. *)
+  let covers_bitwidth bits z = is_right_mask z && right_mask_size z = bits
+
+  let of_bool n b =
+    if equal Bool.v_true b then one n
+    else if equal Bool.v_false b then zero n
+    else Unop (BvOfBool n, b) <| TBitVector n
+
+  let to_bool v =
+    match v.node.kind with
+    | BitVec z -> Bool.bool (Stdlib.not (Z.equal z Z.zero))
+    | Unop (BvOfBool _, sv') -> sv'
+    | _ -> Bool.not (Bool.sem_eq v (zero (size_of v.node.ty)))
+
+  let not_bool v =
+    let n = size_of v.node.ty in
+    match v.node.kind with
+    | BitVec z -> if Z.equal z Z.zero then one n else zero n
+    | Unop (BvOfBool n, g) -> of_bool n (Bool.not g)
+    | _ -> of_bool n (Bool.sem_eq v (zero n))
+
+  let rec add v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> mk_masked (size_of v1.node.ty) Z.(l + r)
+    | Unop (Neg, v1), _ -> sub v2 v1
+    | _, Unop (Neg, v2) -> sub v1 v2
+    | _, BitVec z when Z.equal z Z.zero -> v1
+    | BitVec z, _ when Z.equal z Z.zero -> v2
+    | (BitVec z, Unop (BvNot, v) | Unop (BvNot, v), BitVec z)
+      when Z.equal z Z.one ->
+        neg v
+    | Binop (Add, ({ node = { kind = BitVec _; _ }; _ } as c1), r), BitVec _
+    | Binop (Add, r, ({ node = { kind = BitVec _; _ }; _ } as c1)), BitVec _ ->
+        add (add c1 v2) r
+    (* only propagate down ites if we know it's concrete *)
+    | Ite (b, l, r), BitVec x | BitVec x, Ite (b, l, r) ->
+        let n = size_of v1.node.ty in
+        let x = mk n x in
+        Bool.ite b (add l x) (add r x)
+    | _ -> mk_commut_binop Add v1 v2 <| v1.node.ty
+
+  and sub v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> mk_masked (size_of v1.node.ty) Z.(l - r)
+    | _, BitVec z when Z.equal z Z.zero -> v1
+    | BitVec z, _ when Z.equal z Z.zero -> neg v2
+    (* BAD PERF:!!!! *)
+    | _, Unop (Neg, v2) -> add v1 v2
+    | Binop (Sub, ({ node = { kind = BitVec _; _ }; _ } as c1), s), BitVec _ ->
+        sub (sub c1 v2) s
+    | Binop (Sub, s, ({ node = { kind = BitVec _; _ }; _ } as c1)), BitVec _ ->
+        sub s (add c1 v2)
+    (* only propagate down ites if we know it's concrete *)
+    | Ite (b, l, r), BitVec _ -> Bool.ite b (sub l v2) (sub r v2)
+    | BitVec _, Ite (b, l, r) -> Bool.ite b (sub v1 l) (sub v1 r)
+    | Unop (BvOfBool n, b), BitVec _ -> Bool.ite b (sub (one n) v2) (neg v2)
+    | BitVec _, Unop (BvOfBool n, b) -> Bool.ite b (sub v1 (one n)) v1
+    | _ -> Binop (Sub, v1, v2) <| v1.node.ty
+
+  and neg v =
+    (* let n = size_of v.node.ty in
+    match v.node.kind with
+    | BitVec bv -> mk_masked n Z.(neg bv)
+    | _ -> sub (zero n) v *)
+    let n = size_of v.node.ty in
+    match v.node.kind with
+    | BitVec bv -> mk_masked n Z.(neg bv)
+    | Unop (Neg, v) -> v
+    | Ite (b, l, r) -> Bool.ite b (neg l) (neg r)
+    | Unop (BvOfBool n, b) -> Bool.ite b (neg (one n)) (zero n)
+    | _ -> Unop (Neg, v) <| v.node.ty
+
+  let rec mul v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> mk_masked (size_of v1.node.ty) Z.(l * r)
+    | _, BitVec z when Z.equal z Z.one -> v1
+    | BitVec z, _ when Z.equal z Z.one -> v2
+    | _, BitVec z when Z.equal z Z.zero -> zero (size_of v1.node.ty)
+    | BitVec z, _ when Z.equal z Z.zero -> zero (size_of v1.node.ty)
+    (* only propagate down ites if we know it's concrete *)
+    | Ite (b, l, r), BitVec x | BitVec x, Ite (b, l, r) ->
+        let n = size_of v1.node.ty in
+        let x = mk n x in
+        Bool.ite b (mul l x) (mul r x)
+    | _ -> mk_commut_binop Mul v1 v2 <| v1.node.ty
+
+  let div ~signed v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r ->
+        let size = size_of v1.node.ty in
+        let l = bv_to_z signed size l in
+        let r = bv_to_z signed size r in
+        let res = Z.(l / r) in
+        mk_masked size res
+    | _, BitVec r when Z.equal r Z.one -> v1
+    | _ -> Binop (Div signed, v1, v2) <| v1.node.ty
+
+  (** [rem ~signed v1 v2] is the remainder of [v1 / v2], which takes the sign of
+      the dividend [v1] if [signed]. *)
+  let rec rem ~signed v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r ->
+        let size = size_of v1.node.ty in
+        let l = bv_to_z signed size l in
+        let r = bv_to_z signed size r in
+        if Z.equal r Z.zero then mk_masked size l
+        else
+          let res = Z.(l mod r) in
+          mk_masked size res
+    | _, BitVec r when Stdlib.not signed && Z.(equal r one) ->
+        zero (size_of v1.node.ty)
+    | Binop (Add, { node = { kind = BitVec l; _ }; _ }, r), BitVec d
+      when Stdlib.not signed && Z.(equal l d) ->
+        rem ~signed r v2
+    | Binop (Add, r, { node = { kind = BitVec l; _ }; _ }), BitVec d
+      when Stdlib.not signed && Z.(equal l d) ->
+        rem ~signed r v2
+    | _ -> Binop (Rem signed, v1, v2) <| v1.node.ty
+
+  (** [mod_ v1 v2] is the signed remainder of [v1 / v2], which takes the sign of
+      the divisor [v2] if [signed]. For an unsigned version, use
+      [rem ~signed:false]. *)
+  let mod_ v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r ->
+        let size = size_of v1.node.ty in
+        let l = bv_to_z true size l in
+        let r = bv_to_z true size r in
+        if Z.equal r Z.zero then mk_masked size l
+        else
+          let res = Z.(l mod r) in
+          let res =
+            if Z.(res < zero) && not Z.(r < zero) then Z.(res + r)
+            else if Z.(res >= zero) && Z.(r < zero) then Z.(res + r)
+            else res
+          in
+          mk_masked size res
+    | _ -> Binop (Mod, v1, v2) <| v1.node.ty
+
+  let rec not v =
+    match v.node.kind with
+    | BitVec bv ->
+        let n = size_of v.node.ty in
+        mk_masked n Z.(lognot bv)
+    | Ite (b, l, r) -> Bool.ite b (not l) (not r)
+    | _ -> Unop (BvNot, v) <| v.node.ty
+
+  let rec and_ v1 v2 =
+    let n = size_of v1.node.ty in
+    assert (n == size_of v2.node.ty);
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> mk n Z.(logand l r)
+    | BitVec mask, _ when Z.(equal mask zero) -> v1
+    | _, BitVec mask when Z.(equal mask zero) -> v2
+    | BitVec mask, _ when covers_bitwidth n mask -> v2
+    | _, BitVec mask when covers_bitwidth n mask -> v1
+    (* For (x >> s) & m, the mask is irrelevant if it entirely covers [bitsize - s] *)
+    | ( (Binop ((LShr | AShr), _, { node = { kind = BitVec shift; _ }; _ }) as
+         base),
+        BitVec mask )
+    | ( BitVec mask,
+        (Binop ((LShr | AShr), _, { node = { kind = BitVec shift; _ }; _ }) as
+         base) )
+      when let bitwidth = n - Z.to_int shift in
+           let low_mask = Z.(pred (one lsl bitwidth)) in
+           Z.(equal (mask land low_mask) low_mask) ->
+        base <| t_bv n
+    | BitVec _, Ite (b, l, r) -> Bool.ite b (and_ v1 l) (and_ v1 r)
+    | Ite (b, l, r), BitVec _ -> Bool.ite b (and_ l v2) (and_ r v2)
+    (* if it's a right mask, it's usually beneficial to propagate it *)
+    | (BitVec mask, Binop (BitAnd, l, r) | Binop (BitAnd, l, r), BitVec mask)
+      when is_right_mask mask ->
+        let n = size_of v1.node.ty in
+        let mask = mk n mask in
+        and_ (and_ mask l) (and_ mask r)
+    | BitVec o, Unop (BvOfBool _, _) when Z.equal o Z.one -> v2
+    | Unop (BvOfBool _, _), BitVec o when Z.equal o Z.one -> v1
+    | Unop (BvOfBool _, b1), Unop (BvOfBool _, b2) ->
+        of_bool n (Bool.and_ b1 b2)
+    | ( Ite (b1, l1, { node = { kind = BitVec r1; _ }; _ }),
+        Ite (b2, l2, { node = { kind = BitVec r2; _ }; _ }) )
+      when Z.(equal r1 zero) && Z.(equal r2 zero) ->
+        let n = size_of v1.node.ty in
+        Bool.ite (Bool.and_ b1 b2) (and_ l1 l2) (zero n)
+    | _, _ -> mk_commut_binop BitAnd v1 v2 <| t_bv n
+
+  and or_ v1 v2 =
+    assert (match v1.node.ty with TBitVector _ -> true | _ -> false);
+    assert (match v2.node.ty with TBitVector _ -> true | _ -> false);
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r ->
+        let n = size_of v1.node.ty in
+        mk n Z.(l lor r)
+    | BitVec z, _ when Z.equal z Z.zero -> v2
+    | _, BitVec z when Z.equal z Z.zero -> v1
+    (* 0x0..0X..X | (0x0..0Y..Y << N) when N = |X..X| ==> 0x0..0Y..YX..X  *)
+    | ( Unop (BvExtend (false, nx), base),
+        Binop
+          ( Shl,
+            { node = { kind = Unop (BvExtend (false, _), tail); _ }; _ },
+            { node = { kind = BitVec shift; _ }; _ } ) )
+      when Z.to_int shift = size_of base.node.ty ->
+        let tail_size = size_of tail.node.ty in
+        if nx = tail_size then concat tail base
+        else if nx > tail_size then
+          let new_base = concat tail base in
+          extend ~signed:false (nx - tail_size) new_base
+        else
+          let new_tail = extract 0 (nx - 1) tail in
+          concat new_tail base
+    | Unop (BvOfBool n, b1), Unop (BvOfBool _, b2) -> of_bool n (Bool.or_ b1 b2)
+    | _ -> mk_commut_binop BitOr v1 v2 <| v1.node.ty
+
+  and xor v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r ->
+        let n = size_of v1.node.ty in
+        mk n Z.(l lxor r)
+    | BitVec z, _ when Z.equal z Z.zero -> v2
+    | _, BitVec z when Z.equal z Z.zero -> v1
+    | Unop (BvOfBool n, b1), Unop (BvOfBool _, b2) ->
+        of_bool n (Bool.not (Bool.sem_eq b1 b2))
+    | _ -> mk_commut_binop BitXor v1 v2 <| v1.node.ty
+
+  (** [extract from_ to_ v] returns a bitvector covering bits from index
+      [from_], to index [to_], inclusive. [0 <= from_ <= to_ < size_of v] must
+      hold. *)
+  and extract from_ to_ v =
+    let prev_size = size_of v.node.ty in
+    assert (0 <= from_ && from_ <= to_ && to_ < prev_size);
+    let size = to_ - from_ + 1 in
+    match v.node.kind with
+    | BitVec bv -> mk_masked size Z.(bv asr from_)
+    | Binop (((BitAnd | BitOr | BitXor) as bop), v1, v2) -> (
+        let v1 = extract from_ to_ v1 in
+        let v2 = extract from_ to_ v2 in
+        match bop with
+        | BitAnd -> and_ v1 v2
+        | BitOr -> or_ v1 v2
+        | BitXor -> xor v1 v2
+        | _ -> failwith "unreachable binop")
+    | Binop (LShr, v1, { node = { kind = BitVec x; _ }; _ }) ->
+        (* we have to be careful to not extract bits that are out of bounds *)
+        let shift = Z.to_int x in
+        if to_ + shift < prev_size then
+          (* 1. we can just shift the extraction *)
+          extract (from_ + shift) (to_ + shift) v1
+        else if from_ + shift >= prev_size then
+          (* 2. the full shift is out of bounds! so 0 *)
+          zero size
+        else
+          (* 3. it's an in between - for now, we don't do anything *)
+          Unop (BvExtract (from_, to_), v) <| t_bv size
+    | Ite (b, l, r) ->
+        let l = extract from_ to_ l in
+        let r = extract from_ to_ r in
+        Bool.ite b l r
+    | Unop (BvExtend (false, by), _) when from_ >= prev_size - by ->
+        (* zero extension, and we're extracting only the extended bits *)
+        zero size
+    | Unop (BvExtend (_, by), v) when from_ = 0 && to_ = prev_size - by - 1 ->
+        (* extracting exactly the original bits *)
+        v
+    | Unop (BvExtend (_, by), v) when to_ <= prev_size - by - 1 ->
+        (* extracting from original bits *)
+        extract from_ to_ v
+    | Unop (BvExtract (prev_from_, _), v) ->
+        Unop (BvExtract (prev_from_ + from_, prev_from_ + to_), v) <| t_bv size
+    | Binop (BvConcat, l, r) ->
+        let size_r = size_of r.node.ty in
+        if from_ >= size_r then extract (from_ - size_r) (to_ - size_r) l
+        else if to_ < size_r then extract from_ to_ r
+        else
+          let r' = extract from_ (size_r - 1) r in
+          let l' = extract 0 (to_ - size_r) l in
+          concat l' r'
+    | _ -> Unop (BvExtract (from_, to_), v) <| t_bv size
+
+  and extend ~signed extend_by v =
+    let n = size_of v.node.ty in
+    let to_ = n + extend_by in
+    assert (extend_by > 0);
+    match v.node.kind with
+    | BitVec bv ->
+        if signed && Z.testbit bv (n - 1) then
+          (* Sign extend: replicate the MSB *)
+          let mask = Z.(pred (one lsl extend_by) lsl n) in
+          mk to_ Z.(bv lor mask)
+        else
+          (* Zero extend: just mask to ensure no extra bits *)
+          mk to_ bv
+    | Ite (b, l, r) ->
+        let l = extend ~signed extend_by l in
+        let r = extend ~signed extend_by r in
+        Bool.ite b l r
+    (* can't extend if signed && n == 1, as it should be all 1s *)
+    | Unop (BvOfBool n, b) when Stdlib.not signed || n > 1 -> of_bool to_ b
+    (* unlike with extract, we don't want to propagate extend within the expression for &, |, ^,
+         as that will require a more expensive bit-blasting. *)
+    (* We also note the following reduction is *not valid*, as some upper bits may be set;
+         e.g. given i2bv[3](8) = 0b000, extend[1](i2bv[3](8)) = 0b0000, whereas
+              i2bv[4](8) = 0b1000
+      | Unop (BvOfInt, v) -> Unop (BvOfInt, v) <| t_bv signed to_ *)
+    | _ -> Unop (BvExtend (signed, extend_by), v) <| t_bv to_
+
+  (** [concat v1 v2] for [v1] of size [n] and [v2] of size [m] is a bitvector of
+      size [n + m] where the first [m] bits are [v2] and the following [n] are
+      [v1] *)
+  and concat v1 v2 =
+    let n1 = size_of v1.node.ty in
+    let n2 = size_of v2.node.ty in
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> mk_masked (n1 + n2) Z.(r + shift_left l n2)
+    | Unop (BvExtract (from1, to1), v1), Unop (BvExtract (from2, to2), v2)
+      when to2 + 1 = from1 && equal v1 v2 ->
+        extract from2 to1 v1
+    (* We order (extract A ++ (X ++ extract )) *)
+    | ( Unop (BvExtract (_, _), _),
+        Binop
+          ( BvConcat,
+            ({ node = { kind = Unop (BvExtract _, _); _ }; _ } as left),
+            right ) ) ->
+        concat (concat v1 left) right
+    | Ite (b1, l1, r1), Ite (b2, l2, r2) when equal b1 b2 ->
+        Bool.ite b1 (concat l1 l2) (concat r1 r2)
+    | _, _ -> Binop (BvConcat, v1, v2) <| t_bv (n1 + n2)
+
+  let rec shl v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> mk_masked (size_of v1.node.ty) Z.(l lsl to_int r)
+    | _, BitVec s when Z.equal s Z.zero -> v1
+    | _, BitVec s when Z.geq s (Z.of_int (size_of v1.node.ty)) ->
+        zero (size_of v1.node.ty)
+    | Binop (Shl, v, { node = { kind = BitVec s1; _ }; _ }), BitVec s2 ->
+        let n = size_of v1.node.ty in
+        shl v (mk n Z.(s1 + s2))
+    | _ -> Binop (Shl, v1, v2) <| v1.node.ty
+
+  let rec lshr v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> mk_masked (size_of v1.node.ty) Z.(l asr to_int r)
+    | _, BitVec s when Z.equal s Z.zero -> v1
+    | _, BitVec s when Z.geq s (Z.of_int (size_of v1.node.ty)) ->
+        zero (size_of v1.node.ty)
+    | Binop (LShr, v, { node = { kind = BitVec s1; _ }; _ }), BitVec s2 ->
+        let n = size_of v1.node.ty in
+        lshr v (mk n Z.(s1 + s2))
+    | _ -> Binop (LShr, v1, v2) <| v1.node.ty
+
+  let ashr v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> mk_masked (size_of v1.node.ty) Z.(l asr to_int r)
+    | _, BitVec s when Z.equal s Z.zero -> v1
+    | Binop (AShr, v, { node = { kind = BitVec s1; _ }; _ }), BitVec s2 ->
+        let n = size_of v1.node.ty in
+        lshr v (mk n Z.(s1 + s2))
+    | _ -> Binop (AShr, v1, v2) <| v1.node.ty
+
+  let rec lt ~signed v1 v2 =
+    let bits = size_of v1.node.ty in
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r ->
+        Bool.bool @@ Z.lt (bv_to_z signed bits l) (bv_to_z signed bits r)
+    | _, BitVec x when Stdlib.not signed && Z.(equal x one) ->
+        (* unsigned x < 1 is x == 0 *)
+        Bool.sem_eq v1 (zero bits)
+    | _, BitVec x when signed && Z.(equal x zero) ->
+        (* signed x < 0 is checking the sign bit *)
+        let sign_bit = extract (bits - 1) (bits - 1) v1 in
+        Bool.sem_eq sign_bit (one 1)
+    | BitVec x, _ when signed && Z.equal x Z.zero ->
+        (* signed 0 < x is checking the sign bit of x is not set *)
+        let sign_bit = extract (bits - 1) (bits - 1) v2 in
+        Bool.sem_eq sign_bit (zero 1)
+    | BitVec x, _ when Z.equal (bv_to_z signed bits x) (max_for signed bits) ->
+        Bool.v_false
+    | _, BitVec x when Z.equal (bv_to_z signed bits x) (min_for signed bits) ->
+        Bool.v_false
+    | BitVec x, _ when Z.equal (bv_to_z signed bits x) (min_for signed bits) ->
+        Bool.not (Bool.sem_eq v1 v2)
+    | _, BitVec x when Z.equal (bv_to_z signed bits x) (max_for signed bits) ->
+        Bool.not (Bool.sem_eq v1 v2)
+    (* x < ite(b, 1, 0) => ite(b, x < 1, x < 0) => ite(b, x = 0, false) => b && x = 0 *)
+    | _, Unop (BvOfBool n, b) when Stdlib.not signed ->
+        Bool.and_ b (Bool.sem_eq v1 (zero n))
+    | Ite (b, l, r), _ -> Bool.ite b (lt ~signed l v2) (lt ~signed r v2)
+    | _, Ite (b, l, r) -> Bool.ite b (lt ~signed v1 l) (lt ~signed v1 r)
+    | _ -> Binop (Lt signed, v1, v2) <| TBool
+
+  let leq ~signed v1 v2 =
+    let bits = size_of v1.node.ty in
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r ->
+        Bool.bool @@ Z.leq (bv_to_z signed bits l) (bv_to_z signed bits r)
+    | BitVec x, _ when Z.equal (bv_to_z signed bits x) (min_for signed bits) ->
+        Bool.v_true
+    | _, BitVec x when Z.equal (bv_to_z signed bits x) (max_for signed bits) ->
+        Bool.v_true
+    | _ -> Binop (Leq signed, v1, v2) <| TBool
+
+  let gt ~signed v1 v2 = lt ~signed v2 v1
+  let geq ~signed v1 v2 = leq ~signed v2 v1
+
+  let ovf_check ~signed n l r op =
+    let minz = min_for signed n in
+    let maxz = max_for signed n in
+    let l = bv_to_z signed n l in
+    let r = bv_to_z signed n r in
+    let res = op l r in
+    Bool.bool Z.Compare.(res < minz || res > maxz)
+
+  let add_overflows ~signed v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> ovf_check ~signed (size_of v1.node.ty) l r Z.( + )
+    | BitVec z, _ when Z.equal z Z.zero -> Bool.v_false
+    | _, BitVec z when Z.equal z Z.zero -> Bool.v_false
+    | _ -> Binop (AddOvf signed, v1, v2) <| TBool
+
+  let mul_overflows ~signed v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | BitVec l, BitVec r -> ovf_check ~signed (size_of v1.node.ty) l r Z.( * )
+    | BitVec z, _ when Z.equal z Z.zero || Z.equal z Z.one -> Bool.v_false
+    | _, BitVec z when Z.equal z Z.zero || Z.equal z Z.one -> Bool.v_false
+    | _ -> Binop (MulOvf signed, v1, v2) <| TBool
+
+  let neg_overflows v =
+    match v.node.kind with
+    | BitVec bv ->
+        let n = size_of v.node.ty in
+        Bool.bool (Z.equal (bv_to_z true n bv) (min_for true n))
+    | _ -> Unop (NegOvf, v) <| TBool
+
+  let sub_overflows ~signed v1 v2 =
+    if Stdlib.not signed then lt ~signed v1 v2
+    else
+      let neg_ovf = neg_overflows v2 in
+      let neg_v2 = neg v2 in
+      let add_ovf = add_overflows ~signed v1 neg_v2 in
+      Bool.or_ neg_ovf add_ovf
+
+  let of_float ~signed v =
+    let p = precision_of_f v.node.ty in
+    match (v.node.ty, v.node.kind, p) with
+    | TFloat F32, Float f, F32 ->
+        mk 32 @@ Z.of_int32 (Int32.bits_of_float (Stdlib.Float.of_string f))
+    | TFloat F64, Float f, F64 ->
+        mk 64 @@ Z.of_int64 (Int64.bits_of_float (Stdlib.Float.of_string f))
+    | _, _, _ ->
+        let n = FloatPrecision.size p in
+        Unop (BvOfFloat (signed, n), v) <| t_bv n
+
+  let to_float ~signed v =
+    let size = size_of v.node.ty in
+    let fp = FloatPrecision.of_size size in
+    Unop (FloatOfBv (signed, fp), v) <| t_f fp
+end
+
+(** {2 Floating point} *)
+and Float : Float = struct
+  let f2str = Stdlib.Float.to_string
+  let str2f = Stdlib.Float.of_string
+  let mk fp f = Float f <| t_f fp
+  let mk_f fp f = Float (f2str f) <| t_f fp
+  let like v f = Float (f2str f) <| v.node.ty
+
+  let fp_of v =
+    match v.node.ty with
+    | TFloat fp -> fp
+    | _ -> Fmt.failwith "Unsupported float type"
+
+  let f16 f = mk_f F16 f
+  let f32 f = mk_f F32 f
+  let f64 f = mk_f F64 f
+  let f128 f = mk_f F128 f
+  let eq v1 v2 = mk_commut_binop FEq v1 v2 <| TBool
+
+  let lt v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | Float f1, Float f2 -> Bool.bool (str2f f1 < str2f f2)
+    | _ -> Binop (FLt, v1, v2) <| TBool
+
+  let leq v1 v2 =
+    match (v1.node.kind, v2.node.kind) with
+    | Float f1, Float f2 -> Bool.bool (str2f f1 <= str2f f2)
+    | _ -> Binop (FLeq, v1, v2) <| TBool
+
+  let gt v1 v2 = lt v2 v1
+  let geq v1 v2 = leq v2 v1
+  let add v1 v2 = mk_commut_binop FAdd v1 v2 <| v1.node.ty
+  let sub v1 v2 = Binop (FSub, v1, v2) <| v1.node.ty
+  let div v1 v2 = Binop (FDiv, v1, v2) <| v1.node.ty
+  let mul v1 v2 = mk_commut_binop FMul v1 v2 <| v1.node.ty
+  let rem v1 v2 = Binop (FRem, v1, v2) <| v1.node.ty
+
+  let abs v =
+    match v.node.kind with
+    | Unop (FAbs, _) -> v
+    | _ -> Unop (FAbs, v) <| v.node.ty
+
+  let neg v =
+    let fp = fp_of v in
+    Binop (FSub, mk fp "0.0", v) <| v.node.ty
+
+  let[@inline] is_floatclass fc =
+   fun sv ->
+    match sv.node.kind with
+    | Float f -> Bool.bool (FloatClass.as_fpclass fc = classify_float (str2f f))
+    | _ -> Unop (FIs fc, sv) <| TBool
+
+  let is_normal = is_floatclass Normal
+  let is_subnormal = is_floatclass Subnormal
+  let is_infinite = is_floatclass Infinite
+  let is_nan = is_floatclass NaN
+  let is_zero = is_floatclass Zero
+  let round rm sv = Unop (FRound rm, sv) <| sv.node.ty
+end
+
+(** {2 Pointers} *)
+
+module Ptr = struct
+  let mk l o = Ptr (l, o) <| TPointer (size_of o.node.ty)
+
+  let loc p =
+    match p.node.kind with
+    | Ptr (l, _) -> l
+    | _ -> Unop (GetPtrLoc, p) <| TLoc (size_of p.node.ty)
+
+  let null_loc n = BitVec Z.zero <| TLoc n
+  let is_null_loc l = Bool.sem_eq l (null_loc (size_of l.node.ty))
+  let loc_of_z n z = BitVec z <| TLoc n
+  let loc_of_int n i = loc_of_z n (Z.of_int i)
+
+  let ofs p =
+    match p.node.kind with
+    | Ptr (_, o) -> o
+    | _ ->
+        let n = size_of p.node.ty in
+        Unop (GetPtrOfs, p) <| TBitVector n
+
+  let decompose p =
+    match p.node.kind with Ptr (l, o) -> (l, o) | _ -> (loc p, ofs p)
+
+  let add_ofs p o =
+    let loc, ofs = decompose p in
+    mk loc (BitVec.add ofs o)
+
+  let null n = mk (null_loc n) (BitVec.zero n)
+  let is_null p = Bool.sem_eq p (null (size_of p.node.ty))
+  let is_at_null_loc p = is_null_loc (loc p)
+end
+
+(** {2 Sequences} *)
+
+module SSeq = struct
+  let mk ~seq_ty l = Seq l <| seq_ty
+
+  let inner_ty ty =
+    match ty with TSeq ty -> ty | _ -> failwith "Expected a sequence type"
+end
+
+(** {2 Infix operators} *)
+
+module Infix = struct
+  let bv_z = BitVec.mk
+  let ptr = Ptr.mk
+  let seq = SSeq.mk
+  let ( ==@ ) = Bool.sem_eq
+  let ( ==?@ ) = Bool.sem_eq_untyped
+  let ( &&@ ) = Bool.and_
+  let ( ||@ ) = Bool.or_
+  let ( >@ ) = BitVec.gt ~signed:false
+  let ( >=@ ) = BitVec.geq ~signed:false
+  let ( <@ ) = BitVec.lt ~signed:false
+  let ( <=@ ) = BitVec.leq ~signed:false
+  let ( >$@ ) = BitVec.gt ~signed:true
+  let ( >=$@ ) = BitVec.geq ~signed:true
+  let ( <$@ ) = BitVec.lt ~signed:true
+  let ( <=$@ ) = BitVec.leq ~signed:true
+  let ( +@ ) = BitVec.add
+  let ( -@ ) = BitVec.sub
+  let ( ~- ) = BitVec.neg
+  let ( *@ ) = BitVec.mul
+  let ( /@ ) = BitVec.div ~signed:false
+  let ( /$@ ) = BitVec.div ~signed:true
+  let ( %@ ) = BitVec.rem ~signed:false
+  let ( %$@ ) = BitVec.mod_
+  let ( <<@ ) = BitVec.shl
+  let ( >>@ ) = BitVec.lshr
+  let ( >>>@ ) = BitVec.ashr
+  let ( ^@ ) = BitVec.xor
+  let ( &@ ) = BitVec.and_
+  let ( |@ ) = BitVec.or_
+  let ( ==.@ ) = Float.eq
+  let ( >.@ ) = Float.gt
+  let ( >=.@ ) = Float.geq
+  let ( <.@ ) = Float.lt
+  let ( <=.@ ) = Float.leq
+  let ( +.@ ) = Float.add
+  let ( -.@ ) = Float.sub
+  let ( *.@ ) = Float.mul
+  let ( /.@ ) = Float.div
+end

--- a/soteria/lib/bv_values/svalue.ml
+++ b/soteria/lib/bv_values/svalue.ml
@@ -1,6 +1,6 @@
 open Hc
 open Soteria_std
-module Var = Soteria_symex.Var
+module Var = Symex.Var
 
 module FloatPrecision = struct
   type t = F16 | F32 | F64 | F128

--- a/soteria/lib/bv_values/typed.ml
+++ b/soteria/lib/bv_values/typed.ml
@@ -1,0 +1,65 @@
+open Hc
+include Svalue
+
+module T = struct
+  type sint = [ `NonZero | `MaybeZero ]
+  type sfloat = [ `Float ]
+  type nonzero = [ `NonZero ]
+  type sbool = [ `Bool ]
+  type sptr = [ `Ptr ]
+  type sloc = [ `Loc ]
+  type 'a sseq = [ `List of 'a ]
+  type cval = [ sint | sptr | sfloat ]
+
+  type any =
+    [ `Bool | `Ptr | `Loc | `List of any | `NonZero | `MaybeZero | `Float ]
+
+  let pp_sint _ _ = ()
+  let pp_nonzero _ _ = ()
+  let pp_sbool _ _ = ()
+  let pp_sptr _ _ = ()
+  let pp_sloc _ _ = ()
+  let pp_sseq _ _ _ = ()
+  let pp_any _ _ = ()
+  let pp_cval _ _ = ()
+end
+
+type nonrec +'a t = t
+type nonrec +'a ty = ty
+type sbool = T.sbool
+
+let t_int = t_bv
+
+include Bool
+
+let[@inline] get_ty x = x.node.ty
+let[@inline] type_type x = x
+let[@inline] untype_type x = x
+let ppa = pp
+let pp _ = pp
+let ppa_ty = pp_ty
+let pp_ty _ = pp_ty
+let[@inline] cast x = x
+let[@inline] untyped x = x
+let[@inline] untyped_list l = l
+let[@inline] type_ x = x
+let type_checked x ty = if equal_ty x.node.ty ty then Some x else None
+let cast_checked = type_checked
+let cast_float x = if is_float x.node.ty then Some x else None
+let cast_int x = if is_bv x.node.ty then Some x else None
+let size_of_int x = size_of x.node.ty
+
+let cast_checked2 x y =
+  if equal_ty x.node.ty y.node.ty then Some (x, y, x.node.ty) else None
+
+module BitVec = struct
+  include BitVec
+
+  let mk_nz n z =
+    if Z.equal z Z.zero then failwith "Zero value in mk_nonzero" else mk n z
+
+  let mki_nz n i =
+    if i = 0 then failwith "Zero value in mki_nonzero" else mki n i
+
+  let mki_masked n i = mk_masked n (Z.of_int i)
+end

--- a/soteria/lib/bv_values/typed.mli
+++ b/soteria/lib/bv_values/typed.mli
@@ -1,0 +1,240 @@
+(** {2 Phantom types} *)
+
+module T : sig
+  type sint = [ `NonZero | `MaybeZero ]
+  type sfloat = [ `Float ]
+  type nonzero = [ `NonZero ]
+  type sbool = [ `Bool ]
+  type sptr = [ `Ptr ]
+  type sloc = [ `Loc ]
+  type 'a sseq = [ `List of 'a ]
+  type cval = [ sint | sptr | sfloat ]
+
+  type any =
+    [ `Bool | `Ptr | `Loc | `List of any | `NonZero | `MaybeZero | `Float ]
+
+  val pp_sint : Format.formatter -> sint -> unit
+  val pp_nonzero : Format.formatter -> nonzero -> unit
+  val pp_sbool : Format.formatter -> sbool -> unit
+  val pp_sptr : Format.formatter -> sptr -> unit
+  val pp_sloc : Format.formatter -> sloc -> unit
+  val pp_cval : Format.formatter -> cval -> unit
+
+  val pp_sseq :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a sseq -> unit
+
+  val pp_any : Format.formatter -> any -> unit
+end
+
+open T
+
+(** {2 Types} *)
+type +'a ty
+
+val pp_ty :
+  (Format.formatter -> 'a ty -> unit) -> Format.formatter -> 'a ty -> unit
+
+val ppa_ty : Format.formatter -> 'a ty -> unit
+val equal_ty : 'a ty -> 'b ty -> bool
+val t_bool : [> sbool ] ty
+val t_int : int -> [> sint ] ty
+val t_ptr : int -> [> sptr ] ty
+val t_loc : int -> [> sloc ] ty
+val t_seq : ([< any ] as 'a) ty -> [> 'a sseq ] ty
+val t_f16 : [> sfloat ] ty
+val t_f32 : [> sfloat ] ty
+val t_f64 : [> sfloat ] ty
+val t_f128 : [> sfloat ] ty
+val t_f : Svalue.FloatPrecision.t -> [> sfloat ] ty
+
+(** {2 Typed svalues} *)
+
+type +'a t
+type sbool = T.sbool
+
+(** Basic value operations *)
+
+val get_ty : 'a t -> Svalue.ty
+val type_type : Svalue.ty -> 'a ty
+val untype_type : 'a ty -> Svalue.ty
+val kind : 'a t -> Svalue.t_kind
+val mk_var : Svalue.Var.t -> 'a ty -> 'a t
+val iter_vars : 'a t -> (Svalue.Var.t * 'b ty -> unit) -> unit
+val subst : (Svalue.Var.t -> Svalue.Var.t) -> 'a t -> 'a t
+val type_ : Svalue.t -> 'a t
+val type_checked : Svalue.t -> 'a ty -> 'a t option
+val cast : 'a t -> 'b t
+val cast_checked : 'a t -> 'b ty -> 'b t option
+val cast_checked2 : 'a t -> 'b t -> ('c t * 'c t * 'c ty) option
+val cast_float : 'a t -> [> sfloat ] t option
+val cast_int : 'a t -> [> sint ] t option
+val is_float : 'a ty -> bool
+val size_of_int : [< sint ] t -> int
+val untyped : 'a t -> Svalue.t
+val untyped_list : 'a t list -> Svalue.t list
+val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+val ppa : Format.formatter -> 'a t -> unit
+val equal : ([< any ] as 'a) t -> 'a t -> bool
+val compare : ([< any ] as 'a) t -> 'a t -> int
+val hash : [< any ] t -> int
+
+(** Typed constructors *)
+
+val sem_eq : 'a t -> 'a t -> sbool t
+val sem_eq_untyped : 'a t -> 'a t -> [> sbool ] t
+val v_true : [> sbool ] t
+val v_false : [> sbool ] t
+val bool : bool -> [> sbool ] t
+val as_bool : 'a t -> bool option
+val and_ : [< sbool ] t -> [< sbool ] t -> [> sbool ] t
+val conj : [< sbool ] t list -> [> sbool ] t
+val split_ands : [< sbool ] t -> ([> sbool ] t -> unit) -> unit
+val or_ : [< sbool ] t -> [< sbool ] t -> [> sbool ] t
+val not : sbool t -> sbool t
+val distinct : 'a t list -> [> sbool ] t
+val ite : [< sbool ] t -> 'a t -> 'a t -> 'a t
+
+(** Bit vector operations *)
+
+module BitVec : sig
+  (* constructor *)
+  val mk : int -> Z.t -> [> sint ] t
+  val mk_masked : int -> Z.t -> [> sint ] t
+  val mki : int -> int -> [> sint ] t
+  val mki_masked : int -> int -> [> sint ] t
+  val mk_nz : int -> Z.t -> [> nonzero ] t
+  val mki_nz : int -> int -> [> nonzero ] t
+  val zero : int -> [> sint ] t
+  val one : int -> [> nonzero ] t
+  val bv_to_z : bool -> int -> Z.t -> Z.t
+
+  (* arithmetic *)
+  val add : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val sub : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val mul : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val div : signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+  val rem : signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t
+  val mod_ : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val neg : [< sint ] t -> [> sint ] t
+
+  (* overflow checks *)
+  val add_overflows : signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val sub_overflows : signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val mul_overflows : signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val neg_overflows : [< sint ] t -> [> sbool ] t
+
+  (* inequalities *)
+  val lt : signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val leq : signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val gt : signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val geq : signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
+
+  (* bitvec manipulation *)
+  val concat : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val extend : signed:bool -> int -> [< sint ] t -> [> sint ] t
+  val extract : int -> int -> [< sint ] t -> [> sint ] t
+
+  (* bitwise operations *)
+  val and_ : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val or_ : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val xor : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val shl : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val lshr : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ashr : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val not : [< sint ] t -> [> sint ] t
+
+  (* bool-bv conversions *)
+  val of_bool : int -> [< sbool ] t -> [> sint ] t
+  val to_bool : [< sint ] t -> [> sbool ] t
+  val not_bool : [< sint ] t -> [> sint ] t
+
+  (* float-bv conversions *)
+  val of_float : signed:bool -> [< sfloat ] t -> [> sint ] t
+  val to_float : signed:bool -> [< sint ] t -> [> sfloat ] t
+end
+
+(** Floating point operations *)
+
+module Float : sig
+  val mk : Svalue.FloatPrecision.t -> string -> [> sfloat ] t
+  val f16 : float -> [> sfloat ] t
+  val f32 : float -> [> sfloat ] t
+  val f64 : float -> [> sfloat ] t
+  val f128 : float -> [> sfloat ] t
+  val like : [> sfloat ] t -> float -> [> sfloat ] t
+  val fp_of : [< sfloat ] t -> Svalue.FloatPrecision.t
+  val eq : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val geq : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val gt : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val leq : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val lt : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val add : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val sub : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val mul : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val div : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val rem : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val abs : [< sfloat ] t -> [> sfloat ] t
+  val neg : [< sfloat ] t -> [> sfloat ] t
+  val is_normal : [< sfloat ] t -> [> sbool ] t
+  val is_subnormal : [< sfloat ] t -> [> sbool ] t
+  val is_zero : [< sfloat ] t -> [> sbool ] t
+  val is_infinite : [< sfloat ] t -> [> sbool ] t
+  val is_nan : [< sfloat ] t -> [> sbool ] t
+  val round : Svalue.FloatRoundingMode.t -> [< sfloat ] t -> [> sfloat ] t
+end
+
+module Ptr : sig
+  val mk : [< sloc ] t -> [< sint ] t -> [> sptr ] t
+  val loc : [< sptr ] t -> [> sloc ] t
+  val ofs : [< sptr ] t -> [> sint ] t
+  val decompose : [< sptr ] t -> [> sloc ] t * [> sint ] t
+  val add_ofs : [< sptr ] t -> [< sint ] t -> [> sptr ] t
+  val loc_of_int : int -> int -> [> sloc ] t
+  val null : int -> [> sptr ] t
+  val null_loc : int -> [> sloc ] t
+  val is_null_loc : [< sloc ] t -> [> sbool ] t
+  val is_null : [< sptr ] t -> [> sbool ] t
+  val is_at_null_loc : [< sptr ] t -> [> sbool ] t
+end
+
+module SSeq : sig
+  val mk : seq_ty:'a sseq ty -> 'a t list -> [> 'a sseq ] t
+end
+
+module Infix : sig
+  val ( ==@ ) : ([< any ] as 'a) t -> 'a t -> [> sbool ] t
+  val ( ==?@ ) : 'a t -> 'b t -> [> sbool ] t
+  val ( >@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val ( >$@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val ( >=@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val ( >=$@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val ( <@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val ( <$@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val ( <=@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val ( <=$@ ) : [< sint ] t -> [< sint ] t -> [> sbool ] t
+  val ( &&@ ) : [< sbool ] t -> [< sbool ] t -> [> sbool ] t
+  val ( ||@ ) : [< sbool ] t -> [< sbool ] t -> [> sbool ] t
+  val ( +@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ( -@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ( ~- ) : [< sint ] t -> [> sint ] t
+  val ( *@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ( /@ ) : [< sint ] t -> [< nonzero ] t -> [> sint ] t
+  val ( /$@ ) : [< sint ] t -> [< nonzero ] t -> [> sint ] t
+  val ( %@ ) : [< sint ] t -> [< nonzero ] t -> [> sint ] t
+  val ( %$@ ) : [< sint ] t -> [< nonzero ] t -> [> sint ] t
+  val ( <<@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ( >>@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ( >>>@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ( ^@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ( &@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ( |@ ) : [< sint ] t -> [< sint ] t -> [> sint ] t
+  val ( ==.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val ( >.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val ( >=.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val ( <.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val ( <=.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sbool ] t
+  val ( +.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val ( -.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val ( *.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+  val ( /.@ ) : [< sfloat ] t -> [< sfloat ] t -> [> sfloat ] t
+end

--- a/soteria/lib/c_values/encoding.ml
+++ b/soteria/lib/c_values/encoding.ml
@@ -48,11 +48,10 @@ let smt_of_unop : Svalue.Unop.t -> sexp -> sexp = function
   | IntOfBool -> fun b -> ite b (int_k 1) (int_k 0)
   | BvOfInt (_, size) -> bv_of_int size
   | IntOfBv signed -> int_of_bv signed
-  | BvOfFloat n -> bv_of_float n
-  | FloatOfBv F16 -> f16_of_bv
-  | FloatOfBv F32 -> f32_of_bv
-  | FloatOfBv F64 -> f64_of_bv
-  | FloatOfBv F128 -> f128_of_bv
+  | BvOfFloat (true, n) -> sbv_of_float n
+  | BvOfFloat (false, n) -> ubv_of_float n
+  | FloatOfBv (true, fp) -> float_of_sbv (Svalue.FloatPrecision.size fp)
+  | FloatOfBv (false, fp) -> float_of_ubv (Svalue.FloatPrecision.size fp)
   | BvExtract (from_, to_) -> bv_extract to_ from_
   | BvExtend (true, by) -> bv_sign_extend by
   | BvExtend (false, by) -> bv_zero_extend by

--- a/soteria/lib/c_values/eval.ml
+++ b/soteria/lib/c_values/eval.ml
@@ -50,10 +50,10 @@ let eval_unop : Unop.t -> t -> t = function
   | GetPtrLoc -> Ptr.loc
   | GetPtrOfs -> Ptr.ofs
   | IntOfBool -> int_of_bool
-  | BvOfFloat n -> BitVec.of_float n
-  | BvOfInt (s, n) -> BitVec.of_int s n
+  | BvOfFloat (signed, n) -> BitVec.of_float signed n
+  | BvOfInt (signed, n) -> BitVec.of_int signed n
   | IntOfBv signed -> BitVec.to_int signed
-  | FloatOfBv _ -> BitVec.to_float
+  | FloatOfBv (signed, _) -> BitVec.to_float signed
   | BvExtract (from, to_) -> BitVec.Raw.extract from to_
   | BvExtend (signed, by) -> BitVec.Raw.extend signed by
   | BvNot -> BitVec.Raw.not

--- a/soteria/lib/c_values/typed.mli
+++ b/soteria/lib/c_values/typed.mli
@@ -176,8 +176,8 @@ module Float : sig
   val is_infinite : [< sfloat ] t -> [> sbool ] t
   val is_nan : [< sfloat ] t -> [> sbool ] t
   val round : Svalue.FloatRoundingMode.t -> [< sfloat ] t -> [> sfloat ] t
-  val to_int : int -> [< sfloat ] t -> [> sint ] t
-  val of_int : Svalue.FloatPrecision.t -> [< sint ] t -> [> sfloat ] t
+  val to_int : bool -> int -> [< sfloat ] t -> [> sint ] t
+  val of_int : bool -> Svalue.FloatPrecision.t -> [< sint ] t -> [> sfloat ] t
 end
 
 module Ptr : sig

--- a/soteria/lib/solvers/smt_utils.ml
+++ b/soteria/lib/solvers/smt_utils.ml
@@ -8,6 +8,12 @@ module FloatRoundingMode = struct
   [@@deriving eq, show { with_path = false }, ord]
 end
 
+(** [float_shape n] is the shape of a IEEE float of a given size in bits.
+    Returns a two element list [[exp, mant]], where [exp] is the number of
+    exponent bits, and [mant] is the number of mantissa/significand bits. [mant]
+    {b includes the hidden bit} which is always [1], as per SMT-lib's
+    expectations. Always holds that [n = mant + exp]. Only implemented for
+    [n = 16, 32, 64, 128]. *)
 let float_shape = function
   | 16 -> [ 5; 11 ]
   | 32 -> [ 8; 24 ]
@@ -54,7 +60,7 @@ let f16_k f =
   (* a Float16 has 5 exponent bits, 10 explicit mantissa bits *)
   (* we let Z3 handle the conversion *)
   let f32 = f32_k f in
-  let fam = ifam "to_fp" [ 5; 11 ] in
+  let fam = ifam "to_fp" (float_shape 16) in
   app fam [ rm; f32 ]
 
 (* Float ops *)


### PR DESCRIPTION
Add a modules `Bv_values`, that is entirely backed by bitvectors.
I honestly didn't know how to split this lmao; it's originally a copy of `C_values` that I modified to remove integers, and to which i added a lot more bit vector reductions. `Bv_solver` is also just a copy of `C_solver`. 

The only actual relevant file for you is probably `svalue.ml`.

Also while doing this I realised the sign of the integer is relevant when doing float-int conversions so I just added that on the `C_values` side, and patched the interpreters.

Given bitvectors have wrapping and also that there are both signed and unsigned comparison operators, I for now don't port the `Interval` analysis to it; I have it done but I'll push it in a separate PR in case we want to discuss it separately, + i need to evaluate it anyways.