### PR TITLE
Expose structure of serialized state

### DIFF
--- a/soteria-c/lib/ctree_block.ml
+++ b/soteria-c/lib/ctree_block.ml
@@ -191,9 +191,9 @@ let uninit ~range = Tree.make ~node:(Owned (Uninit Totally)) ~range ()
 let mk_fix_typed ofs ty () =
   let* len = Layout.size_of_s ty in
   let+ fixes = mk_fix_typed ty () in
-  List.map (fun v -> [ MemVal { offset = ofs; len; v } ]) fixes
+  List.map (fun v -> [ TB.MemVal { offset = ofs; len; v } ]) fixes
 
-let mk_fix_any ofs len () = [ [ MemVal { offset = ofs; len; v = SAny } ] ]
+let mk_fix_any ofs len () = [ [ TB.MemVal { offset = ofs; len; v = SAny } ] ]
 
 let decode ~ty ~ofs node =
   match node with

--- a/soteria-c/lib/interp.ml
+++ b/soteria-c/lib/interp.ml
@@ -1154,7 +1154,11 @@ module Make (State : State_intf.S) = struct
         With_origin.
           {
             node =
-              Freeable.Alive [ Ctree_block.MemVal { offset; len; v = SZeros } ];
+              Freeable.Alive
+                [
+                  Soteria.Sym_states.Tree_block.MemVal
+                    { offset; len; v = Ctree_block.MemVal.SZeros };
+                ];
             info = None;
           }
       in

--- a/soteria-rust/lib/state_intf.ml
+++ b/soteria-rust/lib/state_intf.ml
@@ -3,6 +3,12 @@ open T
 open Rustsymex
 open Charon
 open Rust_val
+open Soteria.Sym_states
+
+module Template = struct
+  type ('a, 'b) t = { heap : 'a; globals : 'b }
+  [@@deriving show { with_path = false }]
+end
 
 module type S = sig
   module Sptr : Sptr.S
@@ -11,7 +17,14 @@ module type S = sig
 
   (* state *)
   type t
-  type serialized
+
+  type serialized = (serialized_atom list, sloc Typed.t list) Template.t
+
+  and serialized_atom =
+    sloc Typed.t
+    * (Sptr.t Rtree_block.serialized_val, sint Value.t) Tree_block.serialized
+      Freeable.serialized
+
   type 'a err
 
   val add_to_call_trace :
@@ -21,6 +34,15 @@ module type S = sig
 
   (** Prettier but expensive printing. *)
   val pp_pretty : ignore_freed:bool -> t Fmt.t
+
+  val serialize : t -> serialized
+  val pp_serialized : Format.formatter -> serialized -> unit
+
+  val iter_vars_serialized :
+    serialized -> (Svalue.Var.t * [< cval ] Typed.ty -> unit) -> unit
+
+  val subst_serialized :
+    (Svalue.Var.t -> Svalue.Var.t) -> serialized -> serialized
 
   val empty : t
 

--- a/soteria/lib/sym_states/tree_block.ml
+++ b/soteria/lib/sym_states/tree_block.ml
@@ -163,8 +163,6 @@ struct
 
   type nonrec sint = sint Symex.Value.t
 
-  let pp_sint = Symex.Value.ppa
-
   (* re-export the types to be able to use them easily *)
   type nonrec ('a, 'sint) tree = ('a, 'sint) tree = {
     node : 'a node;
@@ -563,8 +561,7 @@ struct
 
   (** Logic *)
 
-  type serialized = (MemVal.serialized, sint) serialized_atom list
-  [@@deriving show { with_path = false }]
+  type nonrec serialized = (MemVal.serialized, sint) serialized
 
   let lift_miss ~offset ~len symex =
     let+? fix = symex in
@@ -645,6 +642,17 @@ struct
       subst_serialized MemVal.subst_serialized Symex.Value.subst
     in
     subst_serialized subst_var serialized
+
+  let pp_serialized_atom ft serialized =
+    let pp_serialized_atom =
+      pp_serialized_atom MemVal.pp_serialized Symex.Value.ppa
+    in
+    match serialized with
+    | Bound bound -> Fmt.pf ft "Bound(%a)" Symex.Value.ppa bound
+    | _ -> pp_serialized_atom ft serialized
+
+  let pp_serialized ft serialized =
+    Fmt.Dump.list pp_serialized_atom ft serialized
 
   let serialize t =
     let bound =


### PR DESCRIPTION
`State_intf` now exposes the definition of the `serialized` type, including global information and the `serialized_atom` type, which are both needed for RUXt. The serialized structures had to be factored out of the corresponding `Make` functor for modules `Freeable`, `Tree_block` and `Rtree_block`.