### PR TITLE
Better symex run

### DIFF
--- a/doc/odoc-theme/odoc.css
+++ b/doc/odoc-theme/odoc.css
@@ -361,6 +361,7 @@ body.odoc {
 
 .odoc-content {
 	grid-area: content;
+	padding-bottom: 200px;
 }
 
 .odoc-content > *:first-child {

--- a/soteria-c/lib/abductor.ml
+++ b/soteria-c/lib/abductor.ml
@@ -40,7 +40,7 @@ let generate_summaries_for (fundef : fundef) =
   in
   let res =
     let@ () = L.with_section "Running symbolic execution" in
-    Csymex.run_needs_stats ~mode:UX ~fuel:default_abductor_fuel process
+    Csymex.run ~stats:Handled ~mode:UX ~fuel:default_abductor_fuel process
   in
   let+ (args, ret, bi_state), pc = res in
   let args = List.map Aggregate_val.to_syn args in

--- a/soteria-c/lib/abductor.ml
+++ b/soteria-c/lib/abductor.ml
@@ -40,7 +40,7 @@ let generate_summaries_for (fundef : fundef) =
   in
   let res =
     let@ () = L.with_section "Running symbolic execution" in
-    Csymex.run ~stats:Handled ~mode:UX ~fuel:default_abductor_fuel process
+    Csymex.run ~stats:Caller ~mode:UX ~fuel:default_abductor_fuel process
   in
   let+ (args, ret, bi_state), pc = res in
   let args = List.map Aggregate_val.to_syn args in

--- a/soteria-c/lib/csymex.ml
+++ b/soteria-c/lib/csymex.ml
@@ -59,24 +59,18 @@ let not_impl msg =
 let of_opt = function Some x -> return x | None -> vanish ()
 let of_opt_not_impl ~msg = function Some x -> return x | None -> not_impl msg
 
-let run ?fuel ~mode process =
+let run ?stats ?flamegraph ?fuel ~mode process =
   run_with_state ~state:Cerb_location.unknown process
   |> SYMEX.map fst
-  |> SYMEX.run ?fuel ~mode
-
-let run_needs_stats ?fuel ~mode process =
-  run_with_state ~state:Cerb_location.unknown process
-  |> SYMEX.map fst
-  |> SYMEX.run_needs_stats ?fuel ~mode
+  |> SYMEX.run ?stats ?flamegraph ?fuel ~mode
 
 module Result = struct
   include CSYMEX.Result
 
-  let run_needs_stats ?flamegraph ?fuel ?fail_fast ~mode
-      (process : ('a, 'b, 'c) CSYMEX.Result.t) =
+  let run ?stats ?flamegraph ?fuel ?fail_fast ~mode process =
     CSYMEX.run_with_state ~state:Cerb_location.unknown process
     |> SYMEX.map fst
-    |> SYMEX.Result.run_needs_stats ?flamegraph ?fuel ?fail_fast ~mode
+    |> SYMEX.Result.run ?stats ?flamegraph ?fuel ?fail_fast ~mode
 
   let error_with_loc ?msg err =
     let open Syntax in

--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -300,7 +300,7 @@ let generate_errors content =
 let initialise ?soteria_config mode config f =
   Option.iter Soteria.Config.set_and_lock soteria_config;
   let@ () = Config.with_config ~config ~mode in
-  Soteria.Stats.As_ctx.with_stats_dumped () f
+  Soteria.Stats.As_ctx.with_dumped () f
 
 let print_states result =
   let pp_state ft state =

--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -258,9 +258,10 @@ let exec_function ~includes ~fuel file_names function_name =
         [%l.debug "@[<2>Initial state:@ %a@]" (Fmt.Dump.option SState.pp) state];
         Wpst_interp.exec_fun entry_point ~args:[]
       in
-      let flamegraph = function_name in
       let@ () = with_function_context linked in
-      Ok (Csymex.Result.run_needs_stats ~flamegraph ~mode:OX ~fuel symex)
+      Ok
+        (Csymex.Result.run ~stats:Handled ~flamegraph:(Dump function_name)
+           ~mode:OX ~fuel symex)
   in
   match result with
   | Ok v -> v

--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -258,13 +258,9 @@ let exec_function ~includes ~fuel file_names function_name =
         [%l.debug "@[<2>Initial state:@ %a@]" (Fmt.Dump.option SState.pp) state];
         Wpst_interp.exec_fun entry_point ~args:[]
       in
-      let flamegraph =
-        Option.map
-          (fun d -> Filename.concat d function_name)
-          (Soteria.Profiling.Config.get ()).flamegraphs
-      in
+      let flamegraph = function_name in
       let@ () = with_function_context linked in
-      Ok (Csymex.Result.run_needs_stats ?flamegraph ~mode:OX ~fuel symex)
+      Ok (Csymex.Result.run_needs_stats ~flamegraph ~mode:OX ~fuel symex)
   in
   match result with
   | Ok v -> v

--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -260,7 +260,7 @@ let exec_function ~includes ~fuel file_names function_name =
       in
       let@ () = with_function_context linked in
       Ok
-        (Csymex.Result.run ~stats:Handled ~flamegraph:(Dump function_name)
+        (Csymex.Result.run ~stats:Caller ~flamegraph:(Dump function_name)
            ~mode:OX ~fuel symex)
   in
   match result with

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -264,7 +264,7 @@ let rec analyse : type a. fid:Ail_tys.sym -> a t -> analysed t =
           in
           let is_manifest =
             try
-              let result = Csymex.run ~stats:Handled ~mode:OX process in
+              let result = Csymex.run ~stats:Caller ~mode:OX process in
               [%l.debug
                 "%a"
                   Fmt.(

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -264,7 +264,7 @@ let rec analyse : type a. fid:Ail_tys.sym -> a t -> analysed t =
           in
           let is_manifest =
             try
-              let result = Csymex.run_needs_stats ~mode:OX process in
+              let result = Csymex.run ~stats:Handled ~mode:OX process in
               [%l.debug
                 "%a"
                   Fmt.(

--- a/soteria-rust/lib/analyses/wpst.ml
+++ b/soteria-rust/lib/analyses/wpst.ml
@@ -61,13 +61,7 @@ let print_outcomes entry_name f =
         "%s (%a): %s, %s@.@." entry_name pp_time time error msg;
       (entry_name, Outcome.Fatal)
 
-let flamegraph_name entry_name =
-  (Soteria.Profiling.Config.get ()).flamegraphs
-  |> Option.map (fun dirname ->
-      let entry_name =
-        Str.global_replace (Str.regexp_string "::") "-" entry_name
-      in
-      Filename.concat dirname entry_name)
+let flamegraph_name = Str.global_replace (Str.regexp_string "::") "-"
 
 let exec_crate (crate : Charon.UllbcAst.crate)
     (entry_points : Frontend.entry_point list) =
@@ -92,12 +86,12 @@ let exec_crate (crate : Charon.UllbcAst.crate)
       [ Int (Typed.BV.usizei 0); Ptr (State.Sptr.null (), Thin) ]
     else []
   in
-  let { res = branches; stats } : 'res Soteria.Stats.with_stats =
+  let branches, stats =
     let@ () = L.entry_point_section fun_decl.item_meta.name in
     let@ () = Layout.Session.with_layout_cache in
     let@@ () =
       Rustsymex.Result.run_with_stats
-        ?flamegraph:(flamegraph_name entry_name)
+        ~flamegraph:(flamegraph_name entry_name)
         ~mode:OX ~fuel ~fail_fast:(Config.get ()).fail_fast
     in
     exec_fun fun_decl ~args

--- a/soteria-rust/lib/analyses/wpst.ml
+++ b/soteria-rust/lib/analyses/wpst.ml
@@ -87,12 +87,13 @@ let exec_crate (crate : Charon.UllbcAst.crate)
     else []
   in
   let branches, stats =
+    let@ () = Stats.As_ctx.with_ () in
     let@ () = L.entry_point_section fun_decl.item_meta.name in
     let@ () = Layout.Session.with_layout_cache in
     let@@ () =
       Rustsymex.Result.run_with_stats
-        ~flamegraph:(flamegraph_name entry_name)
-        ~mode:OX ~fuel ~fail_fast:(Config.get ()).fail_fast
+        ~flamegraph:(Dump (flamegraph_name entry_name))
+        ~stats:(Dump ()) ~mode:OX ~fuel ~fail_fast:(Config.get ()).fail_fast
     in
     exec_fun fun_decl ~args
   in

--- a/soteria-rust/lib/rustsymex.ml
+++ b/soteria-rust/lib/rustsymex.ml
@@ -49,20 +49,10 @@ include Syntaxes.FunctionWrap
    state, and remove it from [MonadState], or add a [serialized] type to
    [Rustsymex], along with the relevant [produce], [consume], etc. *)
 
-let run ?fuel ~mode symex =
+let run ?stats ?flamegraph ?fuel ~mode symex =
   run_with_state ~state:MonadState.empty symex
   |> MonoSymex.map fst
-  |> MonoSymex.run ?fuel ~mode
-
-let run_with_stats ?fuel ~mode symex =
-  run_with_state ~state:MonadState.empty symex
-  |> MonoSymex.map fst
-  |> MonoSymex.run_with_stats ?fuel ~mode
-
-let run_needs_stats ?fuel ~mode symex =
-  run_with_state ~state:MonadState.empty symex
-  |> MonoSymex.map fst
-  |> MonoSymex.run_needs_stats ?fuel ~mode
+  |> MonoSymex.run ?stats ?flamegraph ?fuel ~mode
 
 module Result = struct
   include Result
@@ -73,15 +63,10 @@ module Result = struct
     | Error (e, _) -> Error e
     | Missing f -> Missing f
 
-  let run_with_stats ?flamegraph ?fuel ?fail_fast ~mode symex =
+  let run_with_stats ?stats ?flamegraph ?fuel ?fail_fast ~mode symex =
     run_with_state ~state:MonadState.empty symex
     |> MonoSymex.map ignore_state
-    |> MonoSymex.Result.run_with_stats ?flamegraph ?fuel ?fail_fast ~mode
-
-  let run_needs_stats ?flamegraph ?fuel ?fail_fast ~mode symex =
-    run_with_state ~state:MonadState.empty symex
-    |> MonoSymex.map ignore_state
-    |> MonoSymex.Result.run_needs_stats ?flamegraph ?fuel ?fail_fast ~mode
+    |> MonoSymex.Result.run ?stats ?flamegraph ?fuel ?fail_fast ~mode
 end
 
 module Poly = struct

--- a/soteria/lib/profiling/flamegraph.ml
+++ b/soteria/lib/profiling/flamegraph.ml
@@ -48,12 +48,15 @@ module Make (M : Monad.Base) = struct
   let checkpoint () = Effect.perform Checkpoint
 
   let with_frame (name : string) (f : unit -> 'a M.t) : 'a M.t =
-    push_frame name;
-    M.map
-      (fun r ->
-        pop_frame ();
-        r)
-      (f ())
+    (* the bind + return to make sure the effect isn't raised until the
+       computation is ran. *)
+    M.return ()
+    |> M.bind @@ fun () ->
+       push_frame name;
+       f ()
+       |> M.map @@ fun r ->
+          pop_frame ();
+          r
 
   let with_ _name f =
     let stacks = ref [] in

--- a/soteria/lib/profiling/flamegraph.ml
+++ b/soteria/lib/profiling/flamegraph.ml
@@ -1,5 +1,4 @@
 open Soteria_std
-open Syntaxes.FunctionWrap
 
 type frame = string
 type stack = { rev_frames : frame list; weight : float }
@@ -11,7 +10,7 @@ let pop_stack (stack : stack) =
   let rev_frames = List.tl stack.rev_frames in
   { stack with rev_frames }
 
-let write_folded_stacks path stacks =
+let dump path stacks =
   let path =
     if String.ends_with ~suffix:".collapsed" path then path
     else path ^ ".collapsed"
@@ -38,6 +37,8 @@ module Make (M : Monad.Base) = struct
     | Save : unit Effect.t
     | Checkpoint : unit Effect.t
 
+  type t = stack list
+
   let push_frame (s : string) : unit =
     Effect.perform (Map_stack (push_string_to_stack s))
 
@@ -54,7 +55,7 @@ module Make (M : Monad.Base) = struct
         r)
       (f ())
 
-  let with_dumped flamegraph f =
+  let with_ _name f =
     let stacks = ref [] in
     let current_stack : stack Dynarray.t = Dynarray.create () in
     Dynarray.add_last current_stack
@@ -72,12 +73,11 @@ module Make (M : Monad.Base) = struct
       stacks := { stack with weight = elapsed } :: !stacks
     in
     let open Effect.Deep in
-    let@ () =
-      Fun.protect ~finally:(fun () ->
-          checkpoint ();
-          write_folded_stacks flamegraph (List.rev !stacks))
-    in
-    try f () with
+    try
+      let res = f () in
+      checkpoint ();
+      (res, List.rev !stacks)
+    with
     | effect Map_stack g, k ->
         checkpoint ();
         map_stack g;
@@ -101,4 +101,13 @@ module Make (M : Monad.Base) = struct
     | effect Backtrack_n _, k -> continue k ()
     | effect Save, k -> continue k ()
     | effect Checkpoint, k -> continue k ()
+
+  let with_dumped name f =
+    match (Config.get ()).flamegraphs with
+    | None -> with_ignored () f
+    | Some dir ->
+        let res, stack = with_ name f in
+        let dest_file = Filename.concat dir name in
+        dump dest_file stack;
+        res
 end

--- a/soteria/lib/profiling/flamegraph.ml
+++ b/soteria/lib/profiling/flamegraph.ml
@@ -1,4 +1,5 @@
 open Soteria_std
+open Syntaxes.FunctionWrap
 
 type frame = string
 type stack = { rev_frames : frame list; weight : float }
@@ -30,7 +31,7 @@ let write_folded_stacks path stacks =
   | exception Sys_error e ->
       Terminal.Warn.warn (Fmt.str "Failed to write flamegraph to %s: %s" path e)
 
-module Make () = struct
+module Make (M : Monad.Base) = struct
   type _ Effect.t +=
     | Map_stack : (stack -> stack) -> unit Effect.t
     | Backtrack_n : int -> unit Effect.t
@@ -45,23 +46,19 @@ module Make () = struct
   let backtrack_n n = Effect.perform (Backtrack_n n)
   let checkpoint () = Effect.perform Checkpoint
 
-  module With_frame (M : Monad.Base) = struct
-    let with_frame (name : string) (f : unit -> 'a M.t) : 'a M.t =
-      push_frame name;
-      M.map
-        (fun r ->
-          pop_frame ();
-          r)
-        (f ())
-  end
+  let with_frame (name : string) (f : unit -> 'a M.t) : 'a M.t =
+    push_frame name;
+    M.map
+      (fun r ->
+        pop_frame ();
+        r)
+      (f ())
 
-  let run ~flamegraph f =
+  let with_dumped flamegraph f =
     let stacks = ref [] in
     let current_stack : stack Dynarray.t = Dynarray.create () in
-    let () =
-      Dynarray.add_last current_stack
-        { rev_frames = [ "SYMBOLIC EXECUTION ROOT" ]; weight = 0.0 }
-    in
+    Dynarray.add_last current_stack
+      { rev_frames = [ "SYMBOLIC EXECUTION ROOT" ]; weight = 0.0 };
     let last_checkpoint = ref (Unix.gettimeofday ()) in
     let map_stack (g : stack -> stack) =
       let last = Dynarray.pop_last current_stack in
@@ -75,39 +72,33 @@ module Make () = struct
       stacks := { stack with weight = elapsed } :: !stacks
     in
     let open Effect.Deep in
-    Fun.protect
-      ~finally:(fun () ->
+    let@ () =
+      Fun.protect ~finally:(fun () ->
+          checkpoint ();
+          write_folded_stacks flamegraph (List.rev !stacks))
+    in
+    try f () with
+    | effect Map_stack g, k ->
         checkpoint ();
-        write_folded_stacks flamegraph (List.rev !stacks))
-      (fun () ->
-        try f () with
-        | effect Map_stack g, k ->
-            checkpoint ();
-            map_stack g;
-            continue k ()
-        | effect Backtrack_n n, k ->
-            checkpoint ();
-            let len = Dynarray.length current_stack in
-            Dynarray.truncate current_stack (len - n);
-            continue k ()
-        | effect Save, k ->
-            Dynarray.add_last current_stack (Dynarray.get_last current_stack);
-            continue k ()
-        | effect Checkpoint, k ->
-            checkpoint ();
-            continue k ())
+        map_stack g;
+        continue k ()
+    | effect Backtrack_n n, k ->
+        checkpoint ();
+        let len = Dynarray.length current_stack in
+        Dynarray.truncate current_stack (len - n);
+        continue k ()
+    | effect Save, k ->
+        Dynarray.add_last current_stack (Dynarray.get_last current_stack);
+        continue k ()
+    | effect Checkpoint, k ->
+        checkpoint ();
+        continue k ()
 
-  let run_ignored f =
+  let with_ignored () f =
     let open Effect.Deep in
     try f () with
     | effect Map_stack _, k -> continue k ()
     | effect Backtrack_n _, k -> continue k ()
     | effect Save, k -> continue k ()
     | effect Checkpoint, k -> continue k ()
-
-  (** is [run] if [flamegraph] is [Some _] and [run_ignored] otherwise *)
-  let run_if_file ~flamegraph =
-    match flamegraph with
-    | Some flamegraph -> fun f -> run ~flamegraph f
-    | None -> fun f -> run_ignored f
 end

--- a/soteria/lib/profiling/profiling.ml
+++ b/soteria/lib/profiling/profiling.ml
@@ -1,0 +1,2 @@
+module Config = Config
+module Flamegraph = Flamegraph

--- a/soteria/lib/profiling/profiling.mli
+++ b/soteria/lib/profiling/profiling.mli
@@ -1,0 +1,46 @@
+open Soteria_std
+
+module Config : sig
+  type t = {
+    flamegraphs : string option;
+        (** Specify the folder in which the flamegraphs will be saved. *)
+  }
+
+  val cmdliner_term : unit -> t Cmdliner.Term.t
+  val set_and_lock : t -> unit
+  val get : unit -> t
+end
+
+module Flamegraph : sig
+  (** Module for creating flamegraph files ([.folded], using the format
+      described in
+      {{:https://github.com/brendangregg/flamegraph}Brendan Gregg's Flamegraph
+       repository}). This system is integrated with the {!Symex} module, making
+      it easy and convenient to use. *)
+
+  module Make (M : Monad.Base) : sig
+    include Effects.Managed_effect with type arg := string
+
+    (* FIXME: unfortunately we can't just reuse [Reversible.Effectful] here as
+       we don't want to expose a [wrap] or [run] *)
+
+    (** Checkpoints the current execution time, by increasing the total time of
+        the current frame with the time elapsed since the last checkpoint. This
+        is automatically called by [backtrack_n], but can also be called
+        manually to checkpoint at specific points in the execution. See also
+        {!Symex.Core.with_frame}. *)
+    val checkpoint : unit -> unit
+
+    (** [with_frame name f] runs function [f] inside a new frame with the given
+        name [name], and adds the time spent executing [f] to that frame. This
+        implicitly checkpoints before and after executing [f]. *)
+    val with_frame : string -> (unit -> 'a M.t) -> 'a M.t
+
+    (** Backtracks the current flamegraph state; this also checkpoints (see
+        {!checkpoint}) *)
+    val backtrack_n : int -> unit
+
+    (** Saves the current flamegraph state. *)
+    val save : unit -> unit
+  end
+end

--- a/soteria/lib/profiling/profiling.mli
+++ b/soteria/lib/profiling/profiling.mli
@@ -19,7 +19,7 @@ module Flamegraph : sig
       it easy and convenient to use. *)
 
   module Make (M : Monad.Base) : sig
-    include Effects.Managed_effect with type arg := string
+    include Effects.Bookkeeping with type arg := string
 
     (* FIXME: unfortunately we can't just reuse [Reversible.Effectful] here as
        we don't want to expose a [wrap] or [run] *)

--- a/soteria/lib/soteria_std/effects.ml
+++ b/soteria/lib/soteria_std/effects.ml
@@ -1,6 +1,7 @@
-(** Module type for an effect that can be managed, by dumping its data
-    "somewhere" (typically a file, configured externally), or by ignoring it. *)
-module type Managed_effect = sig
+(** Module type for an effect used for bookkeeping, which keeps tracks of some
+    information that can then be dumped "somewhere" (typically a file,
+    configured externally), or ignored. *)
+module type Bookkeeping = sig
   (** The type of the information tracked by the effect. *)
   type t
 

--- a/soteria/lib/soteria_std/effects.ml
+++ b/soteria/lib/soteria_std/effects.ml
@@ -1,0 +1,18 @@
+(** Module type for an effect that can be managed, by dumping its data
+    "somewhere" (typically a file, configured externally), or by ignoring it. *)
+module type Managed_effect = sig
+  (** The type of the argument to the effect, if it needs to be tracked. *)
+  type arg
+
+  (** [with_dumped () f] runs function [f] and handles effects raised by the
+      functions of this module, and dumps the resulting data to the file
+      specified by the current (externally-defined) configuration if it is set,
+      or ignores them otherwise (if configured to do so). *)
+  val with_dumped : arg -> (unit -> 'a) -> 'a
+
+  (** [with_ignored () f] runs function [f] and handles effects raised by the
+      functions of this module, but ignores their effect. This is to be used
+      when the user does not wish to pay the performance cost of tracking the
+      effect. *)
+  val with_ignored : unit -> (unit -> 'a) -> 'a
+end

--- a/soteria/lib/soteria_std/effects.ml
+++ b/soteria/lib/soteria_std/effects.ml
@@ -1,10 +1,19 @@
 (** Module type for an effect that can be managed, by dumping its data
     "somewhere" (typically a file, configured externally), or by ignoring it. *)
 module type Managed_effect = sig
+  (** The type of the information tracked by the effect. *)
+  type t
+
   (** The type of the argument to the effect, if it needs to be tracked. *)
   type arg
 
-  (** [with_dumped () f] runs function [f] and handles effects raised by the
+  (** [with_ arg f] runs function [f] and handles effects raised by the
+      functions of this module, and returns a pair of the result of [f] and the
+      data tracked by the effect. This is to be used when the user wants to
+      directly manage the data tracked by the effect. *)
+  val with_ : arg -> (unit -> 'a) -> 'a * t
+
+  (** [with_dumped arg f] runs function [f] and handles effects raised by the
       functions of this module, and dumps the resulting data to the file
       specified by the current (externally-defined) configuration if it is set,
       or ignores them otherwise (if configured to do so). *)

--- a/soteria/lib/soteria_std/soteria_std.ml
+++ b/soteria/lib/soteria_std/soteria_std.ml
@@ -4,6 +4,7 @@ module Bimap = Bimap
 module Cmdliner_helpers = Cmdliner_helpers
 module Compo_res = Compo_res
 module Dynarray = Dynarray
+module Effects = Effects
 module Exn = Exn
 module Filename = Filename
 module Foldable = Foldable

--- a/soteria/lib/stats/stats.ml
+++ b/soteria/lib/stats/stats.ml
@@ -90,10 +90,6 @@ and merge m1 m2 =
   Hstring.iter add_pair m2;
   m
 
-type 'a with_stats = { res : 'a; stats : t }
-
-let map_with_stats f { res; stats } = { res = f res; stats }
-let with_empty_stats res = { res; stats = create () }
 let as_int = function Int n -> n | _ -> raise Incompatible_entries
 let as_float = function Float f -> f | _ -> raise Incompatible_entries
 let as_strseq = function StrSeq arr -> arr | _ -> raise Incompatible_entries
@@ -193,21 +189,18 @@ let output t =
 module As_ctx = struct
   type _ Effect.t += Apply : (t -> unit) -> unit Effect.t
 
-  let with_stats () f =
+  let with_ () f =
     let stats = create () in
-    let res =
-      try f ()
-      with effect Apply f, k ->
-        f stats;
-        Effect.Deep.continue k ()
-    in
-    { res; stats }
+    try (f (), stats)
+    with effect Apply f, k ->
+      f stats;
+      Effect.Deep.continue k ()
 
   let with_ignored () f =
     try f () with effect Apply _, k -> Effect.Deep.continue k ()
 
   let with_dumped () f =
-    let { res; stats } = with_stats () f in
+    let res, stats = with_ () f in
     if Option.is_some (Config.get ()).output_stats then output stats;
     res
 

--- a/soteria/lib/stats/stats.ml
+++ b/soteria/lib/stats/stats.ml
@@ -203,10 +203,10 @@ module As_ctx = struct
     in
     { res; stats }
 
-  let with_stats_ignored () f =
+  let with_ignored () f =
     try f () with effect Apply _, k -> Effect.Deep.continue k ()
 
-  let with_stats_dumped () f =
+  let with_dumped () f =
     let { res; stats } = with_stats () f in
     if Option.is_some (Config.get ()).output_stats then output stats;
     res

--- a/soteria/lib/stats/stats.mli
+++ b/soteria/lib/stats/stats.mli
@@ -19,12 +19,8 @@ type stat_entry =
           this as a last resort when no other type fits. *)
 
 type t [@@deriving yojson]
-type 'a with_stats = { res : 'a; stats : t }
 
 exception Incompatible_entries
-
-val with_empty_stats : 'a -> 'a with_stats
-val map_with_stats : ('a -> 'b) -> 'a with_stats -> 'b with_stats
 
 (** [merge s1 s2] merges two statistics [s1] and [s2] into a single statistic by
     combining their entries. Does not modify [s1] or [s2]. *)
@@ -165,13 +161,7 @@ module As_ctx : sig
       only inside a function wrapped with {!val-with_stats}, ensuring that the
       statistics are properly passed around. *)
 
-  include Effects.Managed_effect with type arg := unit
-
-  (** [with_stats () f] runs function [f] and handles effects raised by the
-      functions of this module such as {!push_entry}, and returns a record
-      containing the result of executing [f] together with the obtained
-      statistics. *)
-  val with_stats : unit -> (unit -> 'a) -> 'a with_stats
+  include Effects.Managed_effect with type arg := unit and type t := t
 
   (** [push_entry name entry] adds the given statistic [entry] under the given
       name [name] to the current statistics context. *)

--- a/soteria/lib/stats/stats.mli
+++ b/soteria/lib/stats/stats.mli
@@ -1,6 +1,7 @@
 (** Tracking of statistics across symbolic execution. *)
 
-open Soteria_std.Hashtbl
+open Soteria_std
+open Hashtbl
 
 (** {2 General definitions} *)
 
@@ -164,23 +165,13 @@ module As_ctx : sig
       only inside a function wrapped with {!val-with_stats}, ensuring that the
       statistics are properly passed around. *)
 
+  include Effects.Managed_effect with type arg := unit
+
   (** [with_stats () f] runs function [f] and handles effects raised by the
       functions of this module such as {!push_entry}, and returns a record
       containing the result of executing [f] together with the obtained
       statistics. *)
   val with_stats : unit -> (unit -> 'a) -> 'a with_stats
-
-  (** [with_stats_ignored () f] runs function [f] and handles effects raised by
-      the functions of this module, but ignores their effect. This is to be used
-      when the user does not wish to pay the (minor) performance cost of stats
-      bookkeeping. *)
-  val with_stats_ignored : unit -> (unit -> 'a) -> 'a
-
-  (** [with_stats_dumped () f] runs function [f] and handles effects raised by
-      the functions of this module such as {!push_entry}, and dumps the stats to
-      the file specified by the current [Config.output_stats] if it is set, or
-      ignores them otherwise. *)
-  val with_stats_dumped : unit -> (unit -> 'a) -> 'a
 
   (** [push_entry name entry] adds the given statistic [entry] under the given
       name [name] to the current statistics context. *)

--- a/soteria/lib/stats/stats.mli
+++ b/soteria/lib/stats/stats.mli
@@ -161,7 +161,7 @@ module As_ctx : sig
       only inside a function wrapped with {!val-with_stats}, ensuring that the
       statistics are properly passed around. *)
 
-  include Effects.Managed_effect with type arg := unit and type t := t
+  include Effects.Bookkeeping with type arg := unit and type t := t
 
   (** [push_entry name entry] adds the given statistic [entry] under the given
       name [name] to the current statistics context. *)

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -349,7 +349,7 @@ module type S = sig
     ?fuel:Fuel_gauge.t ->
     mode:Approx.t ->
     'a t ->
-    ('a * sbool v list) list Stats.with_stats
+    ('a * sbool v list) list * Stats.t
 
   (** Same as {!run} but has to be run within {!Stats.As_ctx.with_stats} or will
       throw an exception. This function is exposed should users wish to run
@@ -383,7 +383,7 @@ module type S = sig
       mode:Approx.t ->
       ('ok, 'err, 'fix) t ->
       (('ok, 'err Or_gave_up.t, 'fix) Compo_res.t * Value.(sbool t) list) list
-      Stats.with_stats
+      * Stats.t
 
     val run_needs_stats :
       ?flamegraph:string ->
@@ -1029,7 +1029,7 @@ module Make (Sol : Solver.Mutable_incremental) :
     run_needs_stats ?flamegraph ?fuel ~mode iter
 
   let run_with_stats ?flamegraph ?fuel ~mode iter =
-    let@ () = Stats.As_ctx.with_stats () in
+    let@ () = Stats.As_ctx.with_ () in
     run_needs_stats ?flamegraph ?fuel ~mode iter
 
   module Result = struct
@@ -1065,7 +1065,7 @@ module Make (Sol : Solver.Mutable_incremental) :
       run_needs_stats ?flamegraph ?fuel ?fail_fast ~mode iter
 
     let run_with_stats ?flamegraph ?fuel ?fail_fast ~mode iter =
-      let@ () = Stats.As_ctx.with_stats () in
+      let@ () = Stats.As_ctx.with_ () in
       run_needs_stats ?flamegraph ?fuel ?fail_fast ~mode iter
   end
 end

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -37,7 +37,7 @@ type 'a effect_handling =
       (** Handle the effect, and dump the information according to the relevant
           configuration. The value is the parameter passed to the feature's dump
           handler. *)
-  | Handled
+  | Caller
       (** The effect is already handled by the caller, nothing needs to be done.
       *)
 
@@ -352,8 +352,9 @@ module type S = sig
         handled outside the function (see {!Stats.As_ctx.with_}) or should be
         handled and ignored by this function (default).
       - [flamegraph] specifies whether a flamegraph should be created from this
-        symbolic process or if it should be ignored (default). The value is the
-        name of the top-level frame in the flamegraph.
+        symbolic process or if it should be ignored (default). The value passed
+        in the {{!effect_handling.Dump}Dump} variant is the name of the
+        top-level frame in the flamegraph.
 
       @raise Symex.Gave_up
         if the symbolic process calls [give_up] and the mode is
@@ -1000,18 +1001,18 @@ module Make (Sol : Solver.Mutable_incremental) :
    * let manage (module M : Bookkeeping) = function
    *   | Ignore -> M.with_ignored ()
    *   | Dump arg -> M.with_dumped arg
-   *   | Handled -> fun f -> f ()
+   *   | Caller -> fun f -> f ()
    *)
 
   let manage_flamegraph = function
     | Ignore -> Flamegraph.with_ignored ()
     | Dump name -> Flamegraph.with_dumped name
-    | Handled -> fun f -> f ()
+    | Caller -> fun f -> f ()
 
   let manage_stats = function
     | Ignore -> Stats.As_ctx.with_ignored ()
     | Dump name -> Stats.As_ctx.with_dumped name
-    | Handled -> fun f -> f ()
+    | Caller -> fun f -> f ()
 
   let setup ?(flamegraph = Ignore) ?(stats = Ignore)
       ?(fuel = Fuel_gauge.infinite) ~mode f =

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -499,8 +499,7 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
   module Value = Solver.Value
   module MONAD = Monad.IterM
   include MONAD
-  module Flamegraph = Profiling.Flamegraph.Make ()
-  module Flamegraph_with_frame = Flamegraph.With_frame (MONAD)
+  module Flamegraph = Profiling.Flamegraph.Make (MONAD)
 
   module Give_up = struct
     type _ Effect.t += Gave_up_eff : string -> unit Effect.t
@@ -534,7 +533,10 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
       Flamegraph.save ()
 
     let run ?flamegraph ~init_fuel f =
-      Flamegraph.run_if_file ~flamegraph @@ fun () ->
+      (match flamegraph with
+        | None -> Flamegraph.with_ignored ()
+        | Some f -> Flamegraph.with_dumped f)
+      @@ fun () ->
       Solver.run @@ fun () ->
       Fuel.run ~init:init_fuel @@ fun () -> f ()
   end
@@ -734,8 +736,7 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
     Flamegraph.checkpoint ();
     if should_give_up then Give_up.perform reason
 
-  let with_frame (name : string) (f : unit -> 'a t) : 'a t =
-   fun k -> Flamegraph_with_frame.with_frame name f k
+  let with_frame = Flamegraph.with_frame
 end
 
 module Base_extension (Core : Core) = struct

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -1013,47 +1013,43 @@ module Make (Sol : Solver.Mutable_incremental) :
     | Dump name -> Stats.As_ctx.with_dumped name
     | Handled -> fun f -> f ()
 
-  let run_iter ?(flamegraph = Ignore) ?(stats = Ignore)
-      ?(fuel = Fuel_gauge.infinite) ~mode iter : ('a * Value.(sbool t) list) t =
-   fun continue ->
+  let setup ?(flamegraph = Ignore) ?(stats = Ignore)
+      ?(fuel = Fuel_gauge.infinite) ~mode f =
     let@ () = manage_flamegraph flamegraph in
     let@ () = manage_stats stats in
     let@ () = Stats.As_ctx.add_time_of_to StatKeys.exec_time in
     let@ () = Symex_state.run ~init_fuel:fuel in
     let@ () = Approx.As_ctx.with_mode mode in
     let@ () = Give_up.with_give_up_raising in
+    f ()
+
+  let run_iter ~mode (iter : 'a t) : ('a * Value.(sbool t) list) Iter.t =
+   fun continue ->
     (* Make sure to drop branches that have leftover assumes with unsatisfiable
        PCs. *)
     let admissible () = Solver_result.admissible ~mode (Solver.sat ()) in
     iter @@ fun x -> if admissible () then continue (x, Solver.as_values ())
 
   let run ?flamegraph ?stats ?fuel ~mode iter =
-    Iter.to_list @@ run_iter ?flamegraph ?stats ?fuel ~mode iter
+    let@ () = setup ?flamegraph ?stats ?fuel ~mode in
+    Iter.to_list @@ run_iter ~mode iter
 
   module Result = struct
     include Result
 
-    let run ?(flamegraph = Ignore) ?(stats = Ignore)
-        ?(fuel = Fuel_gauge.infinite) ?(fail_fast = false) ~mode iter =
-      let@ () = manage_flamegraph flamegraph in
-      let@ () = manage_stats stats in
-      let@ () = Stats.As_ctx.add_time_of_to StatKeys.exec_time in
-      let@ () = Symex_state.run ~init_fuel:fuel in
-      let@ () = Approx.As_ctx.with_mode mode in
+    let run ?flamegraph ?stats ?fuel ?(fail_fast = false) ~mode iter =
+      let@ () = setup ?flamegraph ?stats ?fuel ~mode in
       let l = ref [] in
       let () =
         let exception Fail_fast in
         try
-          iter @@ fun x ->
-          if Solver_result.admissible ~mode (Solver.sat ()) then (
-            (* Make sure to drop branche that have leftover assumes with
-               unsatisfiable PCs. *)
-            let x = Compo_res.map_error (fun e -> Or_gave_up.E e) x in
-            l := (x, Solver.as_values ()) :: !l;
-            if fail_fast && Compo_res.is_error x then raise Fail_fast)
+          run_iter ~mode iter @@ fun (res, pc) ->
+          let res = Compo_res.map_error (fun e -> Or_gave_up.E e) res in
+          l := (res, pc) :: !l;
+          if fail_fast && Compo_res.is_error res then raise Fail_fast
         with
         | effect Give_up.Gave_up_eff reason, k ->
-            l := (Compo_res.Error (Gave_up reason), Solver.as_values ()) :: !l;
+            l := (Error (Gave_up reason), Solver.as_values ()) :: !l;
             if fail_fast then Effect.Deep.discontinue k Fail_fast
             else Effect.Deep.continue k ()
         | Fail_fast -> ()

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -1024,7 +1024,7 @@ module Make (Sol : Solver.Mutable_incremental) :
     Iter.to_list (run_needs_stats_iter ?flamegraph ~fuel ~mode iter)
 
   let run ?flamegraph ?fuel ~mode iter =
-    let@ () = Stats.As_ctx.with_stats_ignored () in
+    let@ () = Stats.As_ctx.with_ignored () in
     run_needs_stats ?flamegraph ?fuel ~mode iter
 
   let run_with_stats ?flamegraph ?fuel ~mode iter =
@@ -1060,7 +1060,7 @@ module Make (Sol : Solver.Mutable_incremental) :
       List.rev !l
 
     let run ?flamegraph ?fuel ?fail_fast ~mode iter =
-      let@ () = Stats.As_ctx.with_stats_ignored () in
+      let@ () = Stats.As_ctx.with_ignored () in
       run_needs_stats ?flamegraph ?fuel ?fail_fast ~mode iter
 
     let run_with_stats ?flamegraph ?fuel ?fail_fast ~mode iter =

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -29,6 +29,18 @@ let () =
              reason)
     | _ -> None)
 
+(** The different ways a managed effect can be handled. *)
+type 'a effect_handling =
+  | Ignore
+      (** Handle the effect by ignoring it, so don't collect any information. *)
+  | Dump of 'a
+      (** Handle the effect, and dump the information according to the relevant
+          configuration. The value is the parameter passed to the feature's dump
+          handler. *)
+  | Handled
+      (** The effect is already handled by the caller, nothing needs to be done.
+      *)
+
 module Or_gave_up = struct
   type 'err t = E of 'err | Gave_up of string
 
@@ -322,40 +334,33 @@ module type S = sig
   type 'a v := 'a Value.t
   type sbool := Value.sbool
 
-  (** [run ~fuel  p] actually performs symbolic execution of the symbolic
-      process [p] and returns a list of obtained branches which capture the
-      outcome together with a path condition that is a list of boolean symbolic
-      values.
+  (** [run ~mode p] actually performs symbolic execution of the symbolic process
+      [p] and returns a list of obtained branches which capture the outcome
+      together with a path condition that is a list of boolean symbolic values.
 
       The [mode] parameter is used to specify whether execution should be done
       in an under-approximate ({!Symex.Approx.UX}) or an over-approximate
       ({!Symex.Approx.OX}) manner. Users may optionally pass a
       {{!Fuel_gauge.t}fuel gauge} to limit execution depth and breadth.
 
+      This function also takes a number of optional parameters to configure how
+      the execution is performed and what information is collected during
+      execution:
+      - [fuel] receives a {{!Fuel_gauge.t}fuel gauge} to limit execution depth
+        and breadth. By default, the fuel is infinite.
+      - [stats] specifies whether statistics about the execution are already
+        handled outside the function (see {!Stats.As_ctx.with_}) or should be
+        handled and ignored by this function (default).
+      - [flamegraph] specifies whether a flamegraph should be created from this
+        symbolic process or if it should be ignored (default). The value is the
+        name of the top-level frame in the flamegraph.
+
       @raise Symex.Gave_up
         if the symbolic process calls [give_up] and the mode is
         {!Symex.Approx.OX}. Prefer using {!Result.run} when possible. *)
   val run :
-    ?flamegraph:string ->
-    ?fuel:Fuel_gauge.t ->
-    mode:Approx.t ->
-    'a t ->
-    ('a * sbool v list) list
-
-  (** Same as {!run}, but returns additional information about execution, see
-      {!Soteria.Stats}. *)
-  val run_with_stats :
-    ?flamegraph:string ->
-    ?fuel:Fuel_gauge.t ->
-    mode:Approx.t ->
-    'a t ->
-    ('a * sbool v list) list * Stats.t
-
-  (** Same as {!run} but has to be run within {!Stats.As_ctx.with_stats} or will
-      throw an exception. This function is exposed should users wish to run
-      several symbolic execution processes using a single [stats] record. *)
-  val run_needs_stats :
-    ?flamegraph:string ->
+    ?flamegraph:string effect_handling ->
+    ?stats:unit effect_handling ->
     ?fuel:Fuel_gauge.t ->
     mode:Approx.t ->
     'a t ->
@@ -369,24 +374,8 @@ module type S = sig
         {!Symex.Or_gave_up.t}, potentially adding any path that gave up to the
         list. *)
     val run :
-      ?flamegraph:string ->
-      ?fuel:Fuel_gauge.t ->
-      ?fail_fast:bool ->
-      mode:Approx.t ->
-      ('ok, 'err, 'fix) t ->
-      (('ok, 'err Or_gave_up.t, 'fix) Compo_res.t * Value.(sbool t) list) list
-
-    val run_with_stats :
-      ?flamegraph:string ->
-      ?fuel:Fuel_gauge.t ->
-      ?fail_fast:bool ->
-      mode:Approx.t ->
-      ('ok, 'err, 'fix) t ->
-      (('ok, 'err Or_gave_up.t, 'fix) Compo_res.t * Value.(sbool t) list) list
-      * Stats.t
-
-    val run_needs_stats :
-      ?flamegraph:string ->
+      ?flamegraph:string effect_handling ->
+      ?stats:unit effect_handling ->
       ?fuel:Fuel_gauge.t ->
       ?fail_fast:bool ->
       mode:Approx.t ->
@@ -532,11 +521,7 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
       Fuel.save ();
       Flamegraph.save ()
 
-    let run ?flamegraph ~init_fuel f =
-      (match flamegraph with
-        | None -> Flamegraph.with_ignored ()
-        | Some f -> Flamegraph.with_dumped f)
-      @@ fun () ->
+    let run ~init_fuel f =
       Solver.run @@ fun () ->
       Fuel.run ~init:init_fuel @@ fun () -> f ()
   end
@@ -1011,34 +996,49 @@ module Make (Sol : Solver.Mutable_incremental) :
   include CORE
   include Base_extension (CORE)
 
-  let run_needs_stats_iter ?flamegraph ?(fuel = Fuel_gauge.infinite) ~mode iter
-      : ('a * Value.(sbool t) list) t =
+  (* TODO: with modular explicits this can be implemented for any module:
+   * let manage (module M : Managed_effect) = function
+   *   | Ignore -> M.with_ignored ()
+   *   | Dump arg -> M.with_dumped arg
+   *   | Handled -> fun f -> f ()
+   *)
+
+  let manage_flamegraph = function
+    | Ignore -> Flamegraph.with_ignored ()
+    | Dump name -> Flamegraph.with_dumped name
+    | Handled -> fun f -> f ()
+
+  let manage_stats = function
+    | Ignore -> Stats.As_ctx.with_ignored ()
+    | Dump name -> Stats.As_ctx.with_dumped name
+    | Handled -> fun f -> f ()
+
+  let run_iter ?(flamegraph = Ignore) ?(stats = Ignore)
+      ?(fuel = Fuel_gauge.infinite) ~mode iter : ('a * Value.(sbool t) list) t =
    fun continue ->
+    let@ () = manage_flamegraph flamegraph in
+    let@ () = manage_stats stats in
     let@ () = Stats.As_ctx.add_time_of_to StatKeys.exec_time in
-    let@ () = Symex_state.run ?flamegraph ~init_fuel:fuel in
+    let@ () = Symex_state.run ~init_fuel:fuel in
     let@ () = Approx.As_ctx.with_mode mode in
     let@ () = Give_up.with_give_up_raising in
+    (* Make sure to drop branches that have leftover assumes with unsatisfiable
+       PCs. *)
     let admissible () = Solver_result.admissible ~mode (Solver.sat ()) in
     iter @@ fun x -> if admissible () then continue (x, Solver.as_values ())
 
-  let run_needs_stats ?flamegraph ?(fuel = Fuel_gauge.infinite) ~mode iter =
-    Iter.to_list (run_needs_stats_iter ?flamegraph ~fuel ~mode iter)
-
-  let run ?flamegraph ?fuel ~mode iter =
-    let@ () = Stats.As_ctx.with_ignored () in
-    run_needs_stats ?flamegraph ?fuel ~mode iter
-
-  let run_with_stats ?flamegraph ?fuel ~mode iter =
-    let@ () = Stats.As_ctx.with_ () in
-    run_needs_stats ?flamegraph ?fuel ~mode iter
+  let run ?flamegraph ?stats ?fuel ~mode iter =
+    Iter.to_list @@ run_iter ?flamegraph ?stats ?fuel ~mode iter
 
   module Result = struct
     include Result
 
-    let run_needs_stats ?flamegraph ?(fuel = Fuel_gauge.infinite)
-        ?(fail_fast = false) ~mode iter =
+    let run ?(flamegraph = Ignore) ?(stats = Ignore)
+        ?(fuel = Fuel_gauge.infinite) ?(fail_fast = false) ~mode iter =
+      let@ () = manage_flamegraph flamegraph in
+      let@ () = manage_stats stats in
       let@ () = Stats.As_ctx.add_time_of_to StatKeys.exec_time in
-      let@ () = Symex_state.run ?flamegraph ~init_fuel:fuel in
+      let@ () = Symex_state.run ~init_fuel:fuel in
       let@ () = Approx.As_ctx.with_mode mode in
       let l = ref [] in
       let () =
@@ -1059,13 +1059,5 @@ module Make (Sol : Solver.Mutable_incremental) :
         | Fail_fast -> ()
       in
       List.rev !l
-
-    let run ?flamegraph ?fuel ?fail_fast ~mode iter =
-      let@ () = Stats.As_ctx.with_ignored () in
-      run_needs_stats ?flamegraph ?fuel ?fail_fast ~mode iter
-
-    let run_with_stats ?flamegraph ?fuel ?fail_fast ~mode iter =
-      let@ () = Stats.As_ctx.with_ () in
-      run_needs_stats ?flamegraph ?fuel ?fail_fast ~mode iter
   end
 end

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -997,7 +997,7 @@ module Make (Sol : Solver.Mutable_incremental) :
   include Base_extension (CORE)
 
   (* TODO: with modular explicits this can be implemented for any module:
-   * let manage (module M : Managed_effect) = function
+   * let manage (module M : Bookkeeping) = function
    *   | Ignore -> M.with_ignored ()
    *   | Dump arg -> M.with_dumped arg
    *   | Handled -> fun f -> f ()

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -353,8 +353,9 @@ module type S = sig
         handled and ignored by this function (default).
       - [flamegraph] specifies whether a flamegraph should be created from this
         symbolic process or if it should be ignored (default). The value passed
-        in the {{!effect_handling.Dump}Dump} variant is the name of the
-        top-level frame in the flamegraph.
+        in the {{!effect_handling.Dump}Dump} variant is the name of the created
+        file (while the {{!Profiling.Config}configuration} for flamegraphs
+        specifies the directory in which flamegraphs are saved).
 
       @raise Symex.Gave_up
         if the symbolic process calls [give_up] and the mode is

--- a/soteria/tests/bv_fuzz/fuzz_common.ml
+++ b/soteria/tests/bv_fuzz/fuzz_common.ml
@@ -38,7 +38,7 @@ let pp_pair fmt (smart, direct) =
     pass. *)
 let z3_check_equivalent_raw ~vars_d ~assumptions (smart : Svalue.t)
     (direct : Svalue.t) : Soteria.Symex.Solver_result.t =
-  Soteria.Stats.As_ctx.with_stats_ignored () @@ fun () ->
+  Soteria.Stats.As_ctx.with_ignored () @@ fun () ->
   Z3_raw.reset solver;
   (* The vars of the simplified version should be a subset of the vars of the
      raw version. *)

--- a/soteria/tests/stats/print_stats.ml
+++ b/soteria/tests/stats/print_stats.ml
@@ -17,7 +17,7 @@ let () =
   Soteria.Logs.Config.(set_and_lock (make ~hide_unstable:true ()));
   let _, stats =
     Soteria.Stats.As_ctx.with_ () @@ fun () ->
-    run ~stats:Handled ~mode:UX process
+    run ~stats:Caller ~mode:UX process
   in
   Soteria.Stats.pp Fmt.stdout stats;
   Fmt.pr "@.";

--- a/soteria/tests/stats/print_stats.ml
+++ b/soteria/tests/stats/print_stats.ml
@@ -15,7 +15,10 @@ let process : (int, int, unit) Result.t =
 
 let () =
   Soteria.Logs.Config.(set_and_lock (make ~hide_unstable:true ()));
-  let _, stats = run_with_stats ~mode:UX process in
+  let _, stats =
+    Soteria.Stats.As_ctx.with_ () @@ fun () ->
+    run ~stats:Handled ~mode:UX process
+  in
   Soteria.Stats.pp Fmt.stdout stats;
   Fmt.pr "@.";
   let as_yojson = Soteria.Stats.to_yojson stats in

--- a/soteria/tests/stats/print_stats.ml
+++ b/soteria/tests/stats/print_stats.ml
@@ -15,9 +15,7 @@ let process : (int, int, unit) Result.t =
 
 let () =
   Soteria.Logs.Config.(set_and_lock (make ~hide_unstable:true ()));
-  let { stats; _ } : 'a Soteria.Stats.with_stats =
-    run_with_stats ~mode:UX process
-  in
+  let _, stats = run_with_stats ~mode:UX process in
   Soteria.Stats.pp Fmt.stdout stats;
   Fmt.pr "@.";
   let as_yojson = Soteria.Stats.to_yojson stats in

--- a/soteria/tutorial/core_symex.mld
+++ b/soteria/tutorial/core_symex.mld
@@ -34,7 +34,8 @@ This process has type [int Symex.t], that is, a symbolic process that returns a 
 Executing a symbolic process is done using the {{!Soteria.Symex.S.run}run} function:
 {@ocaml[
 # Symex.run
-- : ?flamegraph:string ->
+- : ?flamegraph:string Symex.effect_handling ->
+    ?stats:unit Symex.effect_handling ->
     ?fuel:Symex.Fuel_gauge.t ->
     mode:Symex.Approx.t ->
     'a Symex.t -> ('a * Symex.Value.sbool Typed.t list) list

--- a/soteria/tutorial/prelude.ml
+++ b/soteria/tutorial/prelude.ml
@@ -1,11 +1,8 @@
 open Soteria;;
 open Tiny_values;;
 
-let pp_stats _pp_inner ft (_t: Soteria.Stats.t) =
-  Fmt.pf ft "...";;
-
-let pp_with_stats pp_res ft ({ res; stats = _ }: 'a Soteria.Stats.with_stats) =
-  Fmt.pf ft "{res = %a; stats = <stats>}" pp_res res;;
+let pp_stats ft (_t: Soteria.Stats.t) =
+  Fmt.pf ft "<stats>";;
 
 let pp_hstring pp_v ft m =
   let pp_pair = Fmt.(pair ~sep:(any " -> ") Fmt.string pp_v) in
@@ -14,7 +11,6 @@ let pp_hstring pp_v ft m =
 
 
 #install_printer pp_stats;;
-#install_printer pp_with_stats;;
 #install_printer pp_run_results;;
 #install_printer Soteria.Tiny_values.Typed.ppa;;
 #install_printer Soteria.Soteria_std.Dynarray.pp;;

--- a/soteria/tutorial/stats.mld
+++ b/soteria/tutorial/stats.mld
@@ -209,7 +209,7 @@ The statistics system is designed to work seamlessly with Soteria's symbolic exe
 
 See {{!Soteria.Symex.StatKeys}[Symex.StatKeys]} for all available entries.
 
-If you don't need statistics (e.g. for performance), use {{!Soteria.Stats.As_ctx.with_stats_ignored}[with_stats_ignored]}, which skips the small overhead of tracking statistics.
+If you don't need statistics (e.g. for performance), use {{!Soteria.Stats.As_ctx.with_ignored}[with_ignored]}, which skips the small overhead of tracking statistics.
 
 {3 Configuration}
 

--- a/soteria/tutorial/stats.mld
+++ b/soteria/tutorial/stats.mld
@@ -20,22 +20,17 @@ A key feature of the statistics system is that it automatically {e merges} stati
 
 {2:basic Getting Started with Statistics}
 
-To collect statistics, you need to wrap your computation with {{!Soteria.Stats.As_ctx.with_stats}[with_stats]}. Note that [with_stats] must be called outside of any symbolic process (i.e. outside functions returning ['a Symex.t]):
+To collect statistics, you need to wrap your computation with {{!Soteria.Stats.As_ctx.with_}[with_]}. Note that [with_] must be called outside of any symbolic process (i.e. outside functions returning ['a Symex.t]):
 
 {@ocaml[
-module Stats = Soteria.Stats
-let computation () =
-  Stats.As_ctx.incr "operations";
-  Stats.As_ctx.incr "operations";
-  Stats.As_ctx.incr "operations";
-  42
-]}
-
-The {{!Soteria.Stats.with_stats}[with_stats]} wrapper returns a record containing both the result and the collected statistics:
-
-{@ocaml[
-# Stats.As_ctx.with_stats () computation;;
-- : int Stats.with_stats = {res = 42; stats = <stats>}
+# let computation () =
+    Stats.As_ctx.incr "operations";
+    Stats.As_ctx.incr "operations";
+    Stats.As_ctx.incr "operations";
+    42
+val computation : unit -> int = <fun>
+# Stats.As_ctx.with_ () computation;;
+- : int * Stats.t = (42, <stats>)
 ]}
 
 
@@ -43,9 +38,9 @@ Because wrapper functions are a regular pattern in Soteria, we recommend definin
 {@ocaml[
 # let ( let@ ) = ( @@ );;
 val ( let@ ) : ('a -> 'b) -> 'a -> 'b = <fun>
-# let@ () = Stats.As_ctx.with_stats () in
+# let@ () = Stats.As_ctx.with_ () in
   computation ();;
-- : int Stats.with_stats = {res = 42; stats = <stats>}
+- : int * Stats.t = (42, <stats>)
 ]}
 
 {3 Basic Counter Operations}
@@ -66,17 +61,17 @@ The simplest statistics are integer counters. Use {{!Soteria.Stats.As_ctx.incr}[
     "done";;
 val count_things : unit -> string = <fun>
 
-# let result =
-    Stats.As_ctx.with_stats () count_things;;
-val result : string Stats.with_stats = {res = "done"; stats = <stats>}
+# let result, stats = Stats.As_ctx.with_ () count_things;;
+val result : string = "done"
+val stats : Stats.t = <stats>
 ]}
 
 Now we can read the statistics back; {!Soteria.Stats} exposes several helper getter functions to retrieve values of the correct type:
 
 {@ocaml[
-# Stats.get_int result.stats "items_processed";;
+# Stats.get_int stats "items_processed";;
 - : int = 3
-# Stats.get_int result.stats "bytes_read";;
+# Stats.get_int stats "bytes_read";;
 - : int = 3072
 ]}
 
@@ -84,18 +79,17 @@ Now we can read the statistics back; {!Soteria.Stats} exposes several helper get
 
 Use {{!Soteria.Stats.As_ctx.add_time_of_to}[add_time_of_to]} to measure how long an operation takes:
 
-{@ocaml[
+{@ocaml skip[
 # let slow_computation () =
     let rec fib n = if n <= 1 then n else fib (n-1) + fib (n-2) in
     fib 30
   in
-  let@ () = Stats.As_ctx.with_stats () in
-  Stats.As_ctx.add_time_of_to "compute_time" slow_computation;;
-- : int Stats.with_stats = {res = 832040; stats = <stats>}
-]}
-{@ocaml skip[
-# let time_taken = Stats.get_float result.stats "compute_time";;
-val time_taken : float = 0.024188995361328125
+  let res, stats =
+    let@ () = Stats.As_ctx.with_ () in
+    Stats.As_ctx.add_time_of_to "compute_time" slow_computation
+  in
+  res, Stats.get_float stats "compute_time";;
+- : int * float = (832040, 0.0228359699249267578)
 ]}
 
 {2:types Statistic Types}
@@ -119,8 +113,8 @@ String sequences are useful for recording events or messages:
     Stats.As_ctx.push_str "warnings" "Deprecated function called";
     ()
   in
-  let result = Stats.As_ctx.with_stats () log_events in
-  Stats.get_strseq result.stats "warnings";;
+  let _, stats = Stats.As_ctx.with_ () log_events in
+  Stats.get_strseq stats "warnings";;
 - : string Dynarray.t =
 ["Missing type annotation", "Unused variable x",
  "Deprecated function called"]
@@ -137,8 +131,8 @@ Maps allow you to organize statistics hierarchically. Use {{!Soteria.Stats.As_ct
     Stats.As_ctx.push_binding "function_calls" "main" (Int 3);
     ()
   in
-  let result = Stats.As_ctx.with_stats () track_by_function in
-  Stats.get_map result.stats "function_calls";;
+  let _, stats = Stats.As_ctx.with_ () track_by_function in
+  Stats.get_map stats "function_calls";;
 - : Stats.stat_entry Soteria_std.Hashtbl.Hstring.t =
   main -> Stats.Int 8
   helper -> Stats.Int 12
@@ -157,10 +151,10 @@ For instance, use {{!Soteria.Stats.register_int_printer}[register_int_printer]} 
     ~name:"Total Operations"
     (fun _stats ft count -> Fmt.pf ft "%d ops" count);
 
-  let result = Stats.As_ctx.with_stats () (fun () ->
+  let _, stats = Stats.As_ctx.with_ () (fun () ->
       Stats.As_ctx.add_int "operations" 42)
   in
-  Fmt.pr "%a" Stats.pp result.stats;;
+  Fmt.pr "%a" Stats.pp stats;;
 Statistics:
 • Total Operations: 42 ops
 
@@ -190,8 +184,8 @@ Printers receive the full statistics object, allowing context-aware formatting. 
     Stats.As_ctx.add_int "successful_checks" 85
   in
 
-  let result = Stats.As_ctx.with_stats () demo_checks in
-  Fmt.pr "%a" Stats.pp result.stats;;
+  let _, stats = Stats.As_ctx.with_ () demo_checks in
+  Fmt.pr "%a" Stats.pp stats;;
 Statistics:
 • Checks: 85 successes of 100 (85%)
 
@@ -209,7 +203,10 @@ The statistics system is designed to work seamlessly with Soteria's symbolic exe
 
 See {{!Soteria.Symex.StatKeys}[Symex.StatKeys]} for all available entries.
 
-If you don't need statistics (e.g. for performance), use {{!Soteria.Stats.As_ctx.with_ignored}[with_ignored]}, which skips the small overhead of tracking statistics.
+The {{!Soteria.Symex.S.run}[Symex.S.run]} function receives an optional [stats] parameter that allows deciding how statistics should be tracked during symbolic execution:
+- {{!Soteria.Symex.effect_handling.Ignore}[~stats:Ignore]}: Don't track any statistics (default)
+- {{!Soteria.Symex.effect_handling.Dump}[~stats:(Dump ())]}: Track statistics and print them after execution according to the current {{!Soteria.Stats.Config}configuration} (see below)
+- {{!Soteria.Symex.effect_handling.Handled}[~stats:Handled]}: Statistics are already tracked, and the effects they raise don't need to be handled here (using {{!Soteria.Stats.As_ctx.with_}[with_]}, {{!Soteria.Stats.As_ctx.with_ignored}[with_ignored]}, or {{!Soteria.Stats.As_ctx.with_dumped}[with_dumped]})
 
 {3 Configuration}
 
@@ -247,7 +244,7 @@ let my_process () =
 
 You now know how to effectively use Soteria's statistics system! Key takeaways:
 
-- Wrap computations with [Stats.As_ctx.with_stats] to enable tracking
+- Wrap computations with [Stats.As_ctx.with_] to enable tracking
 - Use [incr], [add_int], [add_float] for basic metrics
 - Use [add_time_of_to] for timing operations
 - Use [push_str] and [push_binding] for complex data

--- a/soteria/tutorial/stats.mld
+++ b/soteria/tutorial/stats.mld
@@ -206,7 +206,7 @@ See {{!Soteria.Symex.StatKeys}[Symex.StatKeys]} for all available entries.
 The {{!Soteria.Symex.S.run}[Symex.S.run]} function receives an optional [stats] parameter that allows deciding how statistics should be tracked during symbolic execution:
 - {{!Soteria.Symex.effect_handling.Ignore}[~stats:Ignore]}: Don't track any statistics (default)
 - {{!Soteria.Symex.effect_handling.Dump}[~stats:(Dump ())]}: Track statistics and print them after execution according to the current {{!Soteria.Stats.Config}configuration} (see below)
-- {{!Soteria.Symex.effect_handling.Handled}[~stats:Handled]}: Statistics are already tracked, and the effects they raise don't need to be handled here (using {{!Soteria.Stats.As_ctx.with_}[with_]}, {{!Soteria.Stats.As_ctx.with_ignored}[with_ignored]}, or {{!Soteria.Stats.As_ctx.with_dumped}[with_dumped]})
+- {{!Soteria.Symex.effect_handling.Caller}[~stats:Caller]}: Statistics are already tracked, and the effects they raise don't need to be handled here (using {{!Soteria.Stats.As_ctx.with_}[with_]}, {{!Soteria.Stats.As_ctx.with_ignored}[with_ignored]}, or {{!Soteria.Stats.As_ctx.with_dumped}[with_dumped]})
 
 {3 Configuration}
 


### PR DESCRIPTION
Commits are self-contained:
- cleaned up `Flamegraph` to be more like `Stats`
- add a `Effects.Managed_effect` module type for modules that raise effects that can be managed in different ways (notably: ignored, dumped or handled externally),
- simplify the signature of `Symex.run` and merge all variants (`_needs_stats`, `_with_stats`) exploiting that
- Tried sharing more code between `Symex.run` and `Symex.Result.run`; not super convinced about it but eh