### PR TITLE
Fix off-by-one column in Rust diagnostic printing

### DIFF
--- a/soteria-rust/lib/frontend.ml
+++ b/soteria-rust/lib/frontend.ml
@@ -527,7 +527,7 @@ let parse_ullbc_of_crate crate_dir =
 let compile_all_plugins () = List.iter Lib.compile [ Std; Kani; Miri ]
 
 module Diagnostic = struct
-  let to_loc (pos : Charon.Meta.loc) = (pos.line - 1, pos.col)
+  let to_loc (pos : Charon.Meta.loc) = (pos.line - 1, pos.col - 1)
 
   let as_ranges (span : Charon.Meta.span_data) =
     match span.file.name with

--- a/soteria-rust/test/cram/kani.t/run.t
+++ b/soteria-rust/test/cram/kani.t/run.t
@@ -30,54 +30,54 @@ Test kani::assert
   Compiling... done in <time>
   error: assert_false: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion: Expected true! in assert_false
-      ┌─ $TESTCASE_ROOT/assert.rs:4:6
+      ┌─ $TESTCASE_ROOT/assert.rs:4:5
     2 │  fn assert_false() {
-      │   ----------------- 1: Entry point
+      │  ----------------- 1: Entry point
     3 │      let b: bool = kani::any();
     4 │      kani::assert(b, "Expected true!");
-      │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │       │
-      │       Triggering operation
-      │       2: Call trace
+      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │      │
+      │      Triggering operation
+      │      2: Call trace
   PC 1: (V|1| == 0x00) /\ (V|1| == 0x00)
   
   error: fancy_assert_false: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion: 👻 unicode is 𝒮𝒞𝒜ℛ𝒴 in fancy_assert_false
-      ┌─ $TESTCASE_ROOT/assert.rs:10:6
+      ┌─ $TESTCASE_ROOT/assert.rs:10:5
     8 │  fn fancy_assert_false() {
-      │   ----------------------- 1: Entry point
+      │  ----------------------- 1: Entry point
     9 │      let b: bool = kani::any();
    10 │      kani::assert(b, "👻 unicode is 𝒮𝒞𝒜ℛ𝒴");
-      │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │       │
-      │       Triggering operation
-      │       2: Call trace
+      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │      │
+      │      Triggering operation
+      │      2: Call trace
   PC 1: (V|1| == 0x00) /\ (V|1| == 0x00)
   
   error: override_assert_macro: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion: I used "assert!" in override_assert_macro
-      ┌─ $SOTERIA-RUST/std/src/lib.rs:23:10
+      ┌─ $SOTERIA-RUST/std/src/lib.rs:23:9
    23 │          rusteria::assert(!!$cond, concat!(stringify!($($arg)+)));
-      │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │           │
-      │           Triggering operation
-      │           2: Call trace
-      ┌─ $TESTCASE_ROOT/assert.rs:14:2
+      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │          │
+      │          Triggering operation
+      │          2: Call trace
+      ┌─ $TESTCASE_ROOT/assert.rs:14:1
    14 │  fn override_assert_macro() {
-      │   -------------------------- 1: Entry point
+      │  -------------------------- 1: Entry point
   PC 1: (V|1| == 0x00) /\ (V|1| == 0x00)
   
   error: override_asserteq_macro: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion: I used "assert_eq!" in override_asserteq_macro
-      ┌─ $SOTERIA-RUST/std/src/lib.rs:23:10
+      ┌─ $SOTERIA-RUST/std/src/lib.rs:23:9
    23 │          rusteria::assert(!!$cond, concat!(stringify!($($arg)+)));
-      │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │           │
-      │           Triggering operation
-      │           2: Call trace
-      ┌─ $TESTCASE_ROOT/assert.rs:20:2
+      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │          │
+      │          Triggering operation
+      │          2: Call trace
+      ┌─ $TESTCASE_ROOT/assert.rs:20:1
    20 │  fn override_asserteq_macro() {
-      │   ---------------------------- 1: Entry point
+      │  ---------------------------- 1: Entry point
   PC 1: (V|1| != V|2|)
   
   [1]
@@ -162,13 +162,13 @@ Test our simple Kani demo works
   Compiling... done in <time>
   error: saturating_add_overflow: found issues in <time>, errors in 1 branch (out of 3)
   error: Overflow in saturating_add_overflow
-      ┌─ $TESTCASE_ROOT/demo.rs:11:9
+      ┌─ $TESTCASE_ROOT/demo.rs:11:8
     8 │  fn saturating_add_overflow() -> u32 {
-      │   ----------------------------------- 1: Entry point
+      │  ----------------------------------- 1: Entry point
     9 │      let a: u32 = kani::any();
    10 │      let b: u32 = kani::any();
    11 │      if a + b < u32::MAX {
-      │          ^^^^^ Triggering operation
+      │         ^^^^^ Triggering operation
   PC 1: (V|1| +u_ovf V|2|)
   
   note: saturating_add: done in <time>, ran 2 branches
@@ -177,26 +177,26 @@ Test our simple Kani demo works
   
   error: memory_leak: found issues in <time>, errors in 1 branch (out of 1)
   warning: Memory leak at ../alloc/src/alloc.rs:<range> in memory_leak
-      ┌─ $TESTCASE_ROOT/demo.rs:32:2
+      ┌─ $TESTCASE_ROOT/demo.rs:32:1
    32 │  fn memory_leak() {
-      │   ^^^^^^^^^^^^^^^^
-      │   │
-      │   Leaking function
-      │   1: Entry point
+      │  ^^^^^^^^^^^^^^^^
+      │  │
+      │  Leaking function
+      │  1: Entry point
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (extract[0-1](V|1|) == 0b00)
   
   error: uninit_access: found issues in <time>, errors in 1 branch (out of 2)
   bug: Uninitialized memory access in uninit_access
-      ┌─ $TESTCASE_ROOT/demo.rs:63:27
+      ┌─ $TESTCASE_ROOT/demo.rs:63:26
    58 │  fn uninit_access() {
-      │   ------------------ 1: Entry point
+      │  ------------------ 1: Entry point
    59 │      let any_option: MyOption<u32> = kani::any();
    60 │      let addr: *const u32 = &any_option as *const MyOption<u32> as *const u32;
    61 │      unsafe {
    62 │          let addr_value = addr.offset(1);
    63 │          let value: u32 = *addr_value;
-      │                            ^^^^^^^^^^^ Memory load
+      │                           ^^^^^^^^^^^ Memory load
   PC 1: (0x00 == V|1|) /\ (0x00 == V|1|)
   
   [1]

--- a/soteria-rust/test/cram/poly.t/run.t
+++ b/soteria-rust/test/cram/poly.t/run.t
@@ -36,20 +36,19 @@ Try creating a generic vec
   
   error: vec::with_vec_wrong: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion: assertion failed: my_vec.capacity() == 10 in vec::with_vec_wrong
-      ┌─ $SOTERIA-RUST/std/src/lib.rs:20:9
+      ┌─ $SOTERIA-RUST/std/src/lib.rs:20:8
    20 │            rusteria::assert(!!$cond, concat!("assertion failed: ", stringify!($cond)));
-      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │            │
-      │            Triggering operation
-      │            2: Call trace
+      │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │           │
+      │           Triggering operation
+      │           2: Call trace
       ┌─ $TESTCASE_ROOT/vec.rs:14:1
    13 │    #[rusteria::test]
    14 │ ╭  fn with_vec_wrong<T>() {
    15 │ │      let my_vec: Vec<T> = Vec::with_capacity(10);
    16 │ │      assert!(my_vec.capacity() == 10);
-   17 │ │  }
-      │ ╰──' 1: Entry point
-   18 │    
+      │ ╰───────────────────────────────────────' 1: Entry point
+   17 │    }
   PC 1: (0x0000000000000000 == V|1|) /\ (V|2| <=u 0x00000000000003ff) /\
         (0x0000000000000000 == V|1|)
   

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -3,12 +3,12 @@ Test memory leaks
   Compiling... done in <time>
   error: main: found issues in <time>, errors in 1 branch (out of 1)
   warning: Memory leak at ../alloc/src/alloc.rs:<range> in main
-      ┌─ $TESTCASE_ROOT/leak.rs:1:2
+      ┌─ $TESTCASE_ROOT/leak.rs:1:1
     1 │  fn main() {
-      │   ^^^^^^^^^
-      │   │
-      │   Leaking function
-      │   1: Entry point
+      │  ^^^^^^^^^
+      │  │
+      │  Leaking function
+      │  1: Entry point
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (extract[0-1](V|1|) == 0b00)
   
@@ -37,15 +37,15 @@ Test unwinding, and catching that unwind; we need to ignore leaks as this uses a
   Compiling... done in <time>
   error: main: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion: assertion failed: result.is_err() in main
-      ┌─ $SOTERIA-RUST/std/src/lib.rs:20:10
+      ┌─ $SOTERIA-RUST/std/src/lib.rs:20:9
    20 │          rusteria::assert(!!$cond, concat!("assertion failed: ", stringify!($cond)));
-      │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │           │
-      │           Triggering operation
-      │           2: Call trace
-      ┌─ $TESTCASE_ROOT/unwind.rs:1:2
+      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │          │
+      │          Triggering operation
+      │          2: Call trace
+      ┌─ $TESTCASE_ROOT/unwind.rs:1:1
     1 │  fn main() {
-      │   --------- 1: Entry point
+      │  --------- 1: Entry point
   PC 1: (0x00 == V|1|) /\ (0x00 == V|1|)
   
   [1]
@@ -67,26 +67,26 @@ Test function calls on function pointers
   
   error: fn_ptr_read: found issues in <time>, errors in 1 branch (out of 1)
   bug: Accessed function pointer's pointee in fn_ptr_read
-      ┌─ $TESTCASE_ROOT/fn_ptr.rs:25:19
+      ┌─ $TESTCASE_ROOT/fn_ptr.rs:25:18
    21 │  fn fn_ptr_read() {
-      │   ---------------- 1: Entry point
+      │  ---------------- 1: Entry point
    22 │      let add: fn(u8, u8) -> u8 = add;
    23 │      let ptr = add as *const u8;
    24 │      unsafe {
    25 │          let _b = *ptr;
-      │                    ^^^^ Memory load
+      │                   ^^^^ Memory load
   PC 1: empty
   
   error: fn_ptr_write: found issues in <time>, errors in 1 branch (out of 1)
   bug: Accessed function pointer's pointee in fn_ptr_write
-      ┌─ $TESTCASE_ROOT/fn_ptr.rs:34:10
+      ┌─ $TESTCASE_ROOT/fn_ptr.rs:34:9
    30 │  fn fn_ptr_write() {
-      │   ----------------- 1: Entry point
+      │  ----------------- 1: Entry point
    31 │      let add: fn(u8, u8) -> u8 = add;
    32 │      let ptr = add as *mut u8;
    33 │      unsafe {
    34 │          *ptr = 0;
-      │           ^^^^^^^^ Memory store
+      │          ^^^^^^^^ Memory store
   PC 1: empty
   
   [1]
@@ -96,17 +96,17 @@ Check strict provenance disables int to ptr casts
   Compiling... done in <time>
   error: main: found issues in <time>, errors in 1 branch (out of 1)
   bug: Attempted ot cast integer to pointer with strict provenance in main
-      ┌─ $RUSTLIB/src/rust/library/core/src/ptr/mod.rs:986:6
+      ┌─ $RUSTLIB/src/rust/library/core/src/ptr/mod.rs:986:5
   986 │      addr as *const T
-      │       ^^^^^^^^^^^^^^^ Casting integer to pointer
-      ┌─ $TESTCASE_ROOT/provenance.rs:5:19
+      │      ^^^^^^^^^^^^^^^^ Casting integer to pointer
+      ┌─ $TESTCASE_ROOT/provenance.rs:5:18
     1 │  fn main() {
-      │   --------- 1: Entry point
+      │  --------- 1: Entry point
     2 │      let mut x: u8 = 0;
     3 │      let p = &mut x as *mut u8;
     4 │      let p_int = p.expose_provenance();
     5 │      let p_back = std::ptr::with_exposed_provenance::<u8>(p_int) as *mut u8;
-      │                    ---------------------------------------------- 2: Call trace
+      │                   ---------------------------------------------- 2: Call trace
   PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd)
   
   [1]
@@ -116,16 +116,16 @@ Check permissive provenance allows int to ptr casts
   Compiling... done in <time>
   error: main: found issues in <time>, errors in 1 branch (out of 1)
   bug: UB: dangling pointer in main
-      ┌─ $TESTCASE_ROOT/provenance.rs:7:10
+      ┌─ $TESTCASE_ROOT/provenance.rs:7:9
     1 │  fn main() {
-      │   --------- 1: Entry point
+      │  --------- 1: Entry point
     2 │      let mut x: u8 = 0;
     3 │      let p = &mut x as *mut u8;
     4 │      let p_int = p.expose_provenance();
     5 │      let p_back = std::ptr::with_exposed_provenance::<u8>(p_int) as *mut u8;
     6 │      unsafe {
     7 │          *p_back = 1;
-      │           ^^^^^^^^^^^ Memory store
+      │          ^^^^^^^^^^^ Memory store
   PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd)
   
   [1]
@@ -135,9 +135,9 @@ Check corner cases with permissive provenance, around transmutes
   Compiling... done in <time>
   error: addr_doesnt_expose: found issues in <time>, errors in 1 branch (out of 1)
   bug: UB: dangling pointer in addr_doesnt_expose
-      ┌─ $TESTCASE_ROOT/provenance_transmute.rs:9:10
+      ┌─ $TESTCASE_ROOT/provenance_transmute.rs:9:9
     2 │  fn addr_doesnt_expose() {
-      │   ----------------------- 1: Entry point
+      │  ----------------------- 1: Entry point
     3 │      let mut x: u8 = 0;
     4 │      let p = &mut x as *mut u8;
     5 │      let p_int = p.addr();
@@ -145,14 +145,14 @@ Check corner cases with permissive provenance, around transmutes
     7 │      let p_back = std::ptr::with_exposed_provenance::<u8>(p_int) as *mut u8;
     8 │      unsafe {
     9 │          *p_back = 1;
-      │           ^^^^^^^^^^^ Memory store
+      │          ^^^^^^^^^^^ Memory store
   PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd)
   
   error: transmute_doesnt_restore_provenance: found issues in <time>, errors in 1 branch (out of 1)
   bug: UB: dangling pointer in transmute_doesnt_restore_provenance
-      ┌─ $TESTCASE_ROOT/provenance_transmute.rs:22:10
+      ┌─ $TESTCASE_ROOT/provenance_transmute.rs:22:9
    15 │  fn transmute_doesnt_restore_provenance() {
-      │   ---------------------------------------- 1: Entry point
+      │  ---------------------------------------- 1: Entry point
    16 │      let mut x: u8 = 0;
    17 │      let p = &mut x as *mut u8;
    18 │      let p_int = p.expose_provenance();
@@ -160,7 +160,7 @@ Check corner cases with permissive provenance, around transmutes
    20 │      let p_back = unsafe { std::mem::transmute::<usize, *mut u8>(p_int) };
    21 │      unsafe {
    22 │          *p_back = 1;
-      │           ^^^^^^^^^^^ Memory store
+      │          ^^^^^^^^^^^ Memory store
   PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd)
   
   [1]
@@ -190,22 +190,22 @@ Test null and dangling pointers
   
   error: null_ptr_not_zst: found issues in <time>, errors in 1 branch (out of 1)
   error: Null dereference in null_ptr_not_zst
-      ┌─ $TESTCASE_ROOT/dangling_ptrs.rs:11:31
+      ┌─ $TESTCASE_ROOT/dangling_ptrs.rs:11:30
     9 │  fn null_ptr_not_zst() {
-      │   --------------------- 1: Entry point
+      │  --------------------- 1: Entry point
    10 │      let ptr: *const u32 = std::ptr::null();
    11 │      let _val: u32 = unsafe { *ptr };
-      │                                ^^^^ Memory load
+      │                               ^^^^ Memory load
   PC 1: empty
   
   error: dangling_ptr_not_zst: found issues in <time>, errors in 1 branch (out of 1)
   bug: UB: dangling pointer in dangling_ptr_not_zst
-      ┌─ $TESTCASE_ROOT/dangling_ptrs.rs:17:30
+      ┌─ $TESTCASE_ROOT/dangling_ptrs.rs:17:29
    15 │  fn dangling_ptr_not_zst() {
-      │   ------------------------- 1: Entry point
+      │  ------------------------- 1: Entry point
    16 │      let ptr: *const u8 = 0xdeadbeef as *const u8;
    17 │      let _val: u8 = unsafe { *ptr };
-      │                               ^^^^ Memory load
+      │                              ^^^^ Memory load
   PC 1: empty
   
   [1]
@@ -241,15 +241,15 @@ Test cloning ZSTs works; in particular, this generates a function with an empty 
   Compiling... done in <time>
   error: main: found an issue in <time> after exploring 1 branch -- stopped immediately (fail-fast)
   error: Panic: ok in main
-      ┌─ $SOTERIA-RUST/std/src/lib.rs:103:10
+      ┌─ $SOTERIA-RUST/std/src/lib.rs:103:9
   103 │          rusteria::panic(concat!($msg))
-      │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │           │
-      │           Triggering operation
-      │           2: Call trace
-      ┌─ $TESTCASE_ROOT/fail_fast.rs:1:2
+      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │          │
+      │          Triggering operation
+      │          2: Call trace
+      ┌─ $TESTCASE_ROOT/fail_fast.rs:1:1
     1 │  fn main() {
-      │   --------- 1: Entry point
+      │  --------- 1: Entry point
   PC 1: (V|1| == 0x01) /\ (V|1| == 0x01)
   
   [1]

--- a/soteria-rust/test/cram/treeborrow.t/run.t
+++ b/soteria-rust/test/cram/treeborrow.t/run.t
@@ -10,15 +10,15 @@ Simple tree borrow violation
   Compiling... done in <time>
   error: main: found issues in <time>, errors in 1 branch (out of 1)
   bug: Aliasing error in main
-      ┌─ $TESTCASE_ROOT/simple-fail.rs:8:6
+      ┌─ $TESTCASE_ROOT/simple-fail.rs:8:5
     3 │  fn main() {
-      │   --------- 1: Entry point
+      │  --------- 1: Entry point
     4 │      let mut root = 42;
     5 │      let ptr = &mut root as *mut i32;
     6 │      let (x, y) = unsafe { (&mut *ptr, &mut *ptr) };
     7 │      *x = 13;
     8 │      *y = 20; // UB: y is disabled
-      │       ^^^^^^^ Memory store
+      │      ^^^^^^^ Memory store
   PC 1: empty
   
   [1]


### PR DESCRIPTION
This seems to indeed improve things, except in `soteria-rust/test/cram/poly.t/run.t` where one of the errors seem to be all over the place now...