### PR TITLE
Add `[%l.debug ...]` PPX for logging

### DIFF
--- a/soteria-c/lib/abductor.ml
+++ b/soteria-c/lib/abductor.ml
@@ -19,13 +19,13 @@ let generate_summaries_for (fundef : fundef) =
     "Generate summaries for " ^ Cerb_frontend.Symbol.show_symbol fid
   in
   let@ () = L.with_section section_name in
-  L.info (fun m -> m "%s" section_name);
+  [%l.info "%s" section_name];
   let* arg_tys =
     match Ail_helpers.get_param_tys fid with
     | None ->
-        L.info (fun m ->
-            m "No argument types found for %a at loc %a" Fmt_ail.pp_sym fid
-              Fmt_ail.pp_loc floc);
+        [%l.info
+          "No argument types found for %a at loc %a" Fmt_ail.pp_sym fid
+            Fmt_ail.pp_loc floc];
         []
     | Some arg_tys -> [ arg_tys ]
   in
@@ -47,13 +47,13 @@ let generate_summaries_for (fundef : fundef) =
   let ret = Result.map Aggregate_val.to_syn ret in
   let pc = List.map Typed.Expr.of_value pc in
   let@ () = L.with_section "Building summary" in
-  L.trace (fun m ->
-      m "@[<2>Building summary for %a using bistate:@ %a@]" Fmt_ail.pp_sym fid
-        (Fmt.Dump.option Bi_state.pp)
-        bi_state);
+  [%l.trace
+    "@[<2>Building summary for %a using bistate:@ %a@]" Fmt_ail.pp_sym fid
+      (Fmt.Dump.option Bi_state.pp)
+      bi_state];
   let ~pre, ~post = Bi_state.to_spec bi_state in
   let ret = Summary.make ~args ~ret ~pre ~post ~pc () in
-  L.trace (fun m -> m "Obtained summary: %a" Summary.pp ret);
+  [%l.trace "Obtained summary: %a" Summary.pp ret];
   ret
 
 let generate_all_summaries ~functions_to_analyse prog =

--- a/soteria-c/lib/ail_linking.ml
+++ b/soteria-c/lib/ail_linking.ml
@@ -224,7 +224,7 @@ let link_main opt_m1 opt_m2 =
       if (Config.current ()).no_ignore_duplicate_symbols then
         Error "linking: multiple main functions"
       else (
-        L.info (fun m -> m "Detecting several main functions. ");
+        [%l.info "Detecting several main functions."];
         Ok m1)
   | (Some _ as m), None | None, (Some _ as m) -> Ok m
   | None, None -> Ok None

--- a/soteria-c/lib/ctree_block.ml
+++ b/soteria-c/lib/ctree_block.ml
@@ -80,7 +80,7 @@ module MemVal = struct
   let decode ~ty t : ([> T.sint ] Typed.t, 'err, 'fix) Csymex.Result.t =
     match t with
     | Uninit _ ->
-        L.trace (fun m -> m "Uninitialized Memory Access detected!");
+        [%l.trace "Uninitialized Memory Access detected!"];
         Result.error `UninitializedMemoryAccess
     | Zeros -> (
         match ty with
@@ -158,14 +158,14 @@ module MemVal = struct
             not_owned t
         | Missing f -> miss f
         | Error `UninitializedMemoryAccess ->
-            L.info (fun m -> m "Consuming a value from uninit, logical failure");
+            [%l.info "Consuming a value from uninit, logical failure"];
             lfail Typed.v_false)
     (* any *)
     | SAny, Owned _ -> ok (not_owned t)
     (* uninit *)
     | SUninit, Owned (Uninit Totally) -> ok (not_owned t)
     | SUninit, _ ->
-        L.info (fun m -> m "Consuming uninit but no uninit, logical failure");
+        [%l.info "Consuming uninit but no uninit, logical failure"];
         lfail Typed.v_false
     (* zeros *)
     | SZeros, Owned Zeros -> ok (not_owned t)
@@ -180,7 +180,7 @@ module MemVal = struct
         let+ () = learn_eq zero v in
         not_owned t
     | SZeros, _ ->
-        L.info (fun m -> m "Consuming zero but not zero, logical failure");
+        [%l.info "Consuming zero but not zero, logical failure"];
         lfail Typed.v_false
 
   let produce (s : syn) (t : tree) : tree Producer.t =
@@ -202,8 +202,7 @@ open MemVal
 include Tree_block (MemVal)
 
 let log_fixes fixes =
-  L.trace (fun m ->
-      m "MISSING WITH FIXES: %a" Fmt.Dump.(list @@ list pp_syn) fixes);
+  [%l.trace "MISSING WITH FIXES: %a" Fmt.Dump.(list @@ list pp_syn) fixes];
   fixes
 
 let range_of_low_and_type low ty =

--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -55,16 +55,16 @@ let io : Cerb_backend.Pipeline.io_helpers =
     return ()
   in
   let print_endline str =
-    L.debug (fun m -> m "%s" str);
+    [%l.debug "%s" str];
     return ()
   in
   let print_debug n mk_str =
     (* Cerb_debug.print_debug n [] mk_str; *)
-    if n == 0 then L.debug (fun m -> m "%s" (mk_str ()));
+    if n == 0 then [%l.debug "%s" (mk_str ())];
     return ()
   in
   let warn ?always:_ mk_str =
-    L.warn (fun m -> m "%s" (mk_str ()));
+    [%l.warn "%s" (mk_str ())];
     return ()
   in
   { pass_message; set_progress; run_pp; print_endline; print_debug; warn }
@@ -146,7 +146,7 @@ module Frontend = struct
   let frontend = lazy (init ())
 
   let frontend ?cwd ~cpp_cmd filename =
-    L.debug (fun m -> m "Parsing %s" filename);
+    [%l.debug "Parsing %s" filename];
     try
       let cerb_res =
         match cwd with
@@ -165,7 +165,7 @@ module Frontend = struct
   let simple_frontend ~includes filename =
     let cmd = "cc" :: List.map (fun s -> "-I" ^ s) includes in
     let cpp_cmd = String.concat " " cmd in
-    L.trace (fun m -> m "Cpp_cmd: %s" cpp_cmd);
+    [%l.trace "Cpp_cmd: %s" cpp_cmd];
     frontend ~cpp_cmd filename
 end
 
@@ -255,8 +255,7 @@ let exec_function ~includes ~fuel file_names function_name =
         let@@ () = StateM.Result.run_with_state ~state:SState.empty in
         let** () = Wpst_interp.init_prog_state linked in
         let* state = StateM.get_state () in
-        L.debug (fun m ->
-            m "@[<2>Initial state:@ %a@]" (Fmt.Dump.option SState.pp) state);
+        [%l.debug "@[<2>Initial state:@ %a@]" (Fmt.Dump.option SState.pp) state];
         Wpst_interp.exec_fun entry_point ~args:[]
       in
       let@ () = with_function_context linked in
@@ -513,9 +512,9 @@ let linked_prog_of_db json_file =
             match parse_and_signal item with
             | Ok ail -> Some (ail, item)
             | Error (`ParsingError msg, _loc) ->
-                L.debug (fun m ->
-                    m "Ignoring file that did not parse correctly: %s@\n%s"
-                      item.file msg);
+                [%l.debug
+                  "Ignoring file that did not parse correctly: %s@\n%s"
+                    item.file msg];
                 None)
           db
       in

--- a/soteria-c/lib/interp.ml
+++ b/soteria-c/lib/interp.ml
@@ -230,8 +230,7 @@ module Make (State : State_intf.S) = struct
   let mk_store params =
     ListLabels.fold_left params ~init:Store.empty
       ~f:(fun store (pname, ty, value) ->
-        L.trace (fun m ->
-            m "Putting variable to the store: %a" Fmt_ail.pp_sym pname);
+        [%l.trace "Putting variable to the store: %a" Fmt_ail.pp_sym pname];
         Store.add_value pname value ty store)
 
   let dealloc_store () : unit InterpM.t =
@@ -265,7 +264,7 @@ module Make (State : State_intf.S) = struct
         let* binding = IStore.find_opt id in
         match binding with
         | Some { kind = Value v; _ } ->
-            L.trace (fun m -> m "Immediate load: %a" Agv.pp v);
+            [%l.trace "Immediate load: %a" Agv.pp v];
             ok (Some v)
         | Some { kind = Uninit; _ } -> InterpM.error `UninitializedMemoryAccess
         | _ -> ok None)
@@ -278,7 +277,7 @@ module Make (State : State_intf.S) = struct
     match lvalue with
     | AilEident id -> (
         let id = Ail_helpers.resolve_sym id in
-        L.trace (fun m -> m "Trying immediate store at %a" Fmt_ail.pp_sym id);
+        [%l.trace "Trying immediate store at %a" Fmt_ail.pp_sym id];
         let* binding = IStore.find_opt id in
         match binding with
         | Some { kind = Value _ | Uninit; ty } ->
@@ -699,10 +698,9 @@ module Make (State : State_intf.S) = struct
           ok (loc, fname)
       | _ ->
           (* Some function pointer *)
-          L.trace (fun m ->
-              m "Resolving function pointer: %a" Fmt_ail.pp_expr fexpr);
+          [%l.trace "Resolving function pointer: %a" Fmt_ail.pp_expr fexpr];
           let* fptr = eval_expr fexpr in
-          L.trace (fun m -> m "Function pointer is value: %a" Agv.pp fptr);
+          [%l.trace "Function pointer is value: %a" Agv.pp fptr];
           let*^ fptr = cast_aggregate_to_ptr fptr in
           let* () =
             assert_or_error
@@ -758,7 +756,7 @@ module Make (State : State_intf.S) = struct
           @@ lift_state_op
           @@ exec_fun ~args
         in
-        L.debug (fun m -> m "returned %a from %a" Agv.pp v Fmt_ail.pp_expr f);
+        [%l.debug "returned %a from %a" Agv.pp v Fmt_ail.pp_expr f];
         v
     | AilEunary (Address, e) -> (
         match unwrap_expr e with
@@ -1106,7 +1104,7 @@ module Make (State : State_intf.S) = struct
   and exec_body ~ret_ty (body : stmt) : Agv.t InterpM.t =
     let open Stmt_exec_result in
     let rec aux res =
-      L.trace (fun m -> m "Body execution result: %a" Stmt_exec_result.pp res);
+      [%l.trace "Body execution result: %a" Stmt_exec_result.pp res];
       match res with
       | Returned (v, old_ty) -> (
           match ret_ty with
@@ -1116,8 +1114,7 @@ module Make (State : State_intf.S) = struct
           (* Function didn't return, we return void (encoded as 0) *)
           InterpM.ok Agv.void
       | Goto label ->
-          L.trace (fun m ->
-              m "Body terminated with Goto %a" Fmt_ail.pp_sym label);
+          [%l.trace "Body terminated with Goto %a" Fmt_ail.pp_sym label];
           let* res = exec_goto label body in
           aux res
       | Break | Continue | Case _ ->
@@ -1143,9 +1140,9 @@ module Make (State : State_intf.S) = struct
 
   and exec_goto (label : sym) (astmt : stmt) : Stmt_exec_result.t InterpM.t =
     let open Stmt_exec_result in
-    L.trace (fun m ->
-        m "Trying to find label %a, currently at %a" Fmt_ail.pp_sym label
-          Fmt_ail.pp_stmt astmt);
+    [%l.trace
+      "Trying to find label %a, currently at %a" Fmt_ail.pp_sym label
+        Fmt_ail.pp_stmt astmt];
     let AilSyntax.{ node = stmt; _ } = astmt in
     match stmt with
     | AilSlabel (label', stmt, _annot) when Symbol_std.equal label label' ->
@@ -1186,9 +1183,9 @@ module Make (State : State_intf.S) = struct
       if guard != guard' then failwith "Returned a different case?"
     in
     let open Stmt_exec_result in
-    L.trace (fun m ->
-        m "Trying to find case corresponding to guard %a, currently at %a"
-          Typed.ppa guard Fmt_ail.pp_stmt astmt);
+    [%l.trace
+      "Trying to find case corresponding to guard %a, currently at %a" Typed.ppa
+        guard Fmt_ail.pp_stmt astmt];
     let AilSyntax.{ node = stmt; _ } = astmt in
     match stmt with
     | AilScase (case, stmt) ->
@@ -1242,10 +1239,10 @@ module Make (State : State_intf.S) = struct
     let open Stmt_exec_result in
     let exec_stmt = exec_stmt in
     let*^ () = Csymex.consume_fuel_steps 1 in
-    L.debug (fun m -> m "Executing statement: %a" Fmt_ail.pp_stmt astmt);
+    [%l.debug "Executing statement: %a" Fmt_ail.pp_stmt astmt];
     let* () =
       let+ store = get_store () in
-      L.debug (fun m -> m "@[<v 2>STORE:@ %a@]" Store.pp store)
+      [%l.debug "@[<v 2>STORE:@ %a@]" Store.pp store]
     in
     let AilSyntax.{ loc; node = stmt; _ } = astmt in
     let@@ () = with_loc ~loc in
@@ -1253,7 +1250,7 @@ module Make (State : State_intf.S) = struct
     | AilSskip -> ok Normal
     | AilSreturn e ->
         let+ v = eval_expr e in
-        L.debug (fun m -> m "Returning: %a" Agv.pp v);
+        [%l.debug "Returning: %a" Agv.pp v];
         Returned (v, type_of e)
     | AilSreturnVoid -> ok (Returned (Agv.void, Ctype.void))
     | AilSblock (bindings, stmtl) ->
@@ -1283,7 +1280,7 @@ module Make (State : State_intf.S) = struct
           let neg_cond = Typed.not cond_v in
           if%sat neg_cond then ok Normal
           else
-            let () = L.trace (fun m -> m "Condition is SAT!") in
+            let () = [%l.trace "Condition is SAT!"] in
             let* res = exec_stmt stmt in
             match res with
             | Returned _ | Goto _ -> ok res
@@ -1346,8 +1343,8 @@ module Make (State : State_intf.S) = struct
     let name, (_loc, _, _, params, stmt) = fundef in
     let ret_ty = Ail_helpers.get_return_ty name in
     (* FIXME: let@ () = with_loc ~loc in *)
-    L.debug (fun m -> m "Executing function %a" Fmt_ail.pp_sym name);
-    L.trace (fun m -> m "Was given arguments: %a" (Fmt.Dump.list Agv.pp) args);
+    [%l.debug "Executing function %a" Fmt_ail.pp_sym name];
+    [%l.trace "Was given arguments: %a" (Fmt.Dump.list Agv.pp) args];
     let* ptys = get_param_tys name in
     let ps = List.combine3 params ptys args in
     let store = mk_store ps in

--- a/soteria-c/lib/layout.ml
+++ b/soteria-c/lib/layout.ml
@@ -25,7 +25,7 @@ module Tag_defs = struct
     match Hashtbl.find_opt tbl id with
     | Some x -> Some x
     | None ->
-        L.debug (fun m -> m "Cannot find definition for %a" Fmt_ail.pp_sym id);
+        [%l.debug "Cannot find definition for %a" Fmt_ail.pp_sym id];
         None
 
   let add_defs defs tbl =
@@ -121,7 +121,7 @@ let rec layout_of ty =
         match def with
         | UnionDef members -> Some members
         | StructDef _ ->
-            L.debug (fun m -> m "Don't have definition of union");
+            [%l.debug "Don't have definition of union"];
             None
       in
       union_layout_of_members members
@@ -131,7 +131,7 @@ let rec layout_of ty =
       let align = elem_layout.align in
       Some { size; align; members_ofs = [] }
   | _ ->
-      L.debug (fun m -> m "Cannot compute layout of %a" Fmt_ail.pp_ty_ ty);
+      [%l.debug "Cannot compute layout of %a" Fmt_ail.pp_ty_ ty];
       None
 
 and union_layout_of_members members =
@@ -170,7 +170,7 @@ and layout_of_struct tag =
     match def with
     | StructDef (m, fam) -> Some (m, fam)
     | _ ->
-        L.debug (fun m -> m "Don't have a definition of structure");
+        [%l.debug "Don't have a definition of structure"];
         None
   in
   let* () =
@@ -268,8 +268,7 @@ let is_int_ty_signed (int_ty : integerType) =
   | Signed _ -> true
   | Char | Bool | Unsigned _ -> false
   | _ ->
-      L.debug (fun m ->
-          m "Cannot determine signedness of %a" Fmt_ail.pp_int_ty int_ty);
+      [%l.debug "Cannot determine signedness of %a" Fmt_ail.pp_int_ty int_ty];
       false
 
 let int_bv_info (int_ty : integerType) =
@@ -289,7 +288,7 @@ let int_constraints (int_ty : integerType) =
   | Bool -> Some (fun x -> [ U8.(0s) <=@ x; (x <@ U8.(2s)) ])
   | Char | Signed _ | Unsigned _ -> Some (fun _ -> [])
   | _ ->
-      L.debug (fun m -> m "No int constraints for %a" Fmt_ail.pp_int_ty int_ty);
+      [%l.debug "No int constraints for %a" Fmt_ail.pp_int_ty int_ty];
       None
 
 exception Unsupported of string
@@ -331,7 +330,7 @@ let constraints_exn ~(ty : ctype) (v : Agv.t) : Typed.T.sbool Typed.t list =
 let constraints ~ty v =
   try Some (constraints_exn ~ty v)
   with Unsupported msg ->
-    L.debug (fun m -> m "Constraints for %a: %s" Fmt_ail.pp_ty ty msg);
+    [%l.debug "Constraints for %a: %s" Fmt_ail.pp_ty ty msg];
     None
 
 let nondet_c_ty_ (ty : ctype_) : Typed.T.cval Typed.t Csymex.t =

--- a/soteria-c/lib/soteria_c_lsp.ml
+++ b/soteria-c/lib/soteria_c_lsp.ml
@@ -92,7 +92,7 @@ class soteria_lsp_server generate_errors =
     method! on_unknown_notification ~notify_back notif =
       match notif.method_ with
       | "soteria/toggleDebugMode" ->
-          L.debug (fun m -> m "Toggling debug mode");
+          [%l.debug "Toggling debug mode"];
           debug_mode <- not debug_mode
       | _ -> super#on_unknown_notification ~notify_back notif
   end

--- a/soteria-c/lib/state.ml
+++ b/soteria-c/lib/state.ml
@@ -89,11 +89,11 @@ let log action ptr =
   let open SM.Syntax in
   let* st = SM.get_state () in
   let+^ loc = Csymex.get_loc () in
-  L.debug (fun m ->
-      m "About to execute action: %s at %a (%a)@\n@[<2>HEAP:@ %a@]" action
-        Typed.ppa ptr Fmt_ail.pp_loc loc
-        (Fmt.option ~none:(Fmt.any "Empty heap") (pp_pretty ~ignore_freed:true))
-        st)
+  [%l.debug
+    "About to execute action: %s at %a (%a)@\n@[<2>HEAP:@ %a@]" action Typed.ppa
+      ptr Fmt_ail.pp_loc loc
+      (Fmt.option ~none:(Fmt.any "Empty heap") (pp_pretty ~ignore_freed:true))
+      st]
 
 let with_heap (f : ('a, 'err, Heap.syn list) Heap.SM.Result.t) :
     ('a, 'err, syn list) SM.Result.t =
@@ -107,7 +107,7 @@ let with_heap (f : ('a, 'err, Heap.syn list) Heap.SM.Result.t) :
 let[@inline] check_non_null loc =
   let open SM.Syntax in
   if%sat Typed.Ptr.is_null_loc loc then (
-    (L.debug (fun m -> m "Null dereference detected");
+    ([%l.debug "Null dereference detected"];
      SM.Result.error `NullDereference)
     [@name "Null-deref case"])
   else SM.Result.ok () [@name "Non-null case"]
@@ -194,9 +194,9 @@ let rec store (ptr : [< T.sptr ] Typed.t) ty v =
 
 let copy_nonoverlapping ~dst ~(src : [< T.sptr ] Typed.t) ~size =
   let open Typed.Infix in
-  L.trace (fun m ->
-      m "copy_nonoverlapping: copying %a bytes from %a to %a" Typed.ppa size
-        Typed.ppa src Typed.ppa dst);
+  [%l.trace
+    "copy_nonoverlapping: copying %a bytes from %a to %a" Typed.ppa size
+      Typed.ppa src Typed.ppa dst];
   let@ () = with_error_loc ~msg:"Triggering copy" () in
   let** () =
     SM.assert_or_error
@@ -234,7 +234,7 @@ let free (ptr : [< T.sptr ] Typed.t) : (unit, 'err, syn list) SM.Result.t =
 let produce (s : syn) (t : t option) : t option Producer.t =
   let open Producer in
   let open Syntax in
-  L.debug (fun m -> m "Producing: %a" pp_syn s);
+  [%l.debug "Producing: %a" pp_syn s];
   let { heap; globs } = of_opt t in
   match s with
   | Ser_heap sh ->

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -112,11 +112,11 @@ let filter_serialized_state relevant_vars (state : State.syn list) =
                allocated *)
             let leaked = not (Block.is_freed b) in
             if leaked then Leak_set.add leak_origins b.info;
-            L.trace (fun m ->
-                m "Filtering out unreachable location: %a which %a." Expr.pp loc
-                  (fun ft b ->
-                    if b then Fmt.pf ft "leaked" else Fmt.pf ft "did not leak")
-                  leaked);
+            [%l.trace
+              "Filtering out unreachable location: %a which %a." Expr.pp loc
+                (fun ft b ->
+                  if b then Fmt.pf ft "leaked" else Fmt.pf ft "did not leak")
+                leaked];
             false)
   in
   let leaked = List.of_seq (Leak_set.to_seq leak_origins) in
@@ -155,7 +155,7 @@ let make ~args ~pre ~pc ~post ~ret () = After_exec { args; pre; pc; post; ret }
     leak is detected if there was an unreachable block that was not freed. *)
 let prune (summary : after_exec t) : pruned t =
   let (After_exec summary) = summary in
-  L.trace (fun m -> m "Pruning summary %a" pp_raw summary);
+  [%l.trace "Pruning summary %a" pp_raw summary];
   let module Var_graph = Graph.Make_in_place (Var) in
   let graph = Var_graph.with_node_capacity 0 in
   let init_reachable = init_reachable_vars summary in
@@ -214,10 +214,10 @@ let rec analyse : type a. fid:Ail_tys.sym -> a t -> analysed t =
         L.with_section
           ("Analysing a summary for " ^ Cerb_frontend.Symbol.show_symbol fid)
       in
-      L.debug (fun m ->
-          m "Analysing a summary for %s@\n%a"
-            (Cerb_frontend.Symbol.show_symbol fid)
-            pp_raw summary);
+      [%l.debug
+        "Analysing a summary for %s@\n%a"
+          (Cerb_frontend.Symbol.show_symbol fid)
+          pp_raw summary];
       let arg_tys = Option.get (Ail_helpers.get_param_tys fid) in
       match summary.ret with
       | Ok _ ->
@@ -259,30 +259,30 @@ let rec analyse : type a. fid:Ail_tys.sym -> a t -> analysed t =
                   v :: acc)
             in
             let* pc, _ = Csymex.Producer.run ~subst:Expr.Subst.empty producer in
-            L.trace (fun m ->
-                m
-                  "Produced heap, about to check if path condition holds in \
-                   every branch");
+            [%l.trace
+              "Produced heap, about to check if path condition holds in every \
+               branch"];
             Csymex.assert_ (Typed.conj pc)
           in
           let is_manifest =
             try
               let result = Csymex.run_needs_stats ~mode:OX process in
-              L.debug (fun m ->
-                  let pp_pc ft pc =
-                    Fmt.pf ft "@[<2>Path condition: %a@]"
-                      (Fmt.Dump.list Typed.ppa) pc
-                  in
-                  let pp_res ft (res, pc) =
-                    Fmt.pf ft "<v 2>Branch:@.Res: %a@.%a@]" Fmt.bool res pp_pc
-                      pc
-                  in
-                  m "%a" Fmt.(list ~sep:cut pp_res) result);
+              [%l.debug
+                "%a"
+                  Fmt.(
+                    list ~sep:cut (fun ft (res, pc) ->
+                        let pp_pc ft pc =
+                          Fmt.pf ft "@[<2>Path condition: %a@]"
+                            (Fmt.Dump.list Typed.ppa) pc
+                        in
+                        Fmt.pf ft "<v 2>Branch:@.Res: %a@.%a@]" Fmt.bool res
+                          pp_pc pc))
+                  result];
               (* The bug is manifest if the test passed in every branch. *)
               (not (List.is_empty result)) && List.for_all fst result
             with Soteria.Symex.Gave_up _ -> false
           in
-          if is_manifest then L.debug (fun m -> m "Bug is manifest!!");
+          if is_manifest then [%l.debug "Bug is manifest!!"];
           let manifest_bugs = if is_manifest then [ error ] else [] in
           Analysed { raw = summary; manifest_bugs })
 

--- a/soteria-linear/semantic/abductor.ml
+++ b/soteria-linear/semantic/abductor.ml
@@ -33,9 +33,8 @@ let make_spec_opt (((~args, ~res), pc) : branch) : Context.spec option =
 let make_spec_opt x =
   let res = make_spec_opt x in
   (match res with
-  | None -> L.debug (fun m -> m "Discarding a spec because miss")
-  | Some res ->
-      L.debug (fun m -> m "Constructed a spec:@ %a" Context.pp_spec res));
+  | None -> [%l.debug "Discarding a spec because miss"]
+  | Some res -> [%l.debug "Constructed a spec:@ %a" Context.pp_spec res]);
   res
 
 let rec fun_interps ~(context : Context.t) fname =
@@ -53,7 +52,7 @@ and analyse_function ~context fname (func_dec : Lang.Fun_def.t) =
   let () =
     match Hashtbl.Hstring.find_opt context.specs fname with
     | Some _ ->
-        L.info (fun m -> m "%s has already been analysed, doing nothing." fname);
+        [%l.info "%s has already been analysed, doing nothing." fname];
         ()
     | None ->
         let@ () = with_context ~fun_interps context in

--- a/soteria-linear/semantic/interp.ml
+++ b/soteria-linear/semantic/interp.ml
@@ -85,8 +85,7 @@ module Make (State : State_intf.S) = struct
        better interface. *)
     let open Symex in
     let open Syntax in
-    L.debug (fun m ->
-        m "@[<v 2>Executing specification:@ %a@]" Context.pp_spec spec);
+    [%l.debug "@[<v 2>Executing specification:@ %a@]" Context.pp_spec spec];
     let Context.{ args = params; pre; post; pc; ret } = spec in
     let asrt = Logic.Asrt.make ~spatial:pre ~pure:[] in
     let* frame =
@@ -116,9 +115,9 @@ module Make (State : State_intf.S) = struct
 
   let rec eval_expr (subst : subst) expr : (S_val.t, 'err, 'fix) SM.Result.t =
     let* () = SM.consume_fuel_steps 1 in
-    L.debug (fun m ->
-        m "@[<v 0>@[<v 2>Interp expr:@ %a@]@.@[<v 2>In subst:@ %a@]@]" Expr.pp
-          expr pp_subst subst);
+    [%l.debug
+      "@[<v 0>@[<v 2>Interp expr:@ %a@]@.@[<v 2>In subst:@ %a@]@]" Expr.pp expr
+        pp_subst subst];
     match expr with
     | Expr.Pure_expr e -> eval_pure_expr subst e
     | Let (x, e1, e2) ->
@@ -166,11 +165,10 @@ module Make (State : State_intf.S) = struct
 
   and eval_function func args =
     let subst = List.combine func.Fun_def.args args |> String_map.of_list in
-    L.debug (fun m ->
-        m "@[<v 2>Running function %s with args:@ %a@]" func.Fun_def.name
-          pp_subst subst);
+    [%l.debug
+      "@[<v 2>Running function %s with args:@ %a@]" func.Fun_def.name pp_subst
+        subst];
     let++ r = eval_expr subst func.Fun_def.body in
-    L.debug (fun m ->
-        m "@[<v 2>Function %s returned:@ %a@]" func.Fun_def.name S_val.pp r);
+    [%l.debug "@[<v 2>Function %s returned:@ %a@]" func.Fun_def.name S_val.pp r];
     r
 end

--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -188,9 +188,9 @@ module M (StateM : State.StateM.S) = struct
      *    validity checks we need the current state to have these addresses!
      *  - we need to take the max of either types for the alignment, to ensure
      *    that transmuting e.g. from [u16; 2] to (u32) works. *)
-    L.debug (fun m ->
-        m "Transmuting %a: %a -> %a" pp_rust_val v Common.Charon_util.pp_ty
-          from_ty Common.Charon_util.pp_ty to_ty);
+    [%l.debug
+      "Transmuting %a: %a -> %a" pp_rust_val v Common.Charon_util.pp_ty from_ty
+        Common.Charon_util.pp_ty to_ty];
     let* { size; align; _ } = Layout.layout_of from_ty in
     let* { align = align_2; _ } = Layout.layout_of to_ty in
     let align = BV.max ~signed:false align align_2 in

--- a/soteria-rust/lib/builtins/intrinsics_impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics_impl.ml
@@ -412,10 +412,10 @@ module M (StateM : State.StateM.S) : Intrinsics_intf.M(StateM).Impl = struct
 
   let copy_ nonoverlapping ~t ~src:((src, _) as fsrc : full_ptr)
       ~dst:((dst, _) as fdst : full_ptr) ~count : unit ret =
-    L.debug (fun m ->
-        m "Performing copy%s: %a -> %a, count %a"
-          (if nonoverlapping then "_non_overlapping" else "")
-          pp_full_ptr fsrc pp_full_ptr fdst Typed.ppa count);
+    [%l.debug
+      "Performing copy%s: %a -> %a, count %a"
+        (if nonoverlapping then "_non_overlapping" else "")
+        pp_full_ptr fsrc pp_full_ptr fdst Typed.ppa count];
     let zero = Usize.(0s) in
     let* () = State.check_ptr_align fsrc t in
     let* () = State.check_ptr_align fdst t in

--- a/soteria-rust/lib/builtins/soteria_lib.ml
+++ b/soteria-rust/lib/builtins/soteria_lib.ml
@@ -48,7 +48,7 @@ module M (StateM : State.StateM.S) = struct
       | [ Int t ] -> Typed.cast_lit TBool t
       | _ -> failwith "assume with non-one arguments"
     in
-    L.debug (fun g -> g "Assuming: %a\n" Typed.ppa to_assume);
+    [%l.debug "Assuming: %a\n" Typed.ppa to_assume];
     let+ () = assume [ Typed.BitVec.to_bool to_assume ] in
     unit_
 

--- a/soteria-rust/lib/error.ml
+++ b/soteria-rust/lib/error.ml
@@ -158,7 +158,7 @@ let log_at (where : Trace.t) error =
     | Some op -> Fmt.pf ft " due to %s" op
     | None -> Fmt.string ft ""
   in
-  L.error (fun m -> m "Error %a%a%a" pp error pp_loc where.loc pp_op where.op)
+  [%l.error "Error %a%a%a" pp error pp_loc where.loc pp_op where.op]
 
 let decorate (where : Trace.t) (e : t) : with_trace =
   let msg = Option.value ~default:"Triggering operation" where.op in

--- a/soteria-rust/lib/frontend.ml
+++ b/soteria-rust/lib/frontend.ml
@@ -25,7 +25,7 @@ module Exe = struct
       (fun () ->
         Unix.chdir path;
         if (Config.get ()).log_compilation then
-          L.info (fun g -> g "Changed working directory to %s" path);
+          [%l.info "Changed working directory to %s" path];
         f ())
 
   let pp_status ft = function
@@ -81,22 +81,22 @@ module Exe = struct
     let current_env = Unix.environment () in
     let cmd = String.concat " " (cmd :: args) in
     if (Config.get ()).log_compilation then
-      L.info (fun g ->
-          g "Running command: %s@.With env:@.%a@." cmd
-            Fmt.(list ~sep:(any "@.") string)
-            env);
+      [%l.info
+        "Running command: %s@.With env:@.%a@." cmd
+          Fmt.(list ~sep:(any "@.") string)
+          env];
     let env = Array.append current_env (Array.of_list env) in
     let out, inp, err = Unix.open_process_full cmd env in
     let output, error = read_both_nonblocking out err in
     let status = Unix.close_process_full (out, inp, err) in
     if (Config.get ()).log_compilation then
-      L.info (fun g ->
-          g "Command finished with status: %a@.stdout:@.%a@.stderr:@.%a"
-            pp_status status
-            Fmt.(list ~sep:(any "@\n") string)
-            output
-            Fmt.(list ~sep:(any "@\n") string)
-            error);
+      [%l.info
+        "Command finished with status: %a@.stdout:@.%a@.stderr:@.%a" pp_status
+          status
+          Fmt.(list ~sep:(any "@\n") string)
+          output
+          Fmt.(list ~sep:(any "@\n") string)
+          error];
     (output, error, status)
 
   let exec_exn ?env cmd args =
@@ -238,10 +238,9 @@ module Cmd = struct
             | [] -> []
             | [ h ] -> [ h ]
             | h :: _ ->
-                L.warn (fun m ->
-                    m
-                      "Charon currently only support one entry attribute; more \
-                       than one was specified, only the first will be used");
+                [%l.warn
+                  "Charon currently only support one entry attribute; more \
+                   than one was specified, only the first will be used"];
                 [ h ]
           in
           let entries = List.concat_map entry_as_flag (attribs @ non_attribs) in

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -29,24 +29,24 @@ module Make (StateImpl : State.S) = struct
     let binding = Store.find var_id store in
     match binding.kind with
     | Stackptr ptr ->
-        L.debug (fun m ->
-            m "Variable %a has pointer %a" Expressions.pp_var_id var_id
-              pp_full_ptr ptr);
+        [%l.debug
+          "Variable %a has pointer %a" Expressions.pp_var_id var_id pp_full_ptr
+            ptr];
         ok ptr
     | Uninit ->
         let* ptr = State.alloc_ty binding.ty in
         let+ () = map_env (Store.declare_ptr var_id ptr) in
-        L.debug (fun m ->
-            m "Variable %a was uninitialized, allocated pointer %a"
-              Expressions.pp_var_id var_id pp_full_ptr ptr);
+        [%l.debug
+          "Variable %a was uninitialized, allocated pointer %a"
+            Expressions.pp_var_id var_id pp_full_ptr ptr];
         ptr
     | Value v ->
         let* ptr = State.alloc_ty binding.ty in
         let* () = State.store ptr binding.ty v in
         let+ () = map_env (Store.declare_ptr var_id ptr) in
-        L.debug (fun m ->
-            m "Variable %a had value, allocated pointer %a"
-              Expressions.pp_var_id var_id pp_full_ptr ptr);
+        [%l.debug
+          "Variable %a had value, allocated pointer %a" Expressions.pp_var_id
+            var_id pp_full_ptr ptr];
         ptr
     | Dead -> error `DeadVariable
 
@@ -318,14 +318,13 @@ module Make (StateImpl : State.S) = struct
     (* Dereference a pointer *)
     | PlaceProjection (base, Deref) -> (
         let* ptr = resolve_place base in
-        L.debug (fun f ->
-            f "Dereferencing ptr %a of %a" pp_full_ptr ptr pp_ty base.ty);
+        [%l.debug "Dereferencing ptr %a of %a" pp_full_ptr ptr pp_ty base.ty];
         let* v = State.load ptr base.ty in
         match v with
         | Ptr fptr -> (
-            L.debug (fun f ->
-                f "Dereferenced pointer %a to pointer %a" pp_full_ptr ptr
-                  pp_full_ptr fptr);
+            [%l.debug
+              "Dereferenced pointer %a to pointer %a" pp_full_ptr ptr
+                pp_full_ptr fptr];
             let pointee = get_pointee base.ty in
             match base.ty with
             | TRef _ | TAdt { id = TBuiltin TBox; _ } ->
@@ -341,9 +340,8 @@ module Make (StateImpl : State.S) = struct
     | PlaceProjection (base, PtrMetadata) ->
         let* ((ptr, _) as fptr) = resolve_place base in
         let* () = State.fake_read fptr base.ty in
-        L.debug (fun f ->
-            f "Projecting metadata of pointer %a for %a" Sptr.pp ptr pp_ty
-              base.ty);
+        [%l.debug
+          "Projecting metadata of pointer %a for %a" Sptr.pp ptr pp_ty base.ty];
         let+ ptr' =
           Sptr.offset ~check:false ~ty:(TLiteral (TUInt Usize)) ~signed:false
             ptr
@@ -353,14 +351,14 @@ module Make (StateImpl : State.S) = struct
     | PlaceProjection (base, Field (kind, field)) ->
         let* ((ptr, meta) as fptr) = resolve_place base in
         let* () = State.check_ptr_align fptr base.ty in
-        L.debug (fun f ->
-            f "Projecting field %a (kind %a) for %a" Types.pp_field_id field
-              Expressions.pp_field_proj_kind kind Sptr.pp ptr);
+        [%l.debug
+          "Projecting field %a (kind %a) for %a" Types.pp_field_id field
+            Expressions.pp_field_proj_kind kind Sptr.pp ptr];
         let* ptr' = Sptr.project base.ty kind field ptr in
-        L.debug (fun f ->
-            f "Projecting ADT %a, field %a, with pointer %a to pointer %a"
-              Expressions.pp_field_proj_kind kind Types.pp_field_id field
-              Sptr.pp ptr Sptr.pp ptr');
+        [%l.debug
+          "Projecting ADT %a, field %a, with pointer %a to pointer %a"
+            Expressions.pp_field_proj_kind kind Types.pp_field_id field Sptr.pp
+            ptr Sptr.pp ptr'];
         if Layout.is_dst place.ty then ok (ptr', meta) else ok (ptr', Thin)
     | PlaceProjection (base, ProjIndex (idx, from_end)) ->
         let* ptr, meta = resolve_place base in
@@ -380,9 +378,9 @@ module Make (StateImpl : State.S) = struct
           assert_ (Usize.(0s) <=$@ idx &&@ (idx <$@ len)) `OutOfBounds
         in
         let+ ptr' = Sptr.offset ~signed:false ~ty:place.ty ptr idx in
-        L.debug (fun f ->
-            f "Projected %a, index %a, to pointer %a" Sptr.pp ptr Typed.ppa idx
-              Sptr.pp ptr');
+        [%l.debug
+          "Projected %a, index %a, to pointer %a" Sptr.pp ptr Typed.ppa idx
+            Sptr.pp ptr'];
         (ptr', Thin)
     | PlaceProjection (base, Subslice (from, to_, from_end)) ->
         let* ptr, meta = resolve_place base in
@@ -407,11 +405,11 @@ module Make (StateImpl : State.S) = struct
         in
         let+ ptr' = Sptr.offset ~signed:false ~ty ptr from in
         let slice_len = to_ -!@ from in
-        L.debug (fun f ->
-            f "Projected %a, slice %a..%a%s, to pointer %a, len %a" Sptr.pp ptr
-              Typed.ppa from Typed.ppa to_
-              (if from_end then "(from end)" else "")
-              Sptr.pp ptr' Typed.ppa slice_len);
+        [%l.debug
+          "Projected %a, slice %a..%a%s, to pointer %a, len %a" Sptr.pp ptr
+            Typed.ppa from Typed.ppa to_
+            (if from_end then "(from end)" else "")
+            Sptr.pp ptr' Typed.ppa slice_len];
         (ptr', Len slice_len)
 
   and resolve_place_lazy (place : Expressions.place) : lazy_ptr t =
@@ -466,9 +464,8 @@ module Make (StateImpl : State.S) = struct
             Poly.push_generics ~params:fundef.generics ~args:fn.generics
             @@ Poly.subst_tys fundef.signature.inputs
           in
-          L.info (fun g ->
-              g "Resolved function call to %a" Crate.pp_name
-                fundef.item_meta.name);
+          [%l.info
+            "Resolved function call to %a" Crate.pp_name fundef.item_meta.name];
           let fun_maybe_stubbed =
             Std_funs.std_fun_eval fundef fn.generics exec_fun
           in
@@ -504,9 +501,8 @@ module Make (StateImpl : State.S) = struct
         (* Same as with strings -- here we need to somehow cache where we store
            the globals *)
         let fundef = Crate.get_fun decl.init in
-        L.info (fun g ->
-            g "Resolved global init call to %a" Crate.pp_name
-              fundef.item_meta.name);
+        [%l.info
+          "Resolved global init call to %a" Crate.pp_name fundef.item_meta.name];
         let global_fn = Std_funs.std_fun_eval fundef glob.generics exec_fun in
         (* First we allocate the global and store it in the State *)
         let* ptr =
@@ -517,9 +513,9 @@ module Make (StateImpl : State.S) = struct
         (* And only after we compute it; this enables recursive globals *)
         let* v = with_env ~env:() @@ global_fn [] in
         let+ () = State.store ptr decl.ty v in
-        L.info (fun g ->
-            g "Initialized global %a at %a to %a" Crate.pp_name
-              decl.item_meta.name pp_full_ptr ptr pp_rust_val v);
+        [%l.info
+          "Initialized global %a at %a to %a" Crate.pp_name decl.item_meta.name
+            pp_full_ptr ptr pp_rust_val v];
         ptr
 
   and eval_operand (op : Expressions.operand) =
@@ -907,14 +903,14 @@ module Make (StateImpl : State.S) = struct
         | _ -> not_impl "Unexpected len rvalue")
 
   and exec_stmt (stmt : UllbcAst.statement) : unit t =
-    L.info (fun m -> m "Statement: %a" Crate.pp_statement stmt);
+    [%l.info "Statement: %a" Crate.pp_statement stmt];
     let@ () = with_loc ~loc:stmt.span.data in
     match stmt.kind with
     | Nop -> ok ()
     | Assign (place, rval) ->
         let* ptr = resolve_place_lazy place in
         let* v = eval_rvalue rval place.ty in
-        L.info (fun m -> m "Assigning %a <- %a" pp_lazy_ptr ptr pp_rust_val v);
+        [%l.info "Assigning %a <- %a" pp_lazy_ptr ptr pp_rust_val v];
         store_lazy ptr place.ty v
     | StorageLive local ->
         let* store = get_env () in
@@ -970,7 +966,7 @@ module Make (StateImpl : State.S) = struct
       ({ statements; terminator } : UllbcAst.block) =
     let*^ () = Rustsymex.consume_fuel_steps 1 in
     let* () = iter_list statements ~f:exec_stmt in
-    L.info (fun f -> f "Terminator: %a" Crate.pp_terminator terminator);
+    [%l.info "Terminator: %a" Crate.pp_terminator terminator];
     let@ () = with_loc ~loc:terminator.span.data in
     match terminator.kind with
     | Call ({ func; args; dest }, target, on_unwind) ->
@@ -987,10 +983,10 @@ module Make (StateImpl : State.S) = struct
               if Types.equal_ty from_ty to_ty then ok arg
               else Core.transmute ~from_ty ~to_ty arg)
         in
-        L.info (fun g ->
-            g "Executing function with arguments [%a]"
-              Fmt.(list ~sep:(any ", ") pp_rust_val)
-              args);
+        [%l.info
+          "Executing function with arguments [%a]"
+            Fmt.(list ~sep:(any ", ") pp_rust_val)
+            args];
         let fun_exec =
           with_extra_call_trace ~loc:terminator.span.data ~msg:"Call trace"
           @@ with_env ~env:()
@@ -999,15 +995,15 @@ module Make (StateImpl : State.S) = struct
         unwind_with fun_exec
           ~f:(fun v ->
             let* ptr = resolve_place_lazy dest in
-            L.info (fun m ->
-                m "Returned %a <- %a from %a" Crate.pp_place dest pp_rust_val v
-                  Crate.pp_fn_operand func);
+            [%l.info
+              "Returned %a <- %a from %a" Crate.pp_place dest pp_rust_val v
+                Crate.pp_fn_operand func];
             let* () = store_lazy ptr dest.ty v in
             let block = UllbcAst.BlockId.nth body.body target in
             exec_block ~body block)
           ~fe:(fun err ->
             let* () = State.add_error err in
-            L.info (fun m -> m "Unwinding from %a" Crate.pp_fn_operand func);
+            [%l.info "Unwinding from %a" Crate.pp_fn_operand func];
             let block = UllbcAst.BlockId.nth body.body on_unwind in
             exec_block ~body block)
     | Goto b ->
@@ -1025,9 +1021,9 @@ module Make (StateImpl : State.S) = struct
         let* discr = eval_operand discr in
         match switch with
         | If (if_block, else_block) ->
-            L.info (fun g ->
-                g "Switch if/else %a/%a for %a" UllbcAst.pp_block_id if_block
-                  UllbcAst.pp_block_id else_block pp_rust_val discr);
+            [%l.info
+              "Switch if/else %a/%a for %a" UllbcAst.pp_block_id if_block
+                UllbcAst.pp_block_id else_block pp_rust_val discr];
             let bool_discr =
               match discr with
               | Int discr -> BV.to_bool (Typed.cast_lit TBool discr)
@@ -1041,17 +1037,15 @@ module Make (StateImpl : State.S) = struct
               let block = UllbcAst.BlockId.nth body.body else_block in
               exec_block ~body block
         | SwitchInt (_, options, default) ->
-            L.info (fun g ->
-                let options =
-                  List.map
-                    (fun (v, b) -> (PrintValues.literal_to_string v, b))
-                    options
-                in
-                g "Switch options %a (else %a) for %a"
-                  Fmt.(
-                    list ~sep:comma
-                    @@ pair ~sep:(any "->") string UllbcAst.pp_block_id)
-                  options UllbcAst.pp_block_id default pp_rust_val discr);
+            [%l.info
+              "Switch options %a (else %a) for %a"
+                Fmt.(
+                  list ~sep:comma
+                  @@ pair ~sep:(any "->") string UllbcAst.pp_block_id)
+                (List.map
+                   (fun (v, b) -> (PrintValues.literal_to_string v, b))
+                   options)
+                UllbcAst.pp_block_id default pp_rust_val discr];
             let compare_discr =
               match discr with
               | Int discr -> fun (v, _) -> discr ==@ BV.of_literal v
@@ -1100,11 +1094,11 @@ module Make (StateImpl : State.S) = struct
             unwind_with fun_exec
               ~f:(fun _ ->
                 let block = UllbcAst.BlockId.nth body.body target in
-                L.info (fun m -> m "Dropped with %a" Fun_kind.pp drop);
+                [%l.info "Dropped with %a" Fun_kind.pp drop];
                 exec_block ~body block)
               ~fe:(fun err ->
                 let* () = State.add_error err in
-                L.info (fun m -> m "Unwinding drop from %a" Fun_kind.pp drop);
+                [%l.info "Unwinding drop from %a" Fun_kind.pp drop];
                 let block = UllbcAst.BlockId.nth body.body on_unwind in
                 exec_block ~body block)
         | None ->

--- a/soteria-rust/lib/layout.ml
+++ b/soteria-rust/lib/layout.ml
@@ -94,8 +94,7 @@ let mk_concrete ~size ~align =
 let not_impl_layout msg ty =
   Fmt.kstr not_impl "Can't compute layout: %s %a" msg pp_ty ty
 
-let layout_warning msg ty =
-  L.warn (fun m -> m "Layout: %s@.Type: %a" msg pp_ty ty)
+let layout_warning msg ty = [%l.warn "Layout: %s@.Type: %a" msg pp_ty ty]
 
 let rec layout_of (ty : Types.ty) : (t, 'e, 'f) Rustsymex.Result.t =
   let* ty = Poly.subst_ty ty in

--- a/soteria-rust/lib/rustsymex.ml
+++ b/soteria-rust/lib/rustsymex.ml
@@ -96,7 +96,7 @@ module Poly = struct
     if (Config.get ()).polymorphic then (
       let* ({ subst; _ } as st) = get_state () in
       let args' = generic_args_substitute subst args in
-      L.debug (fun m -> m "Pushing generics %a" Crate.pp_generic_args args');
+      [%l.debug "Pushing generics %a" Crate.pp_generic_args args'];
       let subst =
         subst_at_binder_zero (make_sb_subst_from_generics params args' Self)
       in

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -311,7 +311,7 @@ module ArithPtr :
     let+ loc_int, decay_map =
       DecayMap.decay ~expose ~size ~align loc decay_map
     in
-    L.debug (fun fmt -> fmt "Decay %a -> %a" Typed.ppa loc Typed.ppa loc_int);
+    [%l.debug "Decay %a -> %a" Typed.ppa loc Typed.ppa loc_int];
     (loc_int +!!@ ofs, decay_map)
 
   let decay p = _decay ~expose:false p

--- a/soteria-rust/lib/state/rtree_block.ml
+++ b/soteria-rust/lib/state/rtree_block.ml
@@ -217,7 +217,7 @@ module Make (Sptr : Sptr.S) = struct
             Ok ((Rust_val.Int value, offset) :: vs)
         | Owned (Init value, _) -> Result.ok ((value, offset) :: vs)
         | Owned (Any, _) ->
-            L.info (fun m -> m "Reading from Any memory, vanishing.");
+            [%l.info "Reading from Any memory, vanishing."];
             vanish ()
         | NotOwned Partially | Owned ((Lazy | Uninit Partially), _) ->
             failwith "Iterating over an intermediate node?")

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -151,10 +151,10 @@ module Block = struct
     let parent = Option.get ptr.tag in
     let tb', tag = Tree_borrow.add_child ~parent ~state ?protector tb in
     let ptr' = { ptr with tag = Some tag } in
-    L.debug (fun m ->
-        m "%s pointer %a -> %a (%a)"
-          (if protect then "Protecting" else "Borrowing")
-          Sptr.pp ptr Sptr.pp ptr' Tree_borrow.pp_state state);
+    [%l.debug
+      "%s pointer %a -> %a (%a)"
+        (if protect then "Protecting" else "Borrowing")
+        Sptr.pp ptr Sptr.pp ptr' Tree_borrow.pp_state state];
     if not protect then
       let+ () = SM.set_state (to_opt (block, tb')) in
       Ok (ptr', meta)
@@ -331,11 +331,10 @@ open SM.Syntax
 
 let log action ptr =
   let+ st = SM.get_state () in
-  L.trace (fun m ->
-      m "About to execute action: %s (%a)@\n@[<2>STATE:@ %a@]" action Sptr.pp
-        ptr
-        (Fmt.Dump.option (pp_pretty ~ignore_freed:true))
-        st)
+  [%trace
+    "About to execute action: %s (%a)@\n@[<2>STATE:@ %a@]" action Sptr.pp ptr
+      (Fmt.Dump.option (pp_pretty ~ignore_freed:true))
+      st]
 
 let[@inline] with_loc_err ?trace:msg ()
     (f : unit -> ('a, Error.t, 'f) SM.Result.t) :
@@ -405,9 +404,9 @@ let rec size_and_align_of_val ty meta =
 and check_ptr_align ((ptr, meta) : 'a full_ptr) (ty : Types.ty) =
   (* The expected alignment of a dyn pointer is stored inside the VTable *)
   let** _, exp_align = size_and_align_of_val ty meta in
-  L.debug (fun m ->
-      m "Checking pointer alignment of %a: expect %a for %a" Sptr.pp ptr
-        Typed.ppa exp_align Common.Charon_util.pp_ty ty);
+  [%l.debug
+    "Checking pointer alignment of %a: expect %a for %a" Sptr.pp ptr Typed.ppa
+      exp_align Common.Charon_util.pp_ty ty];
   let aligned, err = Sptr.is_aligned exp_align ptr in
   assert_or_error aligned err
 
@@ -427,8 +426,7 @@ and load ?ignore_borrow ?(check_refs = true) ((ptr, meta) as fptr) ty :
   let** () = check_ptr_align fptr ty in
   let parser ~offset = Heap.Decoder.decode ~meta ~offset ty in
   let** value = apply_parser ?ignore_borrow ptr parser in
-  L.debug (fun f ->
-      f "Finished reading rust value %a" (Rust_val.pp Sptr.pp) value);
+  [%l.debug "Finished reading rust value %a" (Rust_val.pp Sptr.pp) value];
   let check_ref =
     if (Config.get ()).recursive_validity <> Allow && check_refs then
       fun ptr ty ->
@@ -464,9 +462,9 @@ and fake_read ((ptr, meta) as fptr) ty =
   in
   if skip_check then Result.ok ()
   else (
-    L.debug (fun m ->
-        m "Checking validity of %a for %a" (pp_full_ptr Sptr.pp) fptr
-          Charon_util.pp_ty ty);
+    [%l.debug
+      "Checking validity of %a for %a" (pp_full_ptr Sptr.pp) fptr
+        Charon_util.pp_ty ty];
     let*- err =
       let++ _ = load ~ignore_borrow:true ~check_refs:false fptr ty in
       ()
@@ -510,10 +508,10 @@ let store ((ptr, _) as fptr) ty sval :
   if Iter.is_empty parts then Result.ok ()
   else
     let** () = check_ptr_align fptr ty in
-    (* L.debug (fun f ->
-     *   f "Parsed to parts [%a]"
-     *     Fmt.(list ~sep:comma Encoder.pp_cval_info)
-     *     parts); *)
+    (* [%l.debug
+     *   "Parsed to parts [%a]"
+     *   Fmt.(list ~sep:comma Encoder.pp_cval_info)
+     *   parts]; *)
     let* () = log "store" ptr in
     let**^ size = Layout.size_of ty in
     let@ ofs = with_ptr ptr in
@@ -674,12 +672,12 @@ let free ((ptr : Sptr.t), _) =
   (* let** () =
    *   with_ptr ptr (fun _ ->
    *       Block.with_tree_block_read_tb (fun tb ->
-   *           L.warn (fun m -> m "%a" Tree_borrow.pp tb);
+   *           [%l.warn "%a" Tree_borrow.pp tb];
    *           if Tree_borrow.strong_protector_exists tb then
    *             Tree_block.SM.Result.error `InvalidFreeStrongProtector
    *           else Tree_block.SM.Result.ok ()))
    * in *)
-  L.debug (fun m -> m "Freeing pointer %a" Sptr.pp ptr);
+  [%l.debug "Freeing pointer %a" Sptr.pp ptr];
   with_heap
     (Heap.wrap loc (Freeable_block_with_meta.wrap (Freeable_block.free ())))
 
@@ -734,7 +732,7 @@ let unprotect ((ptr : Sptr.t), _) (ty : Types.ty) =
       else
         let**^ size = Layout.size_of ty in
         let@ ofs = with_ptr ptr in
-        L.debug (fun m -> m "Unprotecting pointer %a" Sptr.pp ptr);
+        [%l.debug "Unprotecting pointer %a" Sptr.pp ptr];
         Block.unprotect ofs tag size
 
 let with_exposed addr =
@@ -807,18 +805,17 @@ let leak_check () : (unit, Error.with_trace, syn list) Result.t =
          [] heap
      in
      if List.is_empty leaks then Result.ok ()
-     else (
-       L.info (fun m ->
-           let pp_leak ft (k, trace) =
-             Fmt.pf ft "%a (allocated at %a)" Typed.ppa k Trace.pp trace
-           in
-           m "Found leaks: %a" Fmt.(list ~sep:(any ", ") pp_leak) leaks);
+     else
+       let pp_leak ft (k, trace) =
+         Fmt.pf ft "%a (allocated at %a)" Typed.ppa k Trace.pp trace
+       in
+       [%l.info "Found leaks: %a" Fmt.(list ~sep:(any ", ") pp_leak) leaks];
        let wheres = List.map snd leaks in
        let* leak_trace = branches (List.map (fun t () -> return t) wheres) in
        let leak_trace =
          Trace.rename ~rev:true 0 "Leaking function" leak_trace
        in
-       Result.error (Error.decorate leak_trace `MemoryLeak)))
+       Result.error (Error.decorate leak_trace `MemoryLeak))
 
 let with_errors () (f : Error.with_trace list -> 'a * Error.with_trace list) :
     ('a, Error.with_trace, syn list) Result.t =

--- a/soteria-rust/lib/tree_borrow.ml
+++ b/soteria-rust/lib/tree_borrow.ml
@@ -174,12 +174,11 @@ let access accessed e (root : t) (st : tb_state) =
         let st' = transition ~protected st (rel, e) in
         if st' = UB then (
           ub_happened := true;
-          L.debug (fun m ->
-              m
-                "TB: Undefined behavior encountered for %a, %a %a (protected? \
-                 %b): %a -> %a in structure@.%a"
-                pp_tag tag pp_locality rel pp_access e protected pp_state st
-                pp_state st' pp root));
+          [%l.debug
+            "TB: Undefined behavior encountered for %a, %a %a (protected? %b): \
+             %a -> %a in structure@.%a"
+            pp_tag tag pp_locality rel pp_access e protected pp_state st
+              pp_state st' pp root]);
         if (not protected) && st' = initial_state then None
         else Some (protected, st'))
       root

--- a/soteria/lib/bv_values/bv_solver.ml
+++ b/soteria/lib/bv_values/bv_solver.ml
@@ -131,7 +131,7 @@ struct
         | Sat -> Sat
         | Unsat -> Unsat
         | Unknown ->
-            L.info (fun m -> m "Solver returned unknown");
+            [%l.info "Solver returned unknown"];
             Unknown)
 
   let as_values solver =

--- a/soteria/lib/logic/asrt.ml
+++ b/soteria/lib/logic/asrt.ml
@@ -76,7 +76,7 @@ module M (Symex : Symex.Base) = struct
 
     let consume_atom atom st =
       let open Consumer.Syntax in
-      L.debug (fun m -> m "@[Consuming atom:@ %a@]" (pp_atom B.pp_syn) atom);
+      [%l.debug "@[Consuming atom:@ %a@]" (pp_atom B.pp_syn) atom];
       match atom with
       | Spatial pred -> B.consume pred st
       | Pure f ->
@@ -87,12 +87,10 @@ module M (Symex : Symex.Base) = struct
         (B.t option, B.syn list) Consumer.t =
       let open Consumer.Syntax in
       let* subst = Consumer.expose_subst () in
-      L.debug (fun m ->
-          m
-            "@[<v>@[About to consume asrt:@ %a@]@ @[in subst:@ %a@]@ @[and \
-             current state:@ %a@]@]"
-            (pp B.pp_syn) asrt Value.Expr.Subst.pp subst (Fmt.Dump.option B.pp)
-            st);
+      [%l.debug
+        "@[<v>@[About to consume asrt:@ %a@]@ @[in subst:@ %a@]@ @[and current \
+         state:@ %a@]@]"
+        (pp B.pp_syn) asrt Value.Expr.Subst.pp subst (Fmt.Dump.option B.pp) st];
       let rec aux (remaining : B.syn t) (st : B.t option) :
           (B.t option, B.syn list) Consumer.t =
         if List.is_empty remaining then Consumer.ok st
@@ -100,12 +98,11 @@ module M (Symex : Symex.Base) = struct
           let* subst = Consumer.expose_subst () in
           match List.find_with_rest (is_consumable subst) remaining with
           | None ->
-              L.info (fun m ->
-                  m
-                    "@[<v>Failed to consume assertion because I can't find any \
-                     consumable atom left given my current substitution.@.@[<v \
-                     2>Substitution:@ %a@]@.@[<v 2>Atoms left:@ %a@]@]"
-                    Value.Expr.Subst.pp subst (pp B.pp_syn) remaining);
+              [%l.info
+                "@[<v>Failed to consume assertion because I can't find any \
+                 consumable atom left given my current substitution.@.@[<v \
+                 2>Substitution:@ %a@]@.@[<v 2>Atoms left:@ %a@]@]"
+                Value.Expr.Subst.pp subst (pp B.pp_syn) remaining];
               Consumer.lfail @@ Value.of_bool false
           | Some (atom, rest) ->
               let* st' = consume_atom atom st in

--- a/soteria/lib/solvers/z3.ml
+++ b/soteria/lib/solvers/z3.ml
@@ -124,15 +124,15 @@ module Make (Value : Value.S) :
     let smt_res =
       try check solver
       with Simple_smt.UnexpectedSolverResponse s ->
-        L.error (fun m ->
-            m "Unexpected solver response: %s" (Sexplib.Sexp.to_string_hum s));
+        [%l.error
+          "Unexpected solver response: %s" (Sexplib.Sexp.to_string_hum s)];
         Unknown
     in
     match smt_res with
     | Sat -> Sat
     | Unsat -> Unsat
     | Unknown ->
-        L.info (fun m -> m "Solver returned unknown");
+        [%l.info "Solver returned unknown"];
         Unknown
 
   let push solver n = ack_command solver (Simple_smt.push n)

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -568,7 +568,7 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
     match Fuel.consume_fuel_steps n with
     | Exhausted ->
         Stats.As_ctx.incr StatKeys.unexplored_branches;
-        L.debug (fun m -> m "Exhausted step fuel")
+        [%l.debug "Exhausted step fuel"]
     | Not_exhausted ->
         Stats.As_ctx.add_int StatKeys.steps n;
         f ()
@@ -583,8 +583,7 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
           let l = Solver.simplify l in
           match Value.to_bool l with
           | Some true -> aux acc ls
-          | Some false ->
-              L.trace (fun m -> m "Assuming false, stopping this branch")
+          | Some false -> [%l.trace "Assuming false, stopping this branch"]
           | None -> aux (l :: acc) ls)
     in
     aux [] learned
@@ -605,8 +604,8 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
         Solver.add_constraints [ Value.(not value) ];
         let sat_result = Solver.sat () in
         let () =
-          L.debug (fun m ->
-              m "Entailment SAT check returned %a" Solver_result.pp sat_result)
+          [%l.debug
+            "Entailment SAT check returned %a" Solver_result.pp sat_result]
         in
         Symex_state.backtrack_n 1;
         if Approx.As_ctx.is_ux () then not (Solver_result.is_sat sat_result)
@@ -644,7 +643,7 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
             let sat_res = Solver.sat () in
             left_unsat := Solver_result.is_unsat sat_res;
             if Solver_result.is_sat sat_res then then_ () f
-            else L.trace (fun m -> m "Branch is not feasible"));
+            else [%l.trace "Branch is not feasible"]);
         Symex_state.backtrack_n 1;
         L.with_section ~is_branch:true right_branch_name (fun () ->
             Solver.add_constraints [ Value.(not guard) ];
@@ -657,12 +656,11 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
               match Fuel.consume_branching 1 with
               | Exhausted ->
                   Stats.As_ctx.incr StatKeys.unexplored_branches;
-                  L.debug (fun m ->
-                      m "Exhausted branching fuel, not continuing")
+                  [%l.debug "Exhausted branching fuel, not continuing"]
               | Not_exhausted ->
                   Stats.As_ctx.incr StatKeys.branches;
                   if Solver_result.is_sat (Solver.sat ()) then else_ () f
-                  else L.trace (fun m -> m "Branch is not feasible")))
+                  else [%l.trace "Branch is not feasible"]))
 
   let if_sure ?left_branch_name:_ ?right_branch_name:_ guard
       ~(then_ : unit -> 'a t) ~(else_ : unit -> 'a t) : 'a t =
@@ -750,7 +748,7 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
   let give_up reason _f =
     (* The bind ensures that the side effect will not be enacted before the
        whole process is ran. *)
-    L.warn (fun m -> m "Gave up: %s" reason);
+    [%l.warn "Gave up: %s" reason];
     Stats.As_ctx.push_str StatKeys.give_up_reasons reason;
     if
       Approx.As_ctx.is_ox ()
@@ -794,7 +792,7 @@ module Base_extension (Core : Core) = struct
     let miss_no_fix ~reason () =
       bind (ok ()) @@ fun () ->
       Stats.As_ctx.push_str StatKeys.miss_without_fix reason;
-      L.debug (fun m -> m "Missing without fix: %s" reason);
+      [%l.debug "Missing without fix: %s" reason];
       miss []
 
     let foldM ~fold x ~init ~f = Monad.foldM ~bind ~return:ok ~fold x ~init ~f
@@ -905,11 +903,10 @@ module Base_extension (Core : Core) = struct
       let open Syntax in
       let is_bool = Value.is_bool_ty @@ Value.Expr.ty e in
       if not is_bool then (
-        L.error (fun m ->
-            m
-              "Producing non-boolean pure value!! This is quite probably a \
-               tool bug, please report it. Expr: %a"
-              Value.Expr.pp e);
+        [%l.error
+          "Producing non-boolean pure value!! This is quite probably a tool \
+           bug, please report it. Expr: %a"
+          Value.Expr.pp e];
         vanish ())
       else
         let* v = apply_subst Fun.id e in

--- a/soteria/lib/tiny_values/tiny_solver.ml
+++ b/soteria/lib/tiny_values/tiny_solver.ml
@@ -118,7 +118,7 @@ struct
         | Sat -> Sat
         | Unsat -> Unsat
         | Unknown ->
-            L.info (fun m -> m "Solver returned unknown");
+            [%l.info "Solver returned unknown"];
             Unknown)
 
   let as_values solver =

--- a/soteria/ppx/logs.ml
+++ b/soteria/ppx/logs.ml
@@ -1,0 +1,39 @@
+open Ppxlib
+
+module Extension_name = struct
+  type t = Debug | Info | Warn | Error | Trace | Smt
+
+  let to_string = function
+    | Debug -> "l.debug"
+    | Info -> "l.info"
+    | Warn -> "l.warn"
+    | Error -> "l.error"
+    | Trace -> "l.trace"
+    | Smt -> "l.smt"
+end
+
+let associated_fn ~loc = function
+  | Extension_name.Debug -> [%expr L.debug]
+  | Info -> [%expr L.info]
+  | Warn -> [%expr L.warn]
+  | Error -> [%expr L.error]
+  | Trace -> [%expr L.trace]
+  | Smt -> [%expr L.smt]
+
+let rec split_apply expr =
+  match expr.pexp_desc with
+  | Pexp_apply (fn, args) ->
+      let head, args' = split_apply fn in
+      (head, args' @ args)
+  | _ -> (expr, [])
+
+let expand ~ext expr =
+  let loc = { expr.pexp_loc with loc_ghost = true } in
+  let fn = associated_fn ~loc ext in
+  let fmt, args = split_apply expr in
+  (* we use "m__" as the name of the argument to the function passed to [fn] to
+     avoid potential name clashes with variables in the original expression *)
+  let m_call =
+    Ast_builder.Default.pexp_apply ~loc [%expr m__] ((Nolabel, fmt) :: args)
+  in
+  [%expr [%e fn] (fun m__ -> [%e m_call])]

--- a/soteria/ppx/logs.ml
+++ b/soteria/ppx/logs.ml
@@ -20,17 +20,40 @@ let associated_fn ~loc = function
   | Trace -> [%expr L.trace]
   | Smt -> [%expr L.smt]
 
-let rec split_apply expr =
-  match expr.pexp_desc with
-  | Pexp_apply (fn, args) ->
-      let head, args' = split_apply fn in
-      (head, args' @ args)
-  | _ -> (expr, [])
+let split_apply expr =
+  let rec aux acc expr =
+    match expr.pexp_desc with
+    | Pexp_apply (fn, args) -> aux (args @ acc) fn
+    | _ -> (expr, acc)
+  in
+  aux [] expr
+
+let validate_payload ~ext fmt args =
+  let string_of_arg_label = function
+    | Nolabel -> ""
+    | Labelled l -> "~" ^ l
+    | Optional l -> "?" ^ l
+  in
+  let has_labelled_arg = function Nolabel, _ -> false | _ -> true in
+  match List.find_opt has_labelled_arg args with
+  | Some (label, _) ->
+      Location.raise_errorf ~loc:fmt.pexp_loc
+        "%%%s does not support labelled or optional arguments (found %s)"
+        (Extension_name.to_string ext)
+        (string_of_arg_label label)
+  | None -> (
+      match fmt.pexp_desc with
+      | Pexp_constant (Pconst_string _) -> ()
+      | _ ->
+          Location.raise_errorf ~loc:fmt.pexp_loc
+            "%%%s expects a string literal format as first argument"
+            (Extension_name.to_string ext))
 
 let expand ~ext expr =
   let loc = { expr.pexp_loc with loc_ghost = true } in
   let fn = associated_fn ~loc ext in
   let fmt, args = split_apply expr in
+  let () = validate_payload ~ext fmt args in
   (* we use "m__" as the name of the argument to the function passed to [fn] to
      avoid potential name clashes with variables in the original expression *)
   let m_call =

--- a/soteria/ppx/ppx_symex.ml
+++ b/soteria/ppx/ppx_symex.ml
@@ -18,13 +18,10 @@ let log_ext ext =
 
 (* Registring [if%sat] *)
 let () =
-  let open Expander.If_sat in
-  let register extension =
-    Driver.register_transformation
-      (Extension_name.to_string extension)
-      ~extensions:[ ext extension ]
+  let extensions =
+    List.map ext Expander.If_sat.Extension_name.[ Sat; Sat1; Sure ]
   in
-  List.iter register [ Sat; Sat1; Sure ]
+  Driver.register_transformation "if_sat" ~extensions
 
 (* Register [0s], [1s] etc. *)
 let () =
@@ -38,10 +35,8 @@ let () = Reversible.register ()
 
 (* Register [%l.debug], [%l.info], ... *)
 let () =
-  let open Logs in
-  let register extension =
-    Driver.register_transformation
-      (Extension_name.to_string extension)
-      ~extensions:[ log_ext extension ]
+  let extensions =
+    List.map log_ext
+      Logs.Extension_name.[ Debug; Info; Warn; Error; Trace; Smt ]
   in
-  List.iter register [ Debug; Info; Warn; Error; Trace; Smt ]
+  Driver.register_transformation "logs" ~extensions

--- a/soteria/ppx/ppx_symex.ml
+++ b/soteria/ppx/ppx_symex.ml
@@ -8,6 +8,14 @@ let ext ext =
     Ast_pattern.(single_expr_payload __)
     (fun ~loc:_ ~path:_ ~arg:_ expr -> expand ~ext expr)
 
+let log_ext ext =
+  let open Logs in
+  Extension.declare_with_path_arg
+    (Extension_name.to_string ext)
+    Extension.Context.expression
+    Ast_pattern.(single_expr_payload __)
+    (fun ~loc:_ ~path:_ ~arg:_ expr -> expand ~ext expr)
+
 (* Registring [if%sat] *)
 let () =
   let open Expander.If_sat in
@@ -27,3 +35,13 @@ let () =
 
 (* Register [@@deriving reversible] *)
 let () = Reversible.register ()
+
+(* Register [%l.debug], [%l.info], ... *)
+let () =
+  let open Logs in
+  let register extension =
+    Driver.register_transformation
+      (Extension_name.to_string extension)
+      ~extensions:[ log_ext extension ]
+  in
+  List.iter register [ Debug; Info; Warn; Error; Trace; Smt ]

--- a/soteria/tests/ppx/dune
+++ b/soteria/tests/ppx/dune
@@ -12,5 +12,9 @@
   ./reversible/simple.ml
   ./reversible/ignored.ml
   ./reversible/all_ignored.ml
-  ./reversible/err_non_t.ml)
+  ./reversible/err_non_t.ml
+  ./logs/prelude.ml
+  ./logs/simple.ml
+  ./logs/err_function_payload.ml
+  ./logs/err_labelled.ml)
  (applies_to :whole_subtree))

--- a/soteria/tests/ppx/logs/err_function_payload.ml
+++ b/soteria/tests/ppx/logs/err_function_payload.ml
@@ -1,0 +1,3 @@
+open Prelude
+
+let () = [%l.debug fun x -> x]

--- a/soteria/tests/ppx/logs/err_function_payload.t
+++ b/soteria/tests/ppx/logs/err_function_payload.t
@@ -1,0 +1,6 @@
+  $ ../test.sh err_function_payload.ml
+  File "err_function_payload.ml", line 3, characters 19-29:
+  3 | let () = [%l.debug fun x -> x]
+                         ^^^^^^^^^^
+  Error: %l.debug expects a string literal format as first argument
+  [1]

--- a/soteria/tests/ppx/logs/err_labelled.ml
+++ b/soteria/tests/ppx/logs/err_labelled.ml
@@ -1,0 +1,3 @@
+open Prelude
+
+let () = [%l.info f ~foo:1 "x"]

--- a/soteria/tests/ppx/logs/err_labelled.t
+++ b/soteria/tests/ppx/logs/err_labelled.t
@@ -1,0 +1,6 @@
+  $ ../test.sh err_labelled.ml
+  File "err_labelled.ml", line 3, characters 18-19:
+  3 | let () = [%l.info f ~foo:1 "x"]
+                        ^
+  Error: %l.info does not support labelled or optional arguments (found ~foo)
+  [1]

--- a/soteria/tests/ppx/logs/prelude.ml
+++ b/soteria/tests/ppx/logs/prelude.ml
@@ -1,0 +1,9 @@
+module L = struct
+  let sink fmt = Format.ifprintf Format.std_formatter fmt
+  let debug f = f sink
+  let info f = f sink
+  let warn f = f sink
+  let error f = f sink
+  let trace f = f sink
+  let smt f = f sink
+end

--- a/soteria/tests/ppx/logs/simple.ml
+++ b/soteria/tests/ppx/logs/simple.ml
@@ -1,0 +1,9 @@
+open Prelude
+
+let () =
+  [%l.debug "debug %d" 1];
+  [%l.info "info %s" "x"];
+  [%l.warn "warn %a" Fmt.int 2];
+  [%l.error "error"];
+  [%l.trace "trace"];
+  [%l.smt "smt"]

--- a/soteria/tests/ppx/logs/simple.t
+++ b/soteria/tests/ppx/logs/simple.t
@@ -1,0 +1,11 @@
+  $ ../test.sh simple.ml
+  open Prelude
+  
+  let () =
+    L.debug (fun m__ -> m__ "debug %d" 1);
+    L.info (fun m__ -> m__ "info %s" "x");
+    L.warn (fun m__ -> m__ "warn %a" Fmt.int 2);
+    L.error (fun m__ -> m__ "error");
+    L.trace (fun m__ -> m__ "trace");
+    L.smt (fun m__ -> m__ "smt")
+  Success ✅

--- a/soteria/tutorial/logs.mld
+++ b/soteria/tutorial/logs.mld
@@ -10,6 +10,7 @@ Today you'll be learning how to:
 - {{!html}Output to HTML} with collapsible sections
 - {{!printers}Format output} with colors and styles
 - {{!performance}Write efficient logging} that won't slow your programs down
+- {{!ppx}Use the PPX extension} for convenient logging
 
 {2:basic Basic Logging}
 
@@ -323,6 +324,24 @@ L.trace (fun m ->
   let expensive_string = String.concat ", " (List.init 1000 string_of_int) in
   m "Generated: %s" expensive_string
 );;
+]}
+
+{2:ppx PPX Extension}
+
+Writing calls to the logging function can be a bit verbose, with the need to wrap everything in a lambda. Soteria provides a PPX extension that allows you to write more concise logging statements using [[%l.info]], [[%l.debug]], etc. To use it, first add the PPX dependency to your [dune] file:
+
+{@dune[
+(preprocess (pps ppx_symex))
+]}
+
+This is purely syntactic sugar to save some typing and improve readability. It does not supporting declarations within the logging statement, so if you need to do any let-bindings or computations, you should still use the full lambda form.
+
+{@ocaml[
+[%l.info "Starting symbolic execution"];;
+[%l.debug "Variable x = %d" 67];;
+(* Expands to: *)
+L.info (fun m -> m "Starting symbolic execution");;
+L.debug (fun m -> m "Variable x = %d" 67);;
 ]}
 
 {2 That's it!}


### PR DESCRIPTION
Add a PPX for the logging functions, and use it everywhere. Overall there are 27 instances of the PPX saving us a line of code, which is pretty cool! overall it improves readability quite a bit, esp. for large logging functions where indentation was ridiculously big

```diff
- L.trace (fun m ->
-     m
-       "Produced heap, about to check if path condition holds in \
-        every branch");
+ [%l.trace
+   "Produced heap, about to check if path condition holds in every \
+    branch"];
```