### PR TITLE
Nicer CI

### DIFF
--- a/.github/actions/post-pr-status-comment/action.yml
+++ b/.github/actions/post-pr-status-comment/action.yml
@@ -1,0 +1,75 @@
+name: Post PR status comment
+description: Marks previous bot status comments outdated, minimizes them, and posts a new status comment
+inputs:
+  issue-number:
+    description: Pull request number to post the comment on
+    required: true
+  marker:
+    description: Marker identifier used to identify previous comments for this status family
+    required: true
+  body:
+    description: New comment body (without marker)
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Replace previous status comment
+      uses: actions/github-script@v7
+      env:
+        INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
+        INPUT_MARKER: ${{ inputs.marker }}
+        INPUT_BODY: ${{ inputs.body }}
+      with:
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const issueNumber = Number(process.env.INPUT_ISSUE_NUMBER);
+          const markerInput = process.env.INPUT_MARKER.trim();
+          const marker = markerInput.startsWith('<!--')
+            ? markerInput
+            : `<!-- ${markerInput} -->`;
+          const body = process.env.INPUT_BODY.replace(/\\n/g, '\n');
+          const outdatedMarker = '<!-- soteria:outdated -->';
+          const outdatedNotice = '###### This comment is outdated and has been superseded by a newer run.';
+
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner,
+            repo,
+            issue_number: issueNumber,
+            per_page: 100
+          });
+
+          const previousComments = comments.filter((comment) =>
+            comment.user?.login === 'github-actions[bot]' &&
+            comment.body?.includes(marker)
+          );
+
+          for (const comment of previousComments) {
+            if (comment.body.includes(outdatedMarker)) {
+              continue;
+            }
+
+            const cleanBody = comment.body.replace(marker, '').trim();
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: comment.id,
+              body: `${marker}\n${outdatedMarker}\n${outdatedNotice}\n\n${cleanBody}`
+            });
+
+            try {
+              await github.graphql(
+                'mutation($subjectId: ID!) { minimizeComment(input: { subjectId: $subjectId, classifier: OUTDATED }) { minimizedComment { isMinimized } } }',
+                { subjectId: comment.node_id }
+              );
+            } catch (error) {
+              core.info(`Unable to minimize comment ${comment.id}: ${error.message}`);
+            }
+          }
+
+          await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: issueNumber,
+            body: `${marker}\n${body}`
+          });

--- a/.github/workflows/build-doc-pr.yml
+++ b/.github/workflows/build-doc-pr.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add eyes reaction
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -76,7 +76,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download documentation artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: odoc
           path: site
@@ -84,14 +84,14 @@ jobs:
           run-id: ${{ steps.find-run.outputs.run_id }}
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
           destination_dir: ./api/pr-${{ github.event.issue.number }}
 
       - name: Add rocket reaction on success
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -103,7 +103,7 @@ jobs:
 
       - name: Checkout default branch for local actions
         if: always()
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: source-repo
@@ -119,7 +119,7 @@ jobs:
 
       - name: Add failure reaction
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.reactions.createForIssueComment({

--- a/.github/workflows/build-doc-pr.yml
+++ b/.github/workflows/build-doc-pr.yml
@@ -52,12 +52,12 @@ jobs:
               --workflow ci.yml \
               --json databaseId,status \
               --jq '.[0].databaseId // empty')
-            
+
             if [ -n "$RUN_ID" ]; then
               echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
               exit 0
             fi
-            
+
             echo "Waiting for CI workflow to start... (attempt $((ATTEMPT + 1))/$MAX_ATTEMPTS)"
             sleep 10
             ATTEMPT=$((ATTEMPT + 1))
@@ -101,20 +101,21 @@ jobs:
               content: 'rocket'
             });
 
-      - name: Post documentation URL
-        uses: actions/github-script@v7
+      - name: Checkout default branch for local actions
+        if: always()
+        uses: actions/checkout@v5
         with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prNumber = context.payload.issue.number;
-            const url = `https://${owner}.github.io/${repo}/api/pr-${prNumber}`;
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: prNumber,
-              body: `Documentation published at: ${url}. It should appear online in a few minutes.`
-            });
+          ref: ${{ github.event.repository.default_branch }}
+          path: source-repo
+
+      - name: Post documentation status comment
+        if: always()
+        uses: ./source-repo/.github/actions/post-pr-status-comment
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          marker: soteria:pr-doc-status
+          body: |
+            ${{ job.status == 'success' && format('Documentation published at: https://{0}.github.io/{1}/api/pr-{2}. It should appear online in a few minutes.\n\nRun: https://github.com/{1}/actions/runs/{3}', github.repository_owner, github.repository, github.event.issue.number, github.run_id) || format('Failed to publish documentation. See [workflow run](https://github.com/{0}/actions/runs/{1}) for details.', github.repository, github.run_id) }}
 
       - name: Add failure reaction
         if: failure()
@@ -126,20 +127,4 @@ jobs:
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
               content: '-1'
-            });
-
-      - name: Post failure comment
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prNumber = context.payload.issue.number;
-            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${{ github.run_id }}`;
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: prNumber,
-              body: `Failed to publish documentation. See [workflow run](${runUrl}) for details.`
             });

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       # Setup steps: checkout, z3, node, ocaml and opam
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check versions.json sync
         run: python3 scripts/versionsync.py check
       - name: Setup Z3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       # Setup steps: checkout, z3, node, ocaml and opam
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check versions.json sync
         run: python3 scripts/versionsync.py check
       - name: Setup Z3
         uses: cda-tum/setup-z3@v1
         id: z3
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: "yarn"
       - name: Setup OCaml
@@ -41,7 +41,7 @@ jobs:
           dune-cache: true
           opam-pin: false
       - name: Restore opam cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: _opam
           key: ${{ runner.os }}-${{ runner.arch }}-opam-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Restore Obol cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: restore-obol-cache
         with:
           path: obol-bin
@@ -80,7 +80,7 @@ jobs:
 
       # Install Charon
       - name: Restore Charon cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: restore-charon-cache
         with:
           path: charon-bin
@@ -134,7 +134,7 @@ jobs:
       - name: Create soteria-c package
         run: make package-soteria-c
       - name: Upload soteria-c package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.operating-system }}-soteria-c-package
           path: packages/soteria-c
@@ -143,7 +143,7 @@ jobs:
       - name: Create soteria-rust package
         run: make package-soteria-rust
       - name: Upload soteria-rust package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.operating-system }}-soteria-rust-package
           path: packages/soteria-rust
@@ -153,7 +153,7 @@ jobs:
         run: make doc
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: odoc
           path: _build/default/_doc/_html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Retrieve documentation artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: odoc
           path: site
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/cleanup-doc-pr.yml
+++ b/.github/workflows/cleanup-doc-pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
 
@@ -44,14 +44,17 @@ jobs:
           git commit -m "Remove documentation for PR #${{ github.event.pull_request.number }}"
           git push
 
+      - name: Checkout default branch for local actions
+        if: steps.check.outputs.found == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: source-repo
+
       - name: Post comment on PR
         if: steps.check.outputs.found == 'true'
-        uses: actions/github-script@v7
+        uses: ./source-repo/.github/actions/post-pr-status-comment
         with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: 'Documentation for this PR has been removed.'
-            });
+          issue-number: ${{ github.event.pull_request.number }}
+          marker: soteria:pr-doc-cleanup
+          body: Documentation for this PR has been removed.

--- a/.github/workflows/cleanup-doc-pr.yml
+++ b/.github/workflows/cleanup-doc-pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout default branch for local actions
         if: steps.check.outputs.found == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: source-repo

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup steps: checkout, z3, node, ocaml and opam
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: install reuse
         run: pip install reuse
       - name: check licenses

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,21 +7,84 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
+    inputs:
+      force:
+        description: Force a nightly release even if no new commits were pushed
+        required: false
+        default: false
+        type: boolean
 
 jobs:
+  check-new-commits:
+    name: Check for new commits since nightly
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Determine whether a new nightly is needed
+        id: check
+        env:
+          FORCE_NIGHTLY: ${{ github.event.inputs.force || 'false' }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$FORCE_NIGHTLY" = "true" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Forced nightly release requested"
+            exit 0
+          fi
+
+          CURRENT_SHA="${{ github.sha }}"
+          REF_DATA=$(gh api \
+            repos/${{ github.repository }}/git/ref/tags/nightly \
+            --jq '{sha: .object.sha, type: .object.type}' 2>/dev/null || true)
+
+          PREVIOUS_NIGHTLY_SHA=""
+          if [ -n "$REF_DATA" ] && [ "$REF_DATA" != "null" ]; then
+            PREVIOUS_NIGHTLY_OBJ_SHA=$(echo "$REF_DATA" | jq -r '.sha // empty')
+            PREVIOUS_NIGHTLY_OBJ_TYPE=$(echo "$REF_DATA" | jq -r '.type // empty')
+
+            if [ "$PREVIOUS_NIGHTLY_OBJ_TYPE" = "tag" ]; then
+              PREVIOUS_NIGHTLY_SHA=$(gh api \
+                repos/${{ github.repository }}/git/tags/${PREVIOUS_NIGHTLY_OBJ_SHA} \
+                --jq '.object.sha' 2>/dev/null || true)
+            else
+              PREVIOUS_NIGHTLY_SHA="$PREVIOUS_NIGHTLY_OBJ_SHA"
+            fi
+          fi
+
+          if [ -z "$PREVIOUS_NIGHTLY_SHA" ]; then
+            echo "No existing nightly tag found; will create first nightly release"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$CURRENT_SHA" = "$PREVIOUS_NIGHTLY_SHA" ]; then
+            echo "No new commits since previous nightly ($CURRENT_SHA); skipping release"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New commits detected since previous nightly"
+            echo "Current:  $CURRENT_SHA"
+            echo "Previous: $PREVIOUS_NIGHTLY_SHA"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: check-new-commits
+    if: needs.check-new-commits.outputs.should_run == 'true'
     uses: ./.github/workflows/build.yml
 
   test-packages:
-    needs: build
+    needs: [check-new-commits, build]
+    if: needs.check-new-commits.outputs.should_run == 'true'
     uses: ./.github/workflows/test-packages.yml
 
   nightly-release:
     name: Nightly Release
     runs-on: ubuntu-latest
-    needs: test-packages
+    needs: [check-new-commits, test-packages]
+    if: needs.check-new-commits.outputs.should_run == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download soteria-c package
         uses: actions/download-artifact@v4
@@ -58,3 +121,12 @@ jobs:
             --prerelease \
             release-artifacts/soteria-c-macos.zip \
             release-artifacts/soteria-rust-macos.zip
+
+  nightly-skip:
+    name: Skip Nightly Release
+    runs-on: ubuntu-latest
+    needs: check-new-commits
+    if: needs.check-new-commits.outputs.should_run != 'true'
+    steps:
+      - name: Explain why nightly release was skipped
+        run: echo "No new commits since the previous nightly tag; skipping release."

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       force:
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
+      previous_sha: ${{ steps.check.outputs.previous_sha }}
+      current_sha: ${{ steps.check.outputs.current_sha }}
     steps:
       - name: Determine whether a new nightly is needed
         id: check
@@ -27,13 +29,14 @@ jobs:
           FORCE_NIGHTLY: ${{ github.event.inputs.force || 'false' }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          CURRENT_SHA="${{ github.sha }}"
+          echo "current_sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
+
           if [ "$FORCE_NIGHTLY" = "true" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Forced nightly release requested"
             exit 0
           fi
-
-          CURRENT_SHA="${{ github.sha }}"
           REF_DATA=$(gh api \
             repos/${{ github.repository }}/git/ref/tags/nightly \
             --jq '{sha: .object.sha, type: .object.type}' 2>/dev/null || true)
@@ -53,10 +56,13 @@ jobs:
           fi
 
           if [ -z "$PREVIOUS_NIGHTLY_SHA" ]; then
+            echo "previous_sha=" >> "$GITHUB_OUTPUT"
             echo "No existing nightly tag found; will create first nightly release"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          echo "previous_sha=$PREVIOUS_NIGHTLY_SHA" >> "$GITHUB_OUTPUT"
 
           if [ "$CURRENT_SHA" = "$PREVIOUS_NIGHTLY_SHA" ]; then
             echo "No new commits since previous nightly ($CURRENT_SHA); skipping release"
@@ -85,6 +91,8 @@ jobs:
     if: needs.check-new-commits.outputs.should_run == 'true'
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Download soteria-c package
         uses: actions/download-artifact@v4
@@ -110,14 +118,51 @@ jobs:
         run: |
           gh release delete nightly --yes || true
           git push --delete origin nightly || true
+          git tag -d nightly || true
 
       - name: Create nightly release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          PREVIOUS_SHA="${{ needs.check-new-commits.outputs.previous_sha }}"
+          CURRENT_SHA="${{ needs.check-new-commits.outputs.current_sha }}"
+
+          if [ -n "$PREVIOUS_SHA" ]; then
+            RANGE="[${PREVIOUS_SHA:0:7}..${CURRENT_SHA:0:7}](https://github.com/${{ github.repository }}/compare/${PREVIOUS_SHA}...${CURRENT_SHA})"
+            PR_LINES=$(gh pr list \
+              --repo "${{ github.repository }}" \
+              --state merged \
+              --base main \
+              --search "merged:>=$(date -u -d '-14 days' +%Y-%m-%d)" \
+              --json title,url,author,mergeCommit \
+              --jq '.[] | select(.mergeCommit.oid != null) | [.mergeCommit.oid, .title, .url, (.author.login // "unknown")] | @tsv' | \
+              while IFS=$'\t' read -r oid title url author; do
+                if git merge-base --is-ancestor "$oid" "$CURRENT_SHA" && ! git merge-base --is-ancestor "$oid" "$PREVIOUS_SHA"; then
+                  printf -- '- **%s** (%s) by @%s\n' "$title" "$url" "$author"
+                fi
+              done)
+          else
+            RANGE="(first nightly release in this repository)"
+            PR_LINES="- No previous nightly release to compare against, so all merged PRs are included in this release"
+          fi
+
+          if [ -z "$PR_LINES" ]; then
+            PR_LINES="- No merged pull requests found in this nightly range"
+          fi
+
+          NOTES_FILE=$(mktemp)
+          {
+            echo "Automated nightly build from \`main\` on $(date -u +%Y-%m-%d)."
+            echo
+            echo "Commit range: $RANGE"
+            echo
+            echo "Merged PRs in this release:"
+            echo "$PR_LINES"
+          } > "$NOTES_FILE"
+
           gh release create nightly \
             --title "Nightly $(date -u +%Y-%m-%d)" \
-            --notes "Automated nightly build from \`main\` on $(date -u +%Y-%m-%d)." \
+            --notes-file "$NOTES_FILE" \
             --prerelease \
             release-artifacts/soteria-c-macos.zip \
             release-artifacts/soteria-rust-macos.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -90,18 +90,18 @@ jobs:
     needs: [check-new-commits, test-packages]
     if: needs.check-new-commits.outputs.should_run == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download soteria-c package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: macos-latest-soteria-c-package
           path: release-artifacts/soteria-c
 
       - name: Download soteria-rust package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: macos-latest-soteria-rust-package
           path: release-artifacts/soteria-rust

--- a/.github/workflows/run-bv-fuzzer.yml
+++ b/.github/workflows/run-bv-fuzzer.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Add eyes reaction
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -53,7 +53,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'issue_comment' && steps.pr.outputs.sha || 'main' }}
 
@@ -69,7 +69,7 @@ jobs:
           opam-pin: false
 
       - name: Restore opam cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: _opam
           key: ${{ runner.os }}-${{ runner.arch }}-opam-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Add rocket reaction on success
         if: success() && github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -99,7 +99,7 @@ jobs:
 
       - name: Checkout default branch for local actions
         if: always() && github.event_name == 'issue_comment'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: source-repo
@@ -115,7 +115,7 @@ jobs:
 
       - name: Add failure reaction
         if: failure() && github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.reactions.createForIssueComment({

--- a/.github/workflows/run-bv-fuzzer.yml
+++ b/.github/workflows/run-bv-fuzzer.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # [versionsync: OCAML_VERSION=5.4.0]
   OCAML_VERSION: 5.4.0
@@ -49,7 +53,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'issue_comment' && steps.pr.outputs.sha || 'main' }}
 
@@ -93,21 +97,21 @@ jobs:
               content: 'rocket'
             });
 
-      - name: Post success comment
-        if: success() && github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+      - name: Checkout default branch for local actions
+        if: always() && github.event_name == 'issue_comment'
+        uses: actions/checkout@v5
         with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prNumber = context.payload.issue.number;
-            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${{ github.run_id }}`;
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: prNumber,
-              body: `✅ BV fuzzer tests passed! See [workflow run](${runUrl}) for details.`
-            });
+          ref: ${{ github.event.repository.default_branch }}
+          path: source-repo
+
+      - name: Post BV fuzzer status comment
+        if: always() && github.event_name == 'issue_comment'
+        uses: ./source-repo/.github/actions/post-pr-status-comment
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          marker: soteria:bv-fuzzer-status
+          body: |
+            ${{ job.status == 'success' && format('✅ BV fuzzer tests passed! See [workflow run](https://github.com/{0}/actions/runs/{1}) for details.', github.repository, github.run_id) || format('❌ BV fuzzer tests failed. See [workflow run](https://github.com/{0}/actions/runs/{1}) for details.', github.repository, github.run_id) }}
 
       - name: Add failure reaction
         if: failure() && github.event_name == 'issue_comment'
@@ -119,20 +123,4 @@ jobs:
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
               content: '-1'
-            });
-
-      - name: Post failure comment
-        if: failure() && github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prNumber = context.payload.issue.number;
-            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${{ github.run_id }}`;
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: prNumber,
-              body: `❌ BV fuzzer tests failed. See [workflow run](${runUrl}) for details.`
             });

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout Collections-C, version where we find a bug
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: srdja/Collections-C
           ref: 67a094035b3f7159cf3f9af82c55ae63fcb86a34
@@ -57,7 +57,7 @@ jobs:
           fi
           echo "✓ Collections-C test passed (found expected bug, exit code 13)"
       - name: Checkout Soteria repository for test files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: soteria-repo
       - name: Test symbolic execution with sym.c (nondet test)
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Download package
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout Collections-C, version where we find a bug
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: srdja/Collections-C
           ref: 67a094035b3f7159cf3f9af82c55ae63fcb86a34
       - name: Download package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.operating-system }}-soteria-c-package
           path: soteria-c-package
@@ -57,7 +57,7 @@ jobs:
           fi
           echo "✓ Collections-C test passed (found expected bug, exit code 13)"
       - name: Checkout Soteria repository for test files
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: soteria-repo
       - name: Test symbolic execution with sym.c (nondet test)
@@ -79,9 +79,9 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Download package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.operating-system }}-soteria-rust-package
           path: soteria-rust-package


### PR DESCRIPTION
- Add an action `post-pr-status-comment` to share the code around "post a comment and mark previous comments as outdated", which is then used in a few places
- Improve the nightly releases:
  - No release is done if no commit has been made to main
  - The release log now has a nice description with a range diff since the previous nightly, along with a list of merged PRs [example](https://github.com/N1ark/soteria/releases/tag/nightly)
- Bump CI dependencies 