### PR TITLE
Fix Makefile for OCaml 5.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+OCAML_VERSION=5.4.0
 OPAM=opam
 OPAMX=$(OPAM) exec --
 DUNE=$(OPAMX) dune
@@ -53,7 +54,7 @@ packaging/macOS_dylibs.txt:
 
 .PHONY: switch
 switch:
-	$(OPAM) switch create . ocaml-base-compiler.5.3.0 --deps-only --with-test --with-doc -y
+	$(OPAM) switch create . ocaml-base-compiler.$(OCAML_VERSION) --deps-only --with-test --with-doc -y
 	$(OPAM) install ocaml-lsp-server odig ocamlformat -y
 
 .PHONY: ocaml-deps


### PR DESCRIPTION
Oops

Is there a way of syncing some `.env`/config file between the GitHub CI and other parts of the repo? There's a bunch of files that have version configuration and it's annoying to update:
- OCaml version, which is hardcoded in: `ci.yml`, `Makefile`, `dune-project`
- ocamlformat version, in `Makefile`, `dune-project`, `.ocamlformat`
- Charon version, which is hardcoded in: `ci.yml`, `soteria-rust.opam`, `soteria-rust.opam.template`
- Obol version, which is hardcoded in `ci.yml` and must be "in sync" with the Charon version