### PR TITLE
Consumption of non-consumable pure atoms via existential quantification

### DIFF
--- a/soteria/lib/bv_values/expr.ml
+++ b/soteria/lib/bv_values/expr.ml
@@ -65,27 +65,27 @@ module Subst = struct
         (v :: vs, s)
 
   and apply_bound ~missing_var s vs sv =
-    (* [max_var_ind] is the index of the freshest semantic variable used in
+    (* [max_var_ind] returns the index of the freshest semantic variable used in
        [sv], which we use to create new fresh variables for the existential. *)
+    let max_var_ind sv init =
+      Svalue.iter_vars sv
+      |> IterLabels.fold ~init ~f:(fun curr (var, _) ->
+          let var = Var.to_int var in
+          if var > curr then var else curr)
+    in
     let max_var_ind, s =
-      let incr_var_ind sv init =
-        Svalue.iter_vars sv
-        |> IterLabels.fold ~init ~f:(fun curr (var, _) ->
-            let var = Var.to_int var in
-            if var > curr then var else curr)
-      in
       Svalue.iter_vars sv
       |> Iter.filter (fun var -> not @@ List.mem var vs)
       |> IterLabels.fold ~init:(0, s) ~f:(fun (curr, s) (var, ty) ->
           let syn_var = mk_var var ty in
           match Raw_map.find_opt syn_var s with
-          | Some sv -> (incr_var_ind sv curr, s)
+          | Some sv -> (max_var_ind sv curr, s)
           | None ->
               (* We call [missing_var] here to ensure that our fresh variables
                  do not clash with other unknown variables and then update [s]
                  so that [missing_var] is only called once. *)
               let sv = missing_var var ty in
-              (incr_var_ind sv curr, Raw_map.add syn_var sv s))
+              (max_var_ind sv curr, Raw_map.add syn_var sv s))
     in
     (* [subst_with_fresh] is the new substitution which extends [s] by binding
        each variable in [vs] to a fresh semantic variable. [fresh_vs] is a list

--- a/soteria/lib/bv_values/expr.ml
+++ b/soteria/lib/bv_values/expr.ml
@@ -65,12 +65,12 @@ module Subst = struct
         (v :: vs, s)
 
   and apply_bound ~missing_var s vs sv =
-    (* [max_var_ind] is the index of the last semantic variable used in [sv],
-       which we use to create new fresh variables for the existential. *)
+    (* [max_var_ind] is the index of the freshest semantic variable used in
+       [sv], which we use to create new fresh variables for the existential. *)
     let max_var_ind, s =
-      let incr_var_ind sv curr =
+      let incr_var_ind sv init =
         Svalue.iter_vars sv
-        |> IterLabels.fold ~init:curr ~f:(fun curr (var, _) ->
+        |> IterLabels.fold ~init ~f:(fun curr (var, _) ->
             let var = Var.to_int var in
             if var > curr then var else curr)
       in

--- a/soteria/lib/bv_values/expr.ml
+++ b/soteria/lib/bv_values/expr.ml
@@ -65,16 +65,27 @@ module Subst = struct
         (v :: vs, s)
 
   and apply_bound ~missing_var s vs sv =
-    (* [max_var_ind] is the index of the last semantic variable, which we use to
-       create new fresh variables for the existential. *)
-    let max_var_ind =
-      Raw_map.fold
-        (fun _ binding curr ->
-          iter_vars binding
-          |> IterLabels.fold ~init:curr ~f:(fun curr (var, _) ->
-              let var = Var.to_int var in
-              if var > curr then var else curr))
-        s 0
+    (* [max_var_ind] is the index of the last semantic variable used in [sv],
+       which we use to create new fresh variables for the existential. *)
+    let max_var_ind, s =
+      let incr_var_ind sv curr =
+        Svalue.iter_vars sv
+        |> IterLabels.fold ~init:curr ~f:(fun curr (var, _) ->
+            let var = Var.to_int var in
+            if var > curr then var else curr)
+      in
+      Svalue.iter_vars sv
+      |> Iter.filter (fun var -> not @@ List.mem var vs)
+      |> IterLabels.fold ~init:(0, s) ~f:(fun (curr, s) (var, ty) ->
+          let syn_var = mk_var var ty in
+          match Raw_map.find_opt syn_var s with
+          | Some sv -> (incr_var_ind sv curr, s)
+          | None ->
+              (* We call [missing_var] here to ensure that our fresh variables
+                 do not clash with other unknown variables and then update [s]
+                 so that [missing_var] is only called once. *)
+              let sv = missing_var var ty in
+              (incr_var_ind sv curr, Raw_map.add syn_var sv s))
     in
     (* [subst_with_fresh] is the new substitution which extends [s] by binding
        each variable in [vs] to a fresh semantic variable. [fresh_vs] is a list

--- a/soteria/lib/bv_values/expr.ml
+++ b/soteria/lib/bv_values/expr.ml
@@ -53,39 +53,45 @@ module Subst = struct
             let vs, s = apply_list ~missing_var s vs in
             (Eval.eval_nop nop vs, s)
         | Exists (vs, sv) ->
-            (* [replaced_bindings] is a list of triples [(old_var, old_binding,
-               new_var)] where [(old_var, old_binding)] was a binding of
-               substitution and needs to be replaced by a [new_var -> new_var]
-               binding to iter over [sv] *)
-            let replaced_bindings =
-              Raw_map.to_seq s
-              |> Seq.filter_map (function
-                | (Hc.{ node = { kind = Var v; _ }; _ } as old_var), old_binding
-                  ->
-                    List.assoc_opt v vs
-                    |> Option.map (fun ty ->
-                        (old_var, old_binding, mk_var v ty))
-                | _ -> None)
-              |> List.of_seq
+            (* [max_var_ind] is the index of the last semantic variable, which
+               we use to create new fresh variables for the existential. *)
+            let max_var_ind =
+              Raw_map.fold
+                (fun _ binding curr ->
+                  iter_vars binding
+                  |> IterLabels.fold ~init:curr ~f:(fun curr (var, _) ->
+                      let var = Var.to_int var in
+                      if var > curr then var else curr))
+                s 0
             in
-            let s =
-              List.fold_left
-                (fun s (old_var, _, new_var) ->
-                  let without = Raw_map.remove old_var s in
-                  Raw_map.add new_var new_var without)
-                s replaced_bindings
+            (* [subst_with_fresh] is the new substitution which extends [s] by
+               binding each variable in [vs] to a fresh semantic variable.
+               [fresh_vs] is a list with all the freshly created variables.
+               [old_bindings] is a list of pairs [(syn_var, sem_var_opt)] where
+               [sem_var_opt] is an optional variable: if [sem_var_opt] holds a
+               value [sem_var], then the binding [(syn_var, sem_var)] existed in
+               the original substitution and must be reverted at the end. *)
+            let _, subst_with_fresh, fresh_vs, old_bindings =
+              ListLabels.fold_left vs
+                ~init:(max_var_ind + 1, s, [], [])
+                ~f:(fun (curr_var_ind, s, vs, bs) (var, ty) ->
+                  let new_var = Var.of_int curr_var_ind in
+                  let syn_var, sem_var = (mk_var var ty, mk_var new_var ty) in
+                  let bs = (syn_var, Raw_map.find_opt syn_var s) :: bs in
+                  let s = Raw_map.add syn_var sem_var s in
+                  (curr_var_ind + 1, s, (new_var, ty) :: vs, bs))
             in
             (* Actually perform substitution *)
-            let sv, s = apply ~missing_var s sv in
+            let sv, subst_with_fresh = apply ~missing_var subst_with_fresh sv in
             (* Revert the dummy bindings *)
             let subst_after_pass =
-              List.fold_left
-                (fun s (old_var, old_binding, new_var) ->
-                  let without_new = Raw_map.remove new_var s in
-                  Raw_map.add old_var old_binding without_new)
-                s replaced_bindings
+              ListLabels.fold_left old_bindings ~init:subst_with_fresh
+                ~f:(fun s -> function
+                | syn_var, None -> Raw_map.remove syn_var s
+                | syn_var, Some sem_var -> Raw_map.add syn_var sem_var s)
             in
-            (Svalue.Bool.mk_exists vs sv, subst_after_pass))
+            (* We bind the existential to the semantic variables [fresh_vs] *)
+            (Svalue.Bool.mk_exists fresh_vs sv, subst_after_pass))
 
   and apply_list ~missing_var s vs =
     match vs with

--- a/soteria/lib/bv_values/expr.ml
+++ b/soteria/lib/bv_values/expr.ml
@@ -53,45 +53,8 @@ module Subst = struct
             let vs, s = apply_list ~missing_var s vs in
             (Eval.eval_nop nop vs, s)
         | Exists (vs, sv) ->
-            (* [max_var_ind] is the index of the last semantic variable, which
-               we use to create new fresh variables for the existential. *)
-            let max_var_ind =
-              Raw_map.fold
-                (fun _ binding curr ->
-                  iter_vars binding
-                  |> IterLabels.fold ~init:curr ~f:(fun curr (var, _) ->
-                      let var = Var.to_int var in
-                      if var > curr then var else curr))
-                s 0
-            in
-            (* [subst_with_fresh] is the new substitution which extends [s] by
-               binding each variable in [vs] to a fresh semantic variable.
-               [fresh_vs] is a list with all the freshly created variables.
-               [old_bindings] is a list of pairs [(syn_var, sem_var_opt)] where
-               [sem_var_opt] is an optional variable: if [sem_var_opt] holds a
-               value [sem_var], then the binding [(syn_var, sem_var)] existed in
-               the original substitution and must be reverted at the end. *)
-            let _, subst_with_fresh, fresh_vs, old_bindings =
-              ListLabels.fold_left vs
-                ~init:(max_var_ind + 1, s, [], [])
-                ~f:(fun (curr_var_ind, s, vs, bs) (var, ty) ->
-                  let new_var = Var.of_int curr_var_ind in
-                  let syn_var, sem_var = (mk_var var ty, mk_var new_var ty) in
-                  let bs = (syn_var, Raw_map.find_opt syn_var s) :: bs in
-                  let s = Raw_map.add syn_var sem_var s in
-                  (curr_var_ind + 1, s, (new_var, ty) :: vs, bs))
-            in
-            (* Actually perform substitution *)
-            let sv, subst_with_fresh = apply ~missing_var subst_with_fresh sv in
-            (* Revert the dummy bindings *)
-            let subst_after_pass =
-              ListLabels.fold_left old_bindings ~init:subst_with_fresh
-                ~f:(fun s -> function
-                | syn_var, None -> Raw_map.remove syn_var s
-                | syn_var, Some sem_var -> Raw_map.add syn_var sem_var s)
-            in
-            (* We bind the existential to the semantic variables [fresh_vs] *)
-            (Svalue.Bool.mk_exists fresh_vs sv, subst_after_pass))
+            let (vs, sv), s = apply_bound ~missing_var s vs sv in
+            (Svalue.Bool.mk_exists vs sv, s))
 
   and apply_list ~missing_var s vs =
     match vs with
@@ -100,6 +63,46 @@ module Subst = struct
         let v, s = apply ~missing_var s v in
         let vs, s = apply_list ~missing_var s vs in
         (v :: vs, s)
+
+  and apply_bound ~missing_var s vs sv =
+    (* [max_var_ind] is the index of the last semantic variable, which we use to
+       create new fresh variables for the existential. *)
+    let max_var_ind =
+      Raw_map.fold
+        (fun _ binding curr ->
+          iter_vars binding
+          |> IterLabels.fold ~init:curr ~f:(fun curr (var, _) ->
+              let var = Var.to_int var in
+              if var > curr then var else curr))
+        s 0
+    in
+    (* [subst_with_fresh] is the new substitution which extends [s] by binding
+       each variable in [vs] to a fresh semantic variable. [fresh_vs] is a list
+       with all the freshly created variables. [old_bindings] is a list of pairs
+       [(syn_var, sem_var_opt)] where [sem_var_opt] is an optional variable: if
+       [sem_var_opt] holds a value [sem_var], then the binding [(syn_var,
+       sem_var)] existed in the original substitution and must be reverted at
+       the end. *)
+    let _, subst_with_fresh, fresh_vs, old_bindings =
+      ListLabels.fold_left vs
+        ~init:(max_var_ind + 1, s, [], [])
+        ~f:(fun (curr_var_ind, s, vs, bs) (var, ty) ->
+          let new_var = Var.of_int curr_var_ind in
+          let syn_var, sem_var = (mk_var var ty, mk_var new_var ty) in
+          let bs = (syn_var, Raw_map.find_opt syn_var s) :: bs in
+          let s = Raw_map.add syn_var sem_var s in
+          (curr_var_ind + 1, s, (new_var, ty) :: vs, bs))
+    in
+    (* Actually perform substitution *)
+    let sv, subst_with_fresh = apply ~missing_var subst_with_fresh sv in
+    (* Revert the dummy bindings *)
+    let subst_after_pass =
+      ListLabels.fold_left old_bindings ~init:subst_with_fresh
+        ~f:(fun s -> function
+        | syn_var, None -> Raw_map.remove syn_var s
+        | syn_var, Some sem_var -> Raw_map.add syn_var sem_var s)
+    in
+    ((fresh_vs, sv), subst_after_pass)
 
   let is_known (s : t) (e : Svalue.t) : bool =
     let exception Not_covered in

--- a/soteria/lib/logic/asrt.ml
+++ b/soteria/lib/logic/asrt.ml
@@ -137,9 +137,9 @@ module M (Symex : Symex.Base) = struct
   struct
     include Execute (B)
 
-    (** Given a list of expressions for which [is_consumable] returns false,
-        returns the conjunction of all expressions where all free variables not
-        covered by [subst] are bound by an existential quantifier. *)
+    (** Given a list of expressions, returns the conjunction of all expressions
+        where all free variables not covered by [subst] are bound by an
+        existential quantifier. *)
     let bind_free_vars_to_exists (subst : Value.Expr.Subst.t)
         (exprs : Value.Expr.t list) : Value.Expr.t =
       let free_vars =

--- a/soteria/lib/logic/asrt.ml
+++ b/soteria/lib/logic/asrt.ml
@@ -119,9 +119,13 @@ module M (Symex : Symex.Base) = struct
 
   (** [Execute_partial] contains the utilities to perform {e production} and
       {e consumption} of a given assertion, using the consumer and producer of
-      the parameter [B]. In the presence of strictly-pure non-consumable atoms,
-      consumption will proceed by creating a new consumable atom via the
-      utilities of the parameter [Syn]. *)
+      the parameter [B]. Unlike {!Execute}, the [consume] function may complete
+      by learning {e partial substitutions}, i.e. substitutions that do not
+      cover all free variables of the assertion being consumed.
+
+      To achieve so, if there are leftover pure assertions to consume for which
+      the free variables cannot be easily learned, we replace them by
+      existential (bound) variables and send that query to the solver. *)
   module Execute_partial
       (B : Base)
       (Syn : sig
@@ -136,9 +140,10 @@ module M (Symex : Symex.Base) = struct
     include Execute (B)
 
     (** Given a list of expressions for which [is_consumable] returns false,
-        returns a single expression for which [is_consumable] returns true. *)
-    let make_consumable (subst : Value.Expr.Subst.t) (exprs : Value.Expr.t list)
-        : Value.Expr.t =
+        returns the conjunction of all expressions where all free variables not
+        covered by [subst] are bound by an existential quantifier. *)
+    let bind_free_vars_to_exists (subst : Value.Expr.Subst.t)
+        (exprs : Value.Expr.t list) : Value.Expr.t =
       let free_vars =
         let r = ref [] in
         ListLabels.iter exprs ~f:(fun expr ->
@@ -149,8 +154,6 @@ module M (Symex : Symex.Base) = struct
             |> ignore);
         !r
       in
-      (* We take the conjunction of all the expressions and existentially
-         quantify all variables that are not covered by the substitution. *)
       Syn.mk_exists free_vars @@ Syn.conj exprs
 
     let consume (asrt : B.syn t) (st : B.t option) :
@@ -172,13 +175,13 @@ module M (Symex : Symex.Base) = struct
                   Value.Expr.Subst.pp subst (pp B.pp_syn) remaining];
                 Consumer.lfail @@ Value.of_bool false)
         in
-        let consumable = make_consumable subst exprs in
+        let exists = bind_free_vars_to_exists subst exprs in
         [%l.debug
           "@[<v>@[No consumable atom left given my current substitution with \
            only pure atoms remaining. About to consume asrt:@ %a@]@ @[in \
            subst:@ %a@]@]"
-          Value.Expr.pp consumable Value.Expr.Subst.pp subst];
-        let+ () = Consumer.consume_pure consumable in
+          Value.Expr.pp exists Value.Expr.Subst.pp subst];
+        let+ () = Consumer.consume_pure exists in
         st
   end
 end

--- a/soteria/lib/logic/asrt.ml
+++ b/soteria/lib/logic/asrt.ml
@@ -130,11 +130,9 @@ module M (Symex : Symex.Base) = struct
       (B : Base)
       (Syn : sig
         val mk_exists :
-          (Var.t * 'a Symex.Value.ty) list ->
-          Symex.Value.Expr.t ->
-          Symex.Value.Expr.t
+          (Var.t * 'a Value.ty) list -> Value.Expr.t -> Value.Expr.t
 
-        val conj : Symex.Value.Expr.t list -> Symex.Value.Expr.t
+        val conj : Value.Expr.t list -> Value.Expr.t
       end) =
   struct
     include Execute (B)

--- a/soteria/lib/logic/asrt.ml
+++ b/soteria/lib/logic/asrt.ml
@@ -83,8 +83,8 @@ module M (Symex : Symex.Base) = struct
           let+ () = Symex.Consumer.consume_pure f in
           st
 
-    let consume (asrt : B.syn t) (st : B.t option) :
-        (B.t option, B.syn list) Consumer.t =
+    let consume_partial (asrt : B.syn t) (st : B.t option) :
+        (B.syn t * B.t option, B.syn list) Consumer.t =
       let open Consumer.Syntax in
       let* subst = Consumer.expose_subst () in
       [%l.debug
@@ -92,22 +92,93 @@ module M (Symex : Symex.Base) = struct
          state:@ %a@]@]"
         (pp B.pp_syn) asrt Value.Expr.Subst.pp subst (Fmt.Dump.option B.pp) st];
       let rec aux (remaining : B.syn t) (st : B.t option) :
-          (B.t option, B.syn list) Consumer.t =
-        if List.is_empty remaining then Consumer.ok st
-        else
-          let* subst = Consumer.expose_subst () in
-          match List.find_with_rest (is_consumable subst) remaining with
-          | None ->
-              [%l.info
-                "@[<v>Failed to consume assertion because I can't find any \
-                 consumable atom left given my current substitution.@.@[<v \
-                 2>Substitution:@ %a@]@.@[<v 2>Atoms left:@ %a@]@]"
-                Value.Expr.Subst.pp subst (pp B.pp_syn) remaining];
-              Consumer.lfail @@ Value.of_bool false
-          | Some (atom, rest) ->
-              let* st' = consume_atom atom st in
-              aux rest st'
+          (B.syn t * B.t option, B.syn list) Consumer.t =
+        let* subst = Consumer.expose_subst () in
+        match List.find_with_rest (is_consumable subst) remaining with
+        | None -> Consumer.ok (remaining, st)
+        | Some (atom, rest) ->
+            let* st' = consume_atom atom st in
+            aux rest st'
       in
       aux asrt st
+
+    let consume (asrt : B.syn t) (st : B.t option) :
+        (B.t option, B.syn list) Consumer.t =
+      let open Consumer.Syntax in
+      let* remaining, st = consume_partial asrt st in
+      if List.is_empty remaining then Consumer.ok st
+      else
+        let* subst = Consumer.expose_subst () in
+        [%l.info
+          "@[<v>Failed to consume assertion because I can't find any \
+           consumable atom left given my current substitution.@.@[<v \
+           2>Substitution:@ %a@]@.@[<v 2>Atoms left:@ %a@]@]"
+          Value.Expr.Subst.pp subst (pp B.pp_syn) remaining];
+        Consumer.lfail @@ Value.of_bool false
+  end
+
+  (** [Execute_partial] contains the utilities to perform {e production} and
+      {e consumption} of a given assertion, using the consumer and producer of
+      the parameter [B]. In the presence of strictly-pure non-consumable atoms,
+      consumption will proceed by creating a new consumable atom via the
+      utilities of the parameter [Syn]. *)
+  module Execute_partial
+      (B : Base)
+      (Syn : sig
+        val mk_exists :
+          (Var.t * 'a Symex.Value.ty) list ->
+          Symex.Value.Expr.t ->
+          Symex.Value.Expr.t
+
+        val conj : Symex.Value.Expr.t list -> Symex.Value.Expr.t
+      end) =
+  struct
+    include Execute (B)
+
+    (** Given a list of expressions for which [is_consumable] returns false,
+        returns a single expression for which [is_consumable] returns true. *)
+    let make_consumable (subst : Value.Expr.Subst.t) (exprs : Value.Expr.t list)
+        : Value.Expr.t =
+      let free_vars =
+        let r = ref [] in
+        ListLabels.iter exprs ~f:(fun expr ->
+            Value.Expr.Subst.apply subst expr ~missing_var:(fun var ty ->
+                let vars = !r in
+                if not @@ List.mem (var, ty) vars then r := (var, ty) :: vars;
+                Value.mk_var var ty)
+            |> ignore);
+        !r
+      in
+      (* We take the conjunction of all the expressions and existentially
+         quantify all variables that are not covered by the substitution. *)
+      Syn.mk_exists free_vars @@ Syn.conj exprs
+
+    let consume (asrt : B.syn t) (st : B.t option) :
+        (B.t option, B.syn list) Consumer.t =
+      let open Consumer.Syntax in
+      let* remaining, st = consume_partial asrt st in
+      if List.is_empty remaining then Consumer.ok st
+      else
+        let* subst = Consumer.expose_subst () in
+        let* exprs =
+          Consumer.fold_list remaining ~init:[] ~f:(fun exprs -> function
+            | Pure expr -> Consumer.ok (expr :: exprs)
+            | Spatial _ ->
+                [%l.info
+                  "@[<v>Failed to consume assertion because I can't find any \
+                   consumable atom left given my current substitution with \
+                   spatial atoms remaining.@.@[<v 2>Substitution:@ %a@]@.@[<v \
+                   2>Atoms left:@ %a@]@]"
+                  Value.Expr.Subst.pp subst (pp B.pp_syn) remaining];
+                Consumer.lfail @@ Value.of_bool false)
+        in
+        let consumable = make_consumable subst exprs in
+        [%l.debug
+          "@[<v>@[No consumable atom left given my current substitution with \
+           only pure atoms remaining. About to consume asrt:@ %a@]@ @[in \
+           subst:@ %a@]@]"
+          Value.Expr.pp consumable Value.Expr.Subst.pp subst];
+        let+ () = Consumer.consume_pure consumable in
+        st
   end
 end


### PR DESCRIPTION
This PR introduces two changes to the main Soteria library:
1. It fixes a previous bug that occurred during substitution of existential values in `bv_values`.
2. It extends `Logic.Asrt` with a new functor `Execute_partial` where `consume` is replaced with an alternative implementation: if only pure atoms remain to be consumed and neither is individually consumable, we create a new atom that existentially quantifies all unknown variables, making the atom consumable.