### PR TITLE
Fix small unsoundness

### DIFF
--- a/soteria/lib/symex/solver_result.ml
+++ b/soteria/lib/symex/solver_result.ml
@@ -2,3 +2,12 @@ type t = Sat | Unsat | Unknown
 
 let is_sat = function Sat -> true | Unsat | Unknown -> false
 let is_unsat = function Unsat -> true | Sat | Unknown -> false
+
+let admissible ~(mode : Approx.t) res =
+  match (res, mode) with
+  (* A Sat branch is always taken. If it's unknown and in OX mode,
+     we must take it to avoid dropping potentially valid branches *)
+  | Sat, _ | Unknown, OX -> true
+  (* An Unsat branch is always dropped. If it's unknown and in UX mode,
+     we must drop it to avoid taking potentially invalid branches *)
+  | Unsat, _ | Unknown, UX -> false


### PR DESCRIPTION
Assume doesn't currently emit a sat check (to avoid running a billion sat checks when we assume a lot of stuff during e.g. production.

It does mean we could finish execution with branches that have left-over unchecked path conditions which could be unsat.

Thankfully, we keep track of what part of the state has been sat checked already, so we just have to run one last sat check at the end and for these corner cases it will emit a sat check and for the others it won't