### PR TITLE
Don't re-expose symex in every abstraction

### DIFF
--- a/soteria-c/lib/ctree_block.ml
+++ b/soteria-c/lib/ctree_block.ml
@@ -9,7 +9,6 @@ module Ctype = Cerb_frontend.Ctype
 
 module MemVal = struct
   module TB = Soteria.Sym_states.Tree_block
-  module Symex = Csymex
 
   module SBoundedInt = struct
     include Typed

--- a/soteria-c/lib/globs.ml
+++ b/soteria-c/lib/globs.ml
@@ -6,15 +6,13 @@ open Csymex.Syntax
 module Sym_map = Concrete_map (Symbol_std)
 
 module Loc = struct
-  module Symex = Csymex
-
   type t = Typed.T.sloc Typed.t
 
   let pp = Typed.ppa
 
   let fresh () =
     let* loc = Csymex.nondet Typed.t_loc in
-    let+ () = Symex.assume [ Typed.not (Typed.Ptr.is_null_loc loc) ] in
+    let+ () = Csymex.assume [ Typed.not (Typed.Ptr.is_null_loc loc) ] in
     loc
 
   let sem_eq = Typed.sem_eq
@@ -22,7 +20,7 @@ module Loc = struct
   let iter_vars = Typed.iter_vars
 end
 
-module GlobFn = Soteria.Sym_states.Pure_fun.Make (Loc)
+module GlobFn = Soteria.Sym_states.Pure_fun.Make (Csymex) (Loc)
 
 type t = GlobFn.t Sym_map.t option [@@deriving show { with_path = false }]
 

--- a/soteria-c/lib/state.ml
+++ b/soteria-c/lib/state.ml
@@ -15,7 +15,6 @@ let add_to_call_trace (err, trace_elem) trace_elem' =
 
 module SPmap = Pmap_direct_access (struct
   include Typed
-  module Symex = Csymex
 
   type t = T.sloc Typed.t
 

--- a/soteria-rust/lib/rtree_block.ml
+++ b/soteria-rust/lib/rtree_block.ml
@@ -17,7 +17,6 @@ module Make (Sptr : Sptr.S) = struct
 
   module MemVal = struct
     module TB = Soteria.Sym_states.Tree_block
-    module Symex = DecayMapMonad
 
     module SBoundedInt = struct
       include Typed
@@ -126,7 +125,7 @@ module Make (Sptr : Sptr.S) = struct
       | SZeros, Owned (Init _, _) -> not_impl "Assume rust_val == 0s"
       | SZeros, _ -> vanish ()
 
-    let produce (s : serialized) (t : tree) : tree Symex.t =
+    let produce (s : serialized) (t : tree) : tree DecayMapMonad.t =
       match (s, t.node) with
       | _, (Owned _ | NotOwned Partially) -> vanish ()
       | SInit v, NotOwned Totally -> return (owned t (Init v))

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -21,7 +21,6 @@ end
 
 module DecayMap : DecayMapS = struct
   module StateKey = struct
-    module Symex = Rustsymex
     include Typed
 
     type t = T.sloc Typed.t

--- a/soteria-rust/lib/state.ml
+++ b/soteria-rust/lib/state.ml
@@ -39,7 +39,6 @@ module Encoder = Encoder.Make (Sptr)
 
 module StateKey = struct
   include Typed
-  module Symex = DecayMapMonad
 
   type t = T.sloc Typed.t
 

--- a/soteria/lib/sym_states/plist.ml
+++ b/soteria/lib/sym_states/plist.ml
@@ -1,29 +1,28 @@
 open Symex
 open Compo_res
 
-module type SInt_sig = sig
-  (** Symbolic integers *)
+module SInt_sig (Symex : Symex.Base) = struct
+  module type S = sig
+    (** Symbolic integers *)
+    open Symex
 
-  module Symex : Symex.Base
-  open Symex
+    type t
 
-  type t
+    include Stdlib.Map.OrderedType with type t := t
 
-  include Stdlib.Map.OrderedType with type t := t
+    type sbool_v := Value.sbool Value.t
 
-  type sbool_v := Value.sbool Value.t
-
-  val pp : Format.formatter -> t -> unit
-  val sem_eq : t -> t -> sbool_v
-  val of_int : int -> t
-  val in_range : t -> t * t -> sbool_v
-  val greater_or_equal : t -> t -> sbool_v
-  val subst : (Var.t -> Var.t) -> t -> t
-  val iter_vars : t -> (Var.t * 'a Value.ty -> unit) -> unit
+    val pp : Format.formatter -> t -> unit
+    val sem_eq : t -> t -> sbool_v
+    val of_int : int -> t
+    val in_range : t -> t * t -> sbool_v
+    val greater_or_equal : t -> t -> sbool_v
+    val subst : (Var.t -> Var.t) -> t -> t
+    val iter_vars : t -> (Var.t * 'a Value.ty -> unit) -> unit
+  end
 end
 
-module Make (Symex : Symex.Base) (SInt : SInt_sig with module Symex = Symex) =
-struct
+module Make (Symex : Symex.Base) (SInt : SInt_sig(Symex).S) = struct
   open Symex.Syntax
   open Symex
   module M = Stdlib.Map.Make (SInt)

--- a/soteria/lib/sym_states/pure_fun.ml
+++ b/soteria/lib/sym_states/pure_fun.ml
@@ -6,19 +6,19 @@
 
 open Symex
 
-module type Codom = sig
-  module Symex : Symex.Base
+module Codom (Symex : Symex.Base) = struct
+  module type S = sig
+    type t
 
-  type t
-
-  val pp : Format.formatter -> t -> unit
-  val fresh : unit -> t Symex.t
-  val sem_eq : t -> t -> Symex.Value.sbool Symex.Value.t
-  val subst : (Var.t -> Var.t) -> t -> t
-  val iter_vars : t -> 'a Symex.Value.ty Var.iter_vars
+    val pp : Format.formatter -> t -> unit
+    val fresh : unit -> t Symex.t
+    val sem_eq : t -> t -> Symex.Value.sbool Symex.Value.t
+    val subst : (Var.t -> Var.t) -> t -> t
+    val iter_vars : t -> 'a Symex.Value.ty Var.iter_vars
+  end
 end
 
-module Make (C : Codom) = struct
+module Make (Symex : Symex.Base) (C : Codom(Symex).S) = struct
   open C
   open Symex.Syntax
 


### PR DESCRIPTION
I realised instead of having functors of the form:
```ocaml
module Make (Symex: Symex.Base) (Param: ParamS with module Symex = Symex)
```
we could just make the `ParamS` signatures parametric on Symex directly.

I find this much nicer, and I believe this will make the abstraction PR much nicer as it'll be much easier to just re-use existing bits.