### PR TITLE
Deploy linux package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,8 @@ jobs:
         run: curl https://raw.githubusercontent.com/$OBOL_REPO/$OBOL_COMMIT_HASH/rust-toolchain.toml > rust-toolchain
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: x86_64-unknown-linux-gnu,aarch64-apple-darwin
       # Restore caches for Obol and Charon
       - name: Restore Obol cache
         uses: actions/cache@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        operating-system: [macos-latest] # TODO: add other operating systems
+        operating-system: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.operating-system }}
     steps:
       # Setup steps: checkout, z3, node, ocaml and opam
@@ -69,12 +69,17 @@ jobs:
         with:
           path: obol-bin
           key: ${{ runner.os }}-${{ runner.arch }}-obol-${{ env.OBOL_COMMIT_HASH }}
-      - name: Install Obol if not cached
+      - name: Install Obol if not cached (macOS)
         run: |
           brew install make
           ../soteria/scripts/versionsync.py pull obol --init
           cp -r ../obol/bin obol-bin
-        if: ${{ !steps.restore-obol-cache.outputs.cache-hit }}
+        if: ${{ !steps.restore-obol-cache.outputs.cache-hit && runner.os == 'macOS' }}
+      - name: Install Obol if not cached (Linux)
+        run: |
+          ../soteria/scripts/versionsync.py pull obol --init
+          cp -r ../obol/bin obol-bin
+        if: ${{ !steps.restore-obol-cache.outputs.cache-hit && runner.os == 'Linux' }}
       - name: Add Obol to path
         run: echo "$PWD/obol-bin/" >> $GITHUB_PATH
 
@@ -85,12 +90,17 @@ jobs:
         with:
           path: charon-bin
           key: ${{ runner.os }}-${{ runner.arch }}-charon-${{ env.CHARON_COMMIT_HASH }}
-      - name: Install Charon if not cached
+      - name: Install Charon if not cached (macOS)
         run: |
           brew install make
           ../soteria/scripts/versionsync.py pull charon --init
           cp -r ../charon/bin charon-bin
-        if: ${{ !steps.restore-charon-cache.outputs.cache-hit }}
+        if: ${{ !steps.restore-charon-cache.outputs.cache-hit && runner.os == 'macOS' }}
+      - name: Install Charon if not cached (Linux)
+        run: |
+          ../soteria/scripts/versionsync.py pull charon --init
+          cp -r ../charon/bin charon-bin
+        if: ${{ !steps.restore-charon-cache.outputs.cache-hit && runner.os == 'Linux' }}
       - name: Add Charon to path
         run: echo "$PWD/charon-bin/" >> $GITHUB_PATH
 
@@ -130,13 +140,23 @@ jobs:
       - name: Build JS stuff
         run: yarn compile
 
+      # Compute platform name for artifact naming (e.g. macos-arm64, linux-x86_64)
+      - name: Set platform artifact name
+        id: platform
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            echo "name=macos-arm64" >> $GITHUB_OUTPUT
+          else
+            echo "name=linux-x86_64" >> $GITHUB_OUTPUT
+          fi
+
       # Packaging OCaml distribution and sending it as artifact
       - name: Create soteria-c package
         run: make package-soteria-c
       - name: Upload soteria-c package
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.operating-system }}-soteria-c-package
+          name: ${{ steps.platform.outputs.name }}-soteria-c-package
           path: packages/soteria-c
           if-no-files-found: error
 
@@ -145,7 +165,7 @@ jobs:
       - name: Upload soteria-rust package
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.operating-system }}-soteria-rust-package
+          name: ${{ steps.platform.outputs.name }}-soteria-rust-package
           path: packages/soteria-rust
           if-no-files-found: error
 
@@ -158,8 +178,7 @@ jobs:
           name: odoc
           path: _build/default/_doc/_html
           if-no-files-found: error
-        # No need to upload artifact twice
-        if: ${{ matrix.operating-system == 'macos-latest' }}
+        if: runner.os == 'macOS'
 
       - name: Opam Cleanup
         run: opam clean -a -r

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,31 +58,18 @@ jobs:
       - name: Check that opam files were up to date
         run: make check-opam-files
 
-      # Install Rust and Obol
+      # Install Rust
       - name: Get Rust toolchain
         run: curl https://raw.githubusercontent.com/$OBOL_REPO/$OBOL_COMMIT_HASH/rust-toolchain.toml > rust-toolchain
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+      # Restore caches for Obol and Charon
       - name: Restore Obol cache
         uses: actions/cache@v5
         id: restore-obol-cache
         with:
           path: obol-bin
           key: ${{ runner.os }}-${{ runner.arch }}-obol-${{ env.OBOL_COMMIT_HASH }}
-      - name: Install Obol if not cached (macOS)
-        run: |
-          brew install make
-          ../soteria/scripts/versionsync.py pull obol --init
-          cp -r ../obol/bin obol-bin
-        if: ${{ !steps.restore-obol-cache.outputs.cache-hit && runner.os == 'macOS' }}
-      - name: Install Obol if not cached (Linux)
-        run: |
-          ../soteria/scripts/versionsync.py pull obol --init
-          cp -r ../obol/bin obol-bin
-        if: ${{ !steps.restore-obol-cache.outputs.cache-hit && runner.os == 'Linux' }}
-      - name: Add Obol to path
-        run: echo "$PWD/obol-bin/" >> $GITHUB_PATH
-
       # Install Charon
       - name: Restore Charon cache
         uses: actions/cache@v5
@@ -90,17 +77,23 @@ jobs:
         with:
           path: charon-bin
           key: ${{ runner.os }}-${{ runner.arch }}-charon-${{ env.CHARON_COMMIT_HASH }}
-      - name: Install Charon if not cached (macOS)
+      # On macOS, we need make
+      - name: Install gmake (macOS)
+        run: brew install make
+        if: ${{ (!steps.restore-charon-cache.outputs.cache-hit || !steps.restore-obol-cache.outputs.cache-hit) && runner.os == 'macOS' }}
+      - name: Install Obol if not cached
         run: |
-          brew install make
+          ../soteria/scripts/versionsync.py pull obol --init
+          cp -r ../obol/bin obol-bin
+        if: ${{ !steps.restore-obol-cache.outputs.cache-hit }}
+      - name: Add Obol to path
+        run: echo "$PWD/obol-bin/" >> $GITHUB_PATH
+
+      - name: Install Charon if not cached
+        run: |
           ../soteria/scripts/versionsync.py pull charon --init
           cp -r ../charon/bin charon-bin
-        if: ${{ !steps.restore-charon-cache.outputs.cache-hit && runner.os == 'macOS' }}
-      - name: Install Charon if not cached (Linux)
-        run: |
-          ../soteria/scripts/versionsync.py pull charon --init
-          cp -r ../charon/bin charon-bin
-        if: ${{ !steps.restore-charon-cache.outputs.cache-hit && runner.os == 'Linux' }}
+        if: ${{ !steps.restore-charon-cache.outputs.cache-hit }}
       - name: Add Charon to path
         run: echo "$PWD/charon-bin/" >> $GITHUB_PATH
 
@@ -178,7 +171,9 @@ jobs:
           name: odoc
           path: _build/default/_doc/_html
           if-no-files-found: error
-        if: runner.os == 'macOS'
+        # Upload only once (same for both platforms).
+        # We do this on linux because linux runners are cheaper.
+        if: runner.os == 'linux'
 
       - name: Opam Cleanup
         run: opam clean -a -r

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,23 +94,37 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download soteria-c package
+      - name: Download soteria-c macOS package
         uses: actions/download-artifact@v8
         with:
-          name: macos-latest-soteria-c-package
-          path: release-artifacts/soteria-c
+          name: macos-arm64-soteria-c-package
+          path: release-artifacts/soteria-c-macos-arm64
 
-      - name: Download soteria-rust package
+      - name: Download soteria-c Linux package
         uses: actions/download-artifact@v8
         with:
-          name: macos-latest-soteria-rust-package
-          path: release-artifacts/soteria-rust
+          name: linux-x86_64-soteria-c-package
+          path: release-artifacts/soteria-c-linux-x86_64
+
+      - name: Download soteria-rust macOS package
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-arm64-soteria-rust-package
+          path: release-artifacts/soteria-rust-macos-arm64
+
+      - name: Download soteria-rust Linux package
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-x86_64-soteria-rust-package
+          path: release-artifacts/soteria-rust-linux-x86_64
 
       - name: Zip packages
         run: |
           cd release-artifacts
-          zip -r soteria-c-macos.zip soteria-c/
-          zip -r soteria-rust-macos.zip soteria-rust/
+          zip -r soteria-c-macos-arm64.zip soteria-c-macos-arm64/
+          zip -r soteria-c-linux-x86_64.zip soteria-c-linux-x86_64/
+          zip -r soteria-rust-macos-arm64.zip soteria-rust-macos-arm64/
+          zip -r soteria-rust-linux-x86_64.zip soteria-rust-linux-x86_64/
 
       - name: Delete existing nightly release and tag
         env:
@@ -164,8 +178,10 @@ jobs:
             --title "Nightly $(date -u +%Y-%m-%d)" \
             --notes-file "$NOTES_FILE" \
             --prerelease \
-            release-artifacts/soteria-c-macos.zip \
-            release-artifacts/soteria-rust-macos.zip
+            release-artifacts/soteria-c-macos-arm64.zip \
+            release-artifacts/soteria-c-linux-x86_64.zip \
+            release-artifacts/soteria-rust-macos-arm64.zip \
+            release-artifacts/soteria-rust-linux-x86_64.zip
 
   nightly-skip:
     name: Skip Nightly Release

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Setup environment variables
         run: |
           PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-c-package"
+          echo "PACKAGE_DIR=${PACKAGE_DIR}" >> $GITHUB_ENV
           echo "CERB_INSTALL_PREFIX=${PACKAGE_DIR}" >> $GITHUB_ENV
           echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
           echo "SOTERIA_AUTO_INCLUDE_PATH=${PACKAGE_DIR}/lib/soteria-c" >> $GITHUB_ENV
@@ -120,6 +121,7 @@ jobs:
       - name: Setup environment variables
         run: |
           PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-rust-package"
+          echo "PACKAGE_DIR=${PACKAGE_DIR}" >> $GITHUB_ENV
           echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
           echo "SOTERIA_OBOL_PATH=${PACKAGE_DIR}/bin/obol" >> $GITHUB_ENV
           echo "SOTERIA_CHARON_PATH=${PACKAGE_DIR}/bin/charon" >> $GITHUB_ENV

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -14,9 +14,17 @@ jobs:
     name: Test soteria-c Package
     strategy:
       matrix:
-        operating-system: [macos-latest]
+        operating-system: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.operating-system }}
     steps:
+      - name: Set platform artifact name
+        id: platform
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            echo "name=macos-arm64" >> $GITHUB_OUTPUT
+          else
+            echo "name=linux-x86_64" >> $GITHUB_OUTPUT
+          fi
       - name: Checkout Collections-C, version where we find a bug
         uses: actions/checkout@v6
         with:
@@ -25,17 +33,29 @@ jobs:
       - name: Download package
         uses: actions/download-artifact@v8
         with:
-          name: ${{ matrix.operating-system }}-soteria-c-package
+          name: ${{ steps.platform.outputs.name }}-soteria-c-package
           path: soteria-c-package
       - name: Add executable permissions
         run: |
           chmod +x ./soteria-c-package/bin/soteria-c
           chmod +x ./soteria-c-package/bin/z3
-      - name: Setup environment variables
+      - name: Setup environment variables (macOS)
+        if: runner.os == 'macOS'
         run: |
           PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-c-package"
           echo "CERB_INSTALL_PREFIX=${PACKAGE_DIR}" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
+          echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
+          echo "SOTERIA_AUTO_INCLUDE_PATH=${PACKAGE_DIR}/lib/soteria-c" >> $GITHUB_ENV
+          echo "SOTERIA_C=${PACKAGE_DIR}/bin/soteria-c" >> $GITHUB_ENV
+          echo "SOTERIA_SOLVER_TIMEOUT=100" >> $GITHUB_ENV
+          echo "SOTERIA_USE_CERB_HEADERS=true" >> $GITHUB_ENV
+      - name: Setup environment variables (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-c-package"
+          echo "CERB_INSTALL_PREFIX=${PACKAGE_DIR}" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
           echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
           echo "SOTERIA_AUTO_INCLUDE_PATH=${PACKAGE_DIR}/lib/soteria-c" >> $GITHUB_ENV
           echo "SOTERIA_C=${PACKAGE_DIR}/bin/soteria-c" >> $GITHUB_ENV
@@ -71,9 +91,17 @@ jobs:
     name: Test soteria-rust Package
     strategy:
       matrix:
-        operating-system: [macos-latest]
+        operating-system: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.operating-system }}
     steps:
+      - name: Set platform artifact name
+        id: platform
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            echo "name=macos-arm64" >> $GITHUB_OUTPUT
+          else
+            echo "name=linux-x86_64" >> $GITHUB_OUTPUT
+          fi
       - name: Get Rust toolchain
         run: curl https://raw.githubusercontent.com/$OBOL_REPO/$OBOL_COMMIT_HASH/rust-toolchain.toml > rust-toolchain
       - name: Setup Rust
@@ -83,7 +111,7 @@ jobs:
       - name: Download package
         uses: actions/download-artifact@v8
         with:
-          name: ${{ matrix.operating-system }}-soteria-rust-package
+          name: ${{ steps.platform.outputs.name }}-soteria-rust-package
           path: soteria-rust-package
       - name: Add executable permissions
         run: |
@@ -93,10 +121,21 @@ jobs:
           chmod +x ./soteria-rust-package/bin/charon
           chmod +x ./soteria-rust-package/bin/obol-driver
           chmod +x ./soteria-rust-package/bin/charon-driver
-      - name: Setup environment variables
+      - name: Setup environment variables (macOS)
+        if: runner.os == 'macOS'
         run: |
           PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-rust-package"
           echo "DYLD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
+          echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
+          echo "SOTERIA_OBOL_PATH=${PACKAGE_DIR}/bin/obol" >> $GITHUB_ENV
+          echo "SOTERIA_CHARON_PATH=${PACKAGE_DIR}/bin/charon" >> $GITHUB_ENV
+          echo "SOTERIA_RUST_PLUGINS=${PACKAGE_DIR}/plugins" >> $GITHUB_ENV
+          echo "SOTERIA_RUST=${PACKAGE_DIR}/bin/soteria-rust" >> $GITHUB_ENV
+      - name: Setup environment variables (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-rust-package"
+          echo "LD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
           echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
           echo "SOTERIA_OBOL_PATH=${PACKAGE_DIR}/bin/obol" >> $GITHUB_ENV
           echo "SOTERIA_CHARON_PATH=${PACKAGE_DIR}/bin/charon" >> $GITHUB_ENV

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -39,28 +39,23 @@ jobs:
         run: |
           chmod +x ./soteria-c-package/bin/soteria-c
           chmod +x ./soteria-c-package/bin/z3
-      - name: Setup environment variables (macOS)
-        if: runner.os == 'macOS'
+
+      - name: Setup environment variables
         run: |
           PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-c-package"
           echo "CERB_INSTALL_PREFIX=${PACKAGE_DIR}" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
           echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
           echo "SOTERIA_AUTO_INCLUDE_PATH=${PACKAGE_DIR}/lib/soteria-c" >> $GITHUB_ENV
           echo "SOTERIA_C=${PACKAGE_DIR}/bin/soteria-c" >> $GITHUB_ENV
           echo "SOTERIA_SOLVER_TIMEOUT=100" >> $GITHUB_ENV
           echo "SOTERIA_USE_CERB_HEADERS=true" >> $GITHUB_ENV
-      - name: Setup environment variables (Linux)
+      - name: Setup dynamic library path (Linux)
         if: runner.os == 'Linux'
-        run: |
-          PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-c-package"
-          echo "CERB_INSTALL_PREFIX=${PACKAGE_DIR}" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-          echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
-          echo "SOTERIA_AUTO_INCLUDE_PATH=${PACKAGE_DIR}/lib/soteria-c" >> $GITHUB_ENV
-          echo "SOTERIA_C=${PACKAGE_DIR}/bin/soteria-c" >> $GITHUB_ENV
-          echo "SOTERIA_SOLVER_TIMEOUT=100" >> $GITHUB_ENV
-          echo "SOTERIA_USE_CERB_HEADERS=true" >> $GITHUB_ENV
+        run: echo "LD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+      - name: Setup dynamic library path (macOS)
+        if: runner.os == 'macOS'
+        run: echo "DYLD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
+
       - name: Create compilation database
         run: |
           mkdir -p build
@@ -121,26 +116,22 @@ jobs:
           chmod +x ./soteria-rust-package/bin/charon
           chmod +x ./soteria-rust-package/bin/obol-driver
           chmod +x ./soteria-rust-package/bin/charon-driver
-      - name: Setup environment variables (macOS)
-        if: runner.os == 'macOS'
+
+      - name: Setup environment variables
         run: |
           PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-rust-package"
-          echo "DYLD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
           echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
           echo "SOTERIA_OBOL_PATH=${PACKAGE_DIR}/bin/obol" >> $GITHUB_ENV
           echo "SOTERIA_CHARON_PATH=${PACKAGE_DIR}/bin/charon" >> $GITHUB_ENV
           echo "SOTERIA_RUST_PLUGINS=${PACKAGE_DIR}/plugins" >> $GITHUB_ENV
           echo "SOTERIA_RUST=${PACKAGE_DIR}/bin/soteria-rust" >> $GITHUB_ENV
-      - name: Setup environment variables (Linux)
+      - name: Setup dynamic library path (Linux)
         if: runner.os == 'Linux'
-        run: |
-          PACKAGE_DIR="${GITHUB_WORKSPACE}/soteria-rust-package"
-          echo "LD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-          echo "SOTERIA_Z3_PATH=${PACKAGE_DIR}/bin/z3" >> $GITHUB_ENV
-          echo "SOTERIA_OBOL_PATH=${PACKAGE_DIR}/bin/obol" >> $GITHUB_ENV
-          echo "SOTERIA_CHARON_PATH=${PACKAGE_DIR}/bin/charon" >> $GITHUB_ENV
-          echo "SOTERIA_RUST_PLUGINS=${PACKAGE_DIR}/plugins" >> $GITHUB_ENV
-          echo "SOTERIA_RUST=${PACKAGE_DIR}/bin/soteria-rust" >> $GITHUB_ENV
+        run: echo "LD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+      - name: Setup dynamic library path (macOS)
+        if: runner.os == 'macOS'
+        run: echo "DYLD_LIBRARY_PATH=${PACKAGE_DIR}/lib:${DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
+
       - name: Run soteria-rust --help (smoke test)
         run: |
           $SOTERIA_RUST --help

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,21 @@ WHICHX=$(DUNE) exec -- which
 
 YARN=yarn
 
-DYLIB_LIST_FILE=packaging/soteria-c/macOS_dylibs.txt
 PACKAGING_BIN=$(DUNE) exec -- packaging/soteria-c/package.exe
 SOTERIA_C_BIN=_build/install/default/bin/soteria-c
 VSCODE_BC_JS=vscode/src/soteria_vscode.bc.js
 
-SOTERIA_RUST_DYLIB_LIST_FILE=packaging/soteria-rust/macOS_dylibs.txt
 SOTERIA_RUST_PACKAGING_BIN=$(DUNE) exec -- packaging/soteria-rust/package.exe
 SOTERIA_RUST_BIN=_build/install/default/bin/soteria-rust
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+  DYLIB_LIST_FILE=packaging/soteria-c/macOS_dylibs.txt
+  SOTERIA_RUST_DYLIB_LIST_FILE=packaging/soteria-rust/macOS_dylibs.txt
+else
+  DYLIB_LIST_FILE=packaging/soteria-c/linux_dylibs.txt
+  SOTERIA_RUST_DYLIB_LIST_FILE=packaging/soteria-rust/linux_dylibs.txt
+endif
 
 SOTERIA_C_PACKAGE=packages/soteria-c
 SOTERIA_RUST_PACKAGE=packages/soteria-rust
@@ -63,7 +70,7 @@ doc:
 package: package-soteria-c package-soteria-rust
 
 .PHONY: package-soteria-c
-package-soteria-c: ocaml packaging/soteria-c/bin-locations.txt packaging/soteria-c/macOS_dylibs.txt
+package-soteria-c: ocaml packaging/soteria-c/bin-locations.txt $(DYLIB_LIST_FILE)
 	$(DUNE) build @soteria-c-dylist-file
 	$(PACKAGING_BIN) copy-files $(DYLIB_LIST_FILE) $(SOTERIA_C_PACKAGE)/lib
 	$(PACKAGING_BIN) copy-files packaging/soteria-c/bin-locations.txt $(SOTERIA_C_PACKAGE)/bin
@@ -79,13 +86,16 @@ packaging/soteria-c/bin-locations.txt:
 packaging/soteria-c/macOS_dylibs.txt:
 	$(PACKAGING_BIN) infer-dylibs $(SOTERIA_C_BIN) > $@
 
+packaging/soteria-c/linux_dylibs.txt:
+	$(PACKAGING_BIN) infer-dylibs $(SOTERIA_C_BIN) > $@
+
 ##### Packaging soteria-rust #####
 
 # From inside the package folder one can run:
 # SOTERIA_Z3_PATH=./bin/z3 SOTERIA_OBOL_PATH=./bin/obol SOTERIA_CHARON_PATH=./bin/charon \
 #   SOTERIA_RUST_PLUGINS=./plugins DYLD_LIBRARY_PATH=./lib:$DYLD_LIBRARY_PATH ./bin/soteria-rust exec .
 .PHONY: package-soteria-rust
-package-soteria-rust: ocaml packaging/soteria-rust/bin-locations.txt packaging/soteria-rust/macOS_dylibs.txt
+package-soteria-rust: ocaml packaging/soteria-rust/bin-locations.txt $(SOTERIA_RUST_DYLIB_LIST_FILE)
 	$(DUNE) build @soteria-rust-dylist-file
 	$(SOTERIA_RUST_PACKAGING_BIN) copy-files $(SOTERIA_RUST_DYLIB_LIST_FILE) $(SOTERIA_RUST_PACKAGE)/lib
 	$(SOTERIA_RUST_PACKAGING_BIN) copy-files packaging/soteria-rust/bin-locations.txt $(SOTERIA_RUST_PACKAGE)/bin
@@ -100,6 +110,9 @@ packaging/soteria-rust/bin-locations.txt:
 	which charon-driver >> $@ 2>/dev/null || true
 
 packaging/soteria-rust/macOS_dylibs.txt:
+	$(SOTERIA_RUST_PACKAGING_BIN) infer-dylibs $(SOTERIA_RUST_BIN) > $@
+
+packaging/soteria-rust/linux_dylibs.txt:
 	$(SOTERIA_RUST_PACKAGING_BIN) infer-dylibs $(SOTERIA_RUST_BIN) > $@
 
 ##### Switch creation / dependency setup #####
@@ -163,8 +176,8 @@ clean:
 	$(DUNE) clean
 	rm -rf packages
 	rm -rf $(VSCODE_DIST)
-	rm -rf packaging/soteria-c/bin-locations.txt packaging/soteria-c/macOS_dylibs.txt
-	rm -rf packaging/soteria-rust/bin-locations.txt packaging/soteria-rust/macOS_dylibs.txt
+	rm -rf packaging/soteria-c/bin-locations.txt packaging/soteria-c/macOS_dylibs.txt packaging/soteria-c/linux_dylibs.txt
+	rm -rf packaging/soteria-rust/bin-locations.txt packaging/soteria-rust/macOS_dylibs.txt packaging/soteria-rust/linux_dylibs.txt
 	rm -f soteria-vscode.vsix
 
 license-check:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 OCAML_VERSION=5.4.0
 # [versionsync: OCAMLFORMAT_VERSION=0.28.1]
 OCAMLFORMAT_VERSION=0.28.1
+# [versionsync: DUNE_VERSION=3.23.0]
+DUNE_VERSION=3.23.0
 
 OPAM=opam
 OPAMX=$(OPAM) exec --
@@ -138,7 +140,7 @@ soteria-core-deps:
 .PHONY: ocaml-deps
 ocaml-deps:
 	$(OPAM) install . --deps-only --with-test --with-doc -y
-	$(OPAM) install ocamlformat.$(OCAMLFORMAT_VERSION) -y
+	$(OPAM) install dune.$(DUNE_VERSION) ocamlformat.$(OCAMLFORMAT_VERSION) -y
 	$(OPAM) install sherlodoc -y
 
 ##### JavaScript stuff #####

--- a/packaging/common_lib.ml
+++ b/packaging/common_lib.ml
@@ -11,8 +11,7 @@ let dest_dir_arg position =
     & info [] ~docv:"DEST_DIR" ~doc:"Path to the destination directory")
 
 module Infer_Dylibs = struct
-  let get_os () =
-    run "uname" [ "-s" ] |. read_all |> eval |> String.trim
+  let get_os () = run "uname" [ "-s" ] |. read_all |> eval |> String.trim
 
   let infer_dylibs exe =
     match get_os () with
@@ -24,7 +23,7 @@ module Infer_Dylibs = struct
         |> eval
         |> print_string
     | _ ->
-        (* Linux: ldd output is "  libfoo.so => /path/to/libfoo.so (0xaddr)" *)
+        (* Linux: ldd output is " libfoo.so => /path/to/libfoo.so (0xaddr)" *)
         run "ldd" [ exe ]
         |. run "awk" [ "/=>/ {print $3}" ]
         |. read_all
@@ -43,7 +42,6 @@ end
 
 module Copy_files = struct
   let ignored_regexp = Str.quote "libSystem.B.dylib" |> Str.regexp
-
   let linux_system_prefixes = [ "/lib/"; "/lib64/"; "/usr/lib/"; "/usr/lib64/" ]
 
   let is_linux_system_lib path =

--- a/packaging/common_lib.ml
+++ b/packaging/common_lib.ml
@@ -11,13 +11,25 @@ let dest_dir_arg position =
     & info [] ~docv:"DEST_DIR" ~doc:"Path to the destination directory")
 
 module Infer_Dylibs = struct
+  let get_os () =
+    run "uname" [ "-s" ] |. read_all |> eval |> String.trim
+
   let infer_dylibs exe =
-    run "otool" [ "-L"; exe ]
-    |. run "awk" [ "{print $1}" ]
-    |. run "tail" [ "-n"; "+2" ]
-    |. read_all
-    |> eval
-    |> print_string
+    match get_os () with
+    | "Darwin" ->
+        run "otool" [ "-L"; exe ]
+        |. run "awk" [ "{print $1}" ]
+        |. run "tail" [ "-n"; "+2" ]
+        |. read_all
+        |> eval
+        |> print_string
+    | _ ->
+        (* Linux: ldd output is "  libfoo.so => /path/to/libfoo.so (0xaddr)" *)
+        run "ldd" [ exe ]
+        |. run "awk" [ "/=>/ {print $3}" ]
+        |. read_all
+        |> eval
+        |> print_string
 
   let exe_arg =
     Arg.(
@@ -32,8 +44,18 @@ end
 module Copy_files = struct
   let ignored_regexp = Str.quote "libSystem.B.dylib" |> Str.regexp
 
+  let linux_system_prefixes = [ "/lib/"; "/lib64/"; "/usr/lib/"; "/usr/lib64/" ]
+
+  let is_linux_system_lib path =
+    List.exists
+      (fun prefix ->
+        let n = String.length prefix in
+        String.length path >= n && String.sub path 0 n = prefix)
+      linux_system_prefixes
+
   let should_ignore lib =
-    try Str.search_forward ignored_regexp lib 0 >= 0 with Not_found -> false
+    (try Str.search_forward ignored_regexp lib 0 >= 0 with Not_found -> false)
+    || is_linux_system_lib lib
 
   let copy_files list_file dest_dir =
     let () = mkdir ~p:() dest_dir |> eval in

--- a/packaging/common_lib.ml
+++ b/packaging/common_lib.ml
@@ -22,13 +22,14 @@ module Infer_Dylibs = struct
         |. read_all
         |> eval
         |> print_string
-    | _ ->
-        (* Linux: ldd output is " libfoo.so => /path/to/libfoo.so (0xaddr)" *)
+    | "Linux" ->
+        (* ldd output is " libfoo.so => /path/to/libfoo.so (0xaddr)" *)
         run "ldd" [ exe ]
         |. run "awk" [ "/=>/ {print $3}" ]
         |. read_all
         |> eval
         |> print_string
+    | os -> failwith ("Unsupported OS: " ^ os)
 
   let exe_arg =
     Arg.(

--- a/packaging/soteria-c/dune
+++ b/packaging/soteria-c/dune
@@ -9,7 +9,8 @@
 
 (rule ; Verify macOS_dylibs.txt is up-to-date on macOS.
  (alias soteria-c-dylist-file)
- (enabled_if (= %{system} "macosx"))
+ (enabled_if
+  (= %{system} "macosx"))
  (deps %{bin:soteria-c} ./package.exe)
  (action
   (progn
@@ -20,7 +21,8 @@
 
 (rule ; Verify linux_dylibs.txt is up-to-date on Linux.
  (alias soteria-c-dylist-file)
- (enabled_if (= %{system} "linux"))
+ (enabled_if
+  (= %{system} "linux"))
  (deps %{bin:soteria-c} ./package.exe)
  (action
   (progn

--- a/packaging/soteria-c/dune
+++ b/packaging/soteria-c/dune
@@ -7,8 +7,9 @@
   cerberus-lib.backend_common
   soteria_c_lib))
 
-(rule ; This rule makes sure the macOS_dylibs.txt are up-to-date.
+(rule ; Verify macOS_dylibs.txt is up-to-date on macOS.
  (alias soteria-c-dylist-file)
+ (enabled_if (= %{system} "macosx"))
  (deps %{bin:soteria-c} ./package.exe)
  (action
   (progn
@@ -16,3 +17,14 @@
     macOS_dylibs_found.txt
     (run ./package.exe infer-dylibs %{bin:soteria-c}))
    (diff? macOS_dylibs.txt macOS_dylibs_found.txt))))
+
+(rule ; Verify linux_dylibs.txt is up-to-date on Linux.
+ (alias soteria-c-dylist-file)
+ (enabled_if (= %{system} "linux"))
+ (deps %{bin:soteria-c} ./package.exe)
+ (action
+  (progn
+   (with-stdout-to
+    linux_dylibs_found.txt
+    (run ./package.exe infer-dylibs %{bin:soteria-c}))
+   (diff? linux_dylibs.txt linux_dylibs_found.txt))))

--- a/packaging/soteria-c/package.ml
+++ b/packaging/soteria-c/package.ml
@@ -9,7 +9,7 @@ module Copy_cerb_runtime = struct
     let path = Cerb_runtime.in_runtime "" in
     let dest_dir = dest_dir / "cerberus-lib" / "runtime" in
     let () = run "mkdir" [ "-p"; dest_dir ] |> eval in
-    let () = run "cp" [ "-r"; path; dest_dir ] |> eval in
+    let () = run "cp" [ "-rL"; path ^ "/."; dest_dir ] |> eval in
     let () = run "rm" [ "-rf"; Filename.concat dest_dir "bmc" ] |> eval in
     Printf.printf "Copied Cerb runtime from %s to %s\n" path dest_dir
 

--- a/packaging/soteria-rust/dune
+++ b/packaging/soteria-rust/dune
@@ -2,8 +2,9 @@
  (name package)
  (libraries packaging_common soteria_rust_lib))
 
-(rule ; This rule makes sure the macOS_dylibs.txt are up-to-date.
+(rule ; Verify macOS_dylibs.txt is up-to-date on macOS.
  (alias soteria-rust-dylist-file)
+ (enabled_if (= %{system} "macosx"))
  (deps %{bin:soteria-rust} ./package.exe)
  (action
   (progn
@@ -11,3 +12,14 @@
     macOS_dylibs_found.txt
     (run ./package.exe infer-dylibs %{bin:soteria-rust}))
    (diff? macOS_dylibs.txt macOS_dylibs_found.txt))))
+
+(rule ; Verify linux_dylibs.txt is up-to-date on Linux.
+ (alias soteria-rust-dylist-file)
+ (enabled_if (= %{system} "linux"))
+ (deps %{bin:soteria-rust} ./package.exe)
+ (action
+  (progn
+   (with-stdout-to
+    linux_dylibs_found.txt
+    (run ./package.exe infer-dylibs %{bin:soteria-rust}))
+   (diff? linux_dylibs.txt linux_dylibs_found.txt))))

--- a/packaging/soteria-rust/dune
+++ b/packaging/soteria-rust/dune
@@ -4,7 +4,8 @@
 
 (rule ; Verify macOS_dylibs.txt is up-to-date on macOS.
  (alias soteria-rust-dylist-file)
- (enabled_if (= %{system} "macosx"))
+ (enabled_if
+  (= %{system} "macosx"))
  (deps %{bin:soteria-rust} ./package.exe)
  (action
   (progn
@@ -15,7 +16,8 @@
 
 (rule ; Verify linux_dylibs.txt is up-to-date on Linux.
  (alias soteria-rust-dylist-file)
- (enabled_if (= %{system} "linux"))
+ (enabled_if
+  (= %{system} "linux"))
  (deps %{bin:soteria-rust} ./package.exe)
  (action
   (progn

--- a/packaging/soteria-rust/package.ml
+++ b/packaging/soteria-rust/package.ml
@@ -7,7 +7,7 @@ module Copy_soteria_rust_plugins = struct
   let copy_plugins dest_dir =
     let path = Stdlib.List.nth Soteria_rust_lib.Runtime_sites.Sites.plugins 0 in
     let () = run "mkdir" [ "-p"; dest_dir ] |> eval in
-    let () = run "cp" [ "-r"; path ^ "/."; dest_dir ] |> eval in
+    let () = run "cp" [ "-rL"; path ^ "/."; dest_dir ] |> eval in
     Printf.printf "Copied Soteria Rust plugins from %s to %s\n" path dest_dir
 
   let term = Term.(const copy_plugins $ Common_lib.dest_dir_arg 0)

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -5,5 +5,6 @@
   "OBOL_REPO": "soteria-tools/obol",
   "OBOL_COMMIT_HASH": "ddea5ca5da4c07301584f47f05ea8615fc365b41",
   "OCAMLFORMAT_VERSION": "0.28.1",
-  "OCAML_VERSION": "5.4.0"
+  "OCAML_VERSION": "5.4.0",
+  "DUNE_VERSION": "3.23.0"
 }

--- a/scripts/versionsync.py
+++ b/scripts/versionsync.py
@@ -473,10 +473,10 @@ def get_make_command() -> str:
     return "make"
 
 
-def pull_project(project: str, target_dir: Path, commit_hash: str, repo: str, build_cmd: str, allow_init: bool) -> None:
+def pull_project(project: str, target_dir: Path, commit_hash: str, repo: str, build_cmd: str, allow_init: bool, post_build_cmds: list[list[str]] | None = None) -> None:
     """
     Pull and build a single project.
-    
+
     Args:
         project: Project name (obol or charon)
         target_dir: Directory where the project is located
@@ -484,6 +484,9 @@ def pull_project(project: str, target_dir: Path, commit_hash: str, repo: str, bu
         repo: Expected repository (e.g., 'soteria-tools/obol')
         build_cmd: Build command to run
         allow_init: If True, will clone the repo if it doesn't exist
+        post_build_cmds: Optional list of commands to run after the build, each
+            as a list of strings. Run from target_dir so the project's
+            rust-toolchain.toml is in scope.
     """
     step(f"Processing {project}...")
     
@@ -531,7 +534,11 @@ def pull_project(project: str, target_dir: Path, commit_hash: str, repo: str, bu
     info(f"Running build command: {' '.join(build_cmd_parts)}")
     run_command(build_cmd_parts, target_dir)
     success(f"Build completed successfully")
-    
+
+    for cmd in (post_build_cmds or []):
+        info(f"Running post-build command: {' '.join(cmd)}")
+        run_command(cmd, target_dir)
+
     color_print(f"\n✓ {project} updated and built successfully!\n", Colors.GREEN + Colors.BOLD)
 
 
@@ -543,6 +550,12 @@ def cmd_pull(args: argparse.Namespace, root: Path, versions: dict[str, str]) -> 
             "version_key": "OBOL_COMMIT_HASH",
             "default_dir": root.parent / "obol",
             "build_cmd": "make build",
+            # Install cross-compilation targets so soteria-rust can analyse code
+            # for platforms other than the host. Run from the obol directory so
+            # that rustup picks up its rust-toolchain.toml.
+            "post_build_cmds": [
+                ["rustup", "target", "add", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin"],
+            ],
         },
         "charon": {
             "repo_key": "CHARON_REPO",
@@ -582,7 +595,8 @@ def cmd_pull(args: argparse.Namespace, root: Path, versions: dict[str, str]) -> 
         commit_hash = versions[config["version_key"]]
         
         try:
-            pull_project(project, target_dir, commit_hash, repo, config["build_cmd"], args.init)
+            pull_project(project, target_dir, commit_hash, repo, config["build_cmd"], args.init,
+                         post_build_cmds=config.get("post_build_cmds"))
         except SystemExit:
             # Error already printed
             return 1

--- a/soteria-c.opam
+++ b/soteria-c.opam
@@ -36,6 +36,7 @@ depends: [
   "dune" {>= "3.14" & build & >= "3.14.0"}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "ocaml-lsp-server" {with-dev-setup}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/soteria-c/includes/soteria-c.h
+++ b/soteria-c/includes/soteria-c.h
@@ -64,6 +64,7 @@ int __builtin___snprintf_chk(char *s, __cerbty_size_t maxlen, int flag, __cerbty
 char *__builtin___strncpy_chk(char *dest, const char *src, __cerbty_size_t n, __cerbty_size_t os);
 __cerbty_size_t __builtin_object_size(const void *ptr, int type);
 
+__cerbty_uint16_t __builtin_bswap16(__cerbty_uint16_t x);
 __cerbty_uint32_t __builtin_bswap32(__cerbty_uint32_t x);
 __cerbty_uint64_t __builtin_bswap64(__cerbty_uint64_t x);
 

--- a/soteria-c/lib/abductor.ml
+++ b/soteria-c/lib/abductor.ml
@@ -15,9 +15,7 @@ let default_abductor_fuel =
 let generate_summaries_for (fundef : fundef) =
   let open Syntaxes.List in
   let fid, (floc, _, _, _, _) = fundef in
-  let section_name =
-    "Generate summaries for " ^ Cerb_frontend.Symbol.show_symbol fid
-  in
+  let section_name = Fmt.str "Generate summaries for %a" Symbol_std.pp fid in
   let@ () = L.with_section section_name in
   [%l.info "%s" section_name];
   let* arg_tys =

--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -286,7 +286,7 @@ let generate_errors content =
       |> List.concat_map (fun (fid, summaries) ->
           let@ () =
             L.with_section
-              ("Analysing summaries for function" ^ Symbol.show_symbol fid)
+              (Fmt.str "Analysing summaries for function %a" Symbol_std.pp fid)
           in
           List.concat_map (Summary.manifest_bugs ~fid) summaries)
       |> List.sort_uniq Stdlib.compare

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -211,13 +211,10 @@ let rec analyse : type a. fid:Ail_tys.sym -> a t -> analysed t =
   | Analysed _ -> summary
   | Pruned { raw = summary; memory_leaks } -> (
       let@ () =
-        L.with_section
-          ("Analysing a summary for " ^ Cerb_frontend.Symbol.show_symbol fid)
+        L.with_section (Fmt.str "Analysing a summary for %a" Symbol_std.pp fid)
       in
       [%l.debug
-        "Analysing a summary for %s@\n%a"
-          (Cerb_frontend.Symbol.show_symbol fid)
-          pp_raw summary];
+        "Analysing a summary for %a@\n%a" Symbol_std.pp fid pp_raw summary];
       let arg_tys = Option.get (Ail_helpers.get_param_tys fid) in
       match summary.ret with
       | Ok _ ->

--- a/soteria-c/lib/symbol_std.ml
+++ b/soteria-c/lib/symbol_std.ml
@@ -9,8 +9,15 @@ module SELF = struct
   let equal = equal_sym
   let compare = compare_sym
   let hash = Hashtbl.hash
-  let show = Cerb_frontend.Pp_symbol.to_string
-  let pp = Fmt.of_to_string show
+
+  let pp ft (Symbol (_, n, sd)) =
+    let pp_id = Soteria.Logs.Printers.pp_unstable ~name:"id" Fmt.int in
+    match sd with
+    | SD_Id str | SD_ObjectAddress str | SD_FunArgValue str ->
+        Fmt.pf ft "%s_%a" str pp_id n
+    | _ -> Fmt.pf ft "a_%a" pp_id n
+
+  let show = Fmt.to_to_string pp
 end
 
 include SELF

--- a/soteria-c/test/cram/cc.t/run.t
+++ b/soteria-c/test/cram/cc.t/run.t
@@ -1,11 +1,11 @@
   $ soteria-c exec array_add.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
   error: Buffer overflow or underflow in main
-      ┌─ array_add.c:104:5
-  104 │      ar->buffer[ar->size] = element;
-      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid memory write
-      ·  
-  157 │          array_add(v1, NULL);
-      │          -------------------- 1: Called from here
+      --> array_add.c:104:5
+  104 |      ar->buffer[ar->size] = element;
+      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid memory write
+      .  
+  157 |          array_add(v1, NULL);
+      |          -------------------- 1: Called from here
   Executed 163 statements
   Verification Failure!
   [13]

--- a/soteria-c/test/cram/cli.t/run.t
+++ b/soteria-c/test/cram/cli.t/run.t
@@ -95,7 +95,8 @@
   LOGS OPTIONS
          --hide-unstable, --diffable (absent HIDE_UNSTABLE env)
              Do not display unstable values like durations (e.g. for diffing
-             purposes).
+             purposes). Also overrides the profile to disable colors and utf8
+             and ensure that it is reproducible accross runs.
   
          --html
              HTML logging, clashes with --log-kind
@@ -308,7 +309,8 @@
   LOGS OPTIONS
          --hide-unstable, --diffable (absent HIDE_UNSTABLE env)
              Do not display unstable values like durations (e.g. for diffing
-             purposes).
+             purposes). Also overrides the profile to disable colors and utf8
+             and ensure that it is reproducible accross runs.
   
          --html
              HTML logging, clashes with --log-kind
@@ -547,7 +549,8 @@
   LOGS OPTIONS
          --hide-unstable, --diffable (absent HIDE_UNSTABLE env)
              Do not display unstable values like durations (e.g. for diffing
-             purposes).
+             purposes). Also overrides the profile to disable colors and utf8
+             and ensure that it is reproducible accross runs.
   
          --html
              HTML logging, clashes with --log-kind
@@ -908,7 +911,8 @@
   LOGS OPTIONS
          --hide-unstable, --diffable (absent HIDE_UNSTABLE env)
              Do not display unstable values like durations (e.g. for diffing
-             purposes).
+             purposes). Also overrides the profile to disable colors and utf8
+             and ensure that it is reproducible accross runs.
   
          --html
              HTML logging, clashes with --log-kind

--- a/soteria-c/test/cram/comp_db.t/run.t
+++ b/soteria-c/test/cram/comp_db.t/run.t
@@ -1,27 +1,27 @@
   $ soteria-c capture-db compilation_database.json --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for test2_725:
+  Summaries for test2_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   
-  Summaries for test1_561:
+  Summaries for test1_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   
-  Summaries for test3_642:
+  Summaries for test3_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   
-  Summaries for main_726:
+  Summaries for main_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   
-  Summaries for test2_643:
+  Summaries for test2_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}

--- a/soteria-c/test/cram/comp_db.t/run.t
+++ b/soteria-c/test/cram/comp_db.t/run.t
@@ -1,27 +1,27 @@
   $ soteria-c capture-db compilation_database.json --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for test2_719:
+  Summaries for test2_725:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   
-  Summaries for test1_559:
+  Summaries for test1_561:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   
-  Summaries for test3_638:
+  Summaries for test3_642:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   
-  Summaries for main_720:
+  Summaries for main_726:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   
-  Summaries for test2_639:
+  Summaries for test2_643:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}

--- a/soteria-c/test/cram/cprover_api.t/run.t
+++ b/soteria-c/test/cram/cprover_api.t/run.t
@@ -1,7 +1,7 @@
 Warning and unspported with CBMC enabled 
   $ soteria-c exec test.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
   warning: CBMC support is not enabled, but detected use of the __CPROVER API. Soteria will consider the function as missing a body.
-  error: Analysis gave up: Unsupported: Cannot call external function: __CPROVER_assume_563 in main
+  error: Analysis gave up: Unsupported: Cannot call external function: __CPROVER_assume_565 in main
   Executed 2 statements
   Verification Failure! (Unsupported features)
   [2]

--- a/soteria-c/test/cram/cprover_api.t/run.t
+++ b/soteria-c/test/cram/cprover_api.t/run.t
@@ -9,12 +9,12 @@ Warning and unspported with CBMC enabled
 Behaves as expected with the API declared.
   $ soteria-c exec test.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --cbmc-compat
   error: Failed assertion in main
-      ┌─ test.c:7:3
-    7 │    __CPROVER_assert(0, "");
-      │    ^^^^^^^^^^^^^^^^^^^^^^^
-      │    │
-      │    Triggering operation
-      │    1: Called from here
+      --> test.c:7:3
+    7 |    __CPROVER_assert(0, "");
+      |    ^^^^^^^^^^^^^^^^^^^^^^^
+      |    |
+      |    Triggering operation
+      |    1: Called from here
   Executed 3 statements
   Verification Failure!
   [13]

--- a/soteria-c/test/cram/cprover_api.t/run.t
+++ b/soteria-c/test/cram/cprover_api.t/run.t
@@ -1,7 +1,7 @@
 Warning and unspported with CBMC enabled 
   $ soteria-c exec test.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
   warning: CBMC support is not enabled, but detected use of the __CPROVER API. Soteria will consider the function as missing a body.
-  error: Analysis gave up: Unsupported: Cannot call external function: __CPROVER_assume_565 in main
+  error: Analysis gave up: Unsupported: Cannot call external function: __CPROVER_assume_<id> in main
   Executed 2 statements
   Verification Failure! (Unsupported features)
   [2]

--- a/soteria-c/test/cram/failed_parse.t/run.t
+++ b/soteria-c/test/cram/failed_parse.t/run.t
@@ -6,7 +6,7 @@
   ^ 
   
   No bugs found
-  Summaries for test_561:
+  Summaries for test_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}

--- a/soteria-c/test/cram/failed_parse.t/run.t
+++ b/soteria-c/test/cram/failed_parse.t/run.t
@@ -6,7 +6,7 @@
   ^ 
   
   No bugs found
-  Summaries for test_559:
+  Summaries for test_561:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}

--- a/soteria-c/test/cram/fixme.t/run.t
+++ b/soteria-c/test/cram/fixme.t/run.t
@@ -1,7 +1,7 @@
   $ soteria-c gen-summaries global_local_eq.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for main_560:
+  Summaries for main_562:
     Analysed {
       raw =
       { args = []; pre = [];
@@ -19,7 +19,7 @@
              (V|2|,
               { node = Bound(0x0000000000000004);
                 info = (Some global_local_eq.c:6:28-30 (cursor: 6:28)) }));
-          (Ser_globs (x_559, V|1|))];
+          (Ser_globs (x_561, V|1|))];
         ret =
         (Error (Failed assertion,
                 [• Called from here: global_local_eq.c:6:3-31;
@@ -30,6 +30,6 @@
       raw =
       { args = []; pre = [];
         pc = [(0x0000000000000000 != V|1|); (V|1| != V|2|)];
-        post = [(Ser_globs (x_559, V|1|))]; ret = (Ok 0x00000000) };
+        post = [(Ser_globs (x_561, V|1|))]; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   

--- a/soteria-c/test/cram/fixme.t/run.t
+++ b/soteria-c/test/cram/fixme.t/run.t
@@ -1,7 +1,7 @@
   $ soteria-c gen-summaries global_local_eq.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for main_562:
+  Summaries for main_<id>:
     Analysed {
       raw =
       { args = []; pre = [];
@@ -19,7 +19,7 @@
              (V|2|,
               { node = Bound(0x0000000000000004);
                 info = (Some global_local_eq.c:6:28-30 (cursor: 6:28)) }));
-          (Ser_globs (x_561, V|1|))];
+          (Ser_globs (x_<id>, V|1|))];
         ret =
         (Error (Failed assertion,
                 [• Called from here: global_local_eq.c:6:3-31;
@@ -30,6 +30,6 @@
       raw =
       { args = []; pre = [];
         pc = [(0x0000000000000000 != V|1|); (V|1| != V|2|)];
-        post = [(Ser_globs (x_561, V|1|))]; ret = (Ok 0x00000000) };
+        post = [(Ser_globs (x_<id>, V|1|))]; ret = (Ok 0x00000000) };
       manifest_bugs = []}
   

--- a/soteria-c/test/cram/multi-files/duplicate-sym.t/run.t
+++ b/soteria-c/test/cram/multi-files/duplicate-sym.t/run.t
@@ -1,7 +1,7 @@
   $ soteria-c gen-summaries file1.c file2.c -I . --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for test_561:
+  Summaries for test_563:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}

--- a/soteria-c/test/cram/multi-files/duplicate-sym.t/run.t
+++ b/soteria-c/test/cram/multi-files/duplicate-sym.t/run.t
@@ -1,7 +1,7 @@
   $ soteria-c gen-summaries file1.c file2.c -I . --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for test_563:
+  Summaries for test_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}

--- a/soteria-c/test/cram/multi-files/test0.t/run.t
+++ b/soteria-c/test/cram/multi-files/test0.t/run.t
@@ -30,6 +30,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,
@@ -70,6 +71,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,
@@ -145,8 +147,8 @@
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000004; v = 0x0000000c : signed int};
                    info = None }));
-             (Ser_globs (x_560, 0x0000000000000002));
-             (Ser_globs (x_642, 0x0000000000000001))])]
+             (Ser_globs (x_562, 0x0000000000000002));
+             (Ser_globs (x_646, 0x0000000000000001))])]
   
   Executed 7 statements
   Verification Success!

--- a/soteria-c/test/cram/multi-files/test0.t/run.t
+++ b/soteria-c/test/cram/multi-files/test0.t/run.t
@@ -147,8 +147,8 @@
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000004; v = 0x0000000c : signed int};
                    info = None }));
-             (Ser_globs (x_562, 0x0000000000000002));
-             (Ser_globs (x_646, 0x0000000000000001))])]
+             (Ser_globs (x_<id>, 0x0000000000000002));
+             (Ser_globs (x_<id>, 0x0000000000000001))])]
   
   Executed 7 statements
   Verification Success!

--- a/soteria-c/test/cram/multi-files/test1.t/run.t
+++ b/soteria-c/test/cram/multi-files/test1.t/run.t
@@ -174,8 +174,8 @@
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000004; v = 0x00000400 : signed int};
                    info = None }));
-             (Ser_globs (glob_648, 0x0000000000000002));
-             (Ser_globs (ref_649, 0x0000000000000001))])]
+             (Ser_globs (glob_<id>, 0x0000000000000002));
+             (Ser_globs (ref_<id>, 0x0000000000000001))])]
   
   Executed 15 statements
   Verification Success!

--- a/soteria-c/test/cram/multi-files/test1.t/run.t
+++ b/soteria-c/test/cram/multi-files/test1.t/run.t
@@ -30,6 +30,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,
@@ -72,6 +73,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,
@@ -172,8 +174,8 @@
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000004; v = 0x00000400 : signed int};
                    info = None }));
-             (Ser_globs (glob_644, 0x0000000000000002));
-             (Ser_globs (ref_645, 0x0000000000000001))])]
+             (Ser_globs (glob_648, 0x0000000000000002));
+             (Ser_globs (ref_649, 0x0000000000000001))])]
   
   Executed 15 statements
   Verification Success!

--- a/soteria-c/test/cram/multi-files/test2.t/run.t
+++ b/soteria-c/test/cram/multi-files/test2.t/run.t
@@ -30,6 +30,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,
@@ -69,6 +70,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,

--- a/soteria-c/test/cram/multi-files/test3.t/run.t
+++ b/soteria-c/test/cram/multi-files/test3.t/run.t
@@ -31,6 +31,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,
@@ -70,6 +71,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,

--- a/soteria-c/test/cram/multi-files/test4.t/run.t
+++ b/soteria-c/test/cram/multi-files/test4.t/run.t
@@ -30,6 +30,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,
@@ -70,6 +71,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,

--- a/soteria-c/test/cram/multi-files/test5.t/run.t
+++ b/soteria-c/test/cram/multi-files/test5.t/run.t
@@ -31,6 +31,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,
@@ -69,6 +70,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,
@@ -107,6 +109,7 @@
   pointer to {const} char, size_t, size_t) returning pointer to char' EMPTY
   | |-Decl_function __builtin_object_size 'function (pointer to {const} void,
   signed int) returning size_t' EMPTY
+  | |-Decl_function __builtin_bswap16 'function (uint16_t) returning uint16_t' EMPTY
   | |-Decl_function __builtin_bswap32 'function (uint32_t) returning uint32_t' EMPTY
   | |-Decl_function __builtin_bswap64 'function (uint64_t) returning uint64_t' EMPTY
   | |-Decl_function __atomic_load_n 'function (pointer to {volatile} signed int,

--- a/soteria-c/test/cram/simple.t/run.t
+++ b/soteria-c/test/cram/simple.t/run.t
@@ -1320,7 +1320,7 @@ Checking that code cannot branch infinitely
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000004; v = 0x00000001 : signed int};
                    info = None }));
-             (Ser_globs (x_559, 0x0000000000000001))])]
+             (Ser_globs (x_561, 0x0000000000000001))])]
   
   Executed 5 statements
   Verification Success!
@@ -1340,8 +1340,8 @@ Checking that code cannot branch infinitely
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000004; v = 0x00000000 : signed int};
                    info = None }));
-             (Ser_globs (x_559, 0x0000000000000001));
-             (Ser_globs (y_560, 0x0000000000000002))])]
+             (Ser_globs (x_561, 0x0000000000000001));
+             (Ser_globs (y_562, 0x0000000000000002))])]
   
   Executed 3 statements
   Verification Success!
@@ -1460,7 +1460,7 @@ Expected to correctly find the harness function
                 (0x0000000000000002,
                  { node = Bound(0x0000000000000008);
                    info = (Some float.c:10:23-47) }));
-             (Ser_globs (f_560, 0x0000000000000001))]);
+             (Ser_globs (f_562, 0x0000000000000001))]);
      Ok: (0x00000001,
           Some
             [(Ser_heap
@@ -1469,7 +1469,7 @@ Expected to correctly find the harness function
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000008; v = 0.0f : float};
                    info = None }));
-             (Ser_globs (f_560, 0x0000000000000001))])]
+             (Ser_globs (f_562, 0x0000000000000001))])]
   
   Executed 11 statements
   Verification Success!
@@ -1516,9 +1516,9 @@ Check with the proper flag we obtain only one branch
 Check that, without proper flag, undefined function calls are not-implemented
   $ soteria-c exec havoc_undef.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --print-states
   Symex terminated with the following outcomes:
-    [Error: Gave up: Unsupported: Cannot call external function: nondet_int_559]
+    [Error: Gave up: Unsupported: Cannot call external function: nondet_int_561]
   
-  error: Analysis gave up: Unsupported: Cannot call external function: nondet_int_559 in main
+  error: Analysis gave up: Unsupported: Cannot call external function: nondet_int_561 in main
   Executed 2 statements
   Verification Failure! (Unsupported features)
   [2]
@@ -1557,7 +1557,7 @@ Check that, with proper flag, undefined function calls are havoced. Expecting 2 
              (Ser_heap
                 (0x0000000000000002,
                  { node = Freed; info = (Some glob_struct.c:16:22-23) }));
-             (Ser_globs (x_561, 0x0000000000000001))])]
+             (Ser_globs (x_563, 0x0000000000000001))])]
   
   Executed 6 statements
   Verification Success!

--- a/soteria-c/test/cram/simple.t/run.t
+++ b/soteria-c/test/cram/simple.t/run.t
@@ -1320,7 +1320,7 @@ Checking that code cannot branch infinitely
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000004; v = 0x00000001 : signed int};
                    info = None }));
-             (Ser_globs (x_561, 0x0000000000000001))])]
+             (Ser_globs (x_<id>, 0x0000000000000001))])]
   
   Executed 5 statements
   Verification Success!
@@ -1340,8 +1340,8 @@ Checking that code cannot branch infinitely
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000004; v = 0x00000000 : signed int};
                    info = None }));
-             (Ser_globs (x_561, 0x0000000000000001));
-             (Ser_globs (y_562, 0x0000000000000002))])]
+             (Ser_globs (x_<id>, 0x0000000000000001));
+             (Ser_globs (y_<id>, 0x0000000000000002))])]
   
   Executed 3 statements
   Verification Success!
@@ -1460,7 +1460,7 @@ Expected to correctly find the harness function
                 (0x0000000000000002,
                  { node = Bound(0x0000000000000008);
                    info = (Some float.c:10:23-47) }));
-             (Ser_globs (f_562, 0x0000000000000001))]);
+             (Ser_globs (f_<id>, 0x0000000000000001))]);
      Ok: (0x00000001,
           Some
             [(Ser_heap
@@ -1469,7 +1469,7 @@ Expected to correctly find the harness function
                    MemVal {offset = 0x0000000000000000;
                      len = 0x0000000000000008; v = 0.0f : float};
                    info = None }));
-             (Ser_globs (f_562, 0x0000000000000001))])]
+             (Ser_globs (f_<id>, 0x0000000000000001))])]
   
   Executed 11 statements
   Verification Success!
@@ -1516,9 +1516,9 @@ Check with the proper flag we obtain only one branch
 Check that, without proper flag, undefined function calls are not-implemented
   $ soteria-c exec havoc_undef.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --print-states
   Symex terminated with the following outcomes:
-    [Error: Gave up: Unsupported: Cannot call external function: nondet_int_561]
+    [Error: Gave up: Unsupported: Cannot call external function: nondet_int_<id>]
   
-  error: Analysis gave up: Unsupported: Cannot call external function: nondet_int_561 in main
+  error: Analysis gave up: Unsupported: Cannot call external function: nondet_int_<id> in main
   Executed 2 statements
   Verification Failure! (Unsupported features)
   [2]
@@ -1557,7 +1557,7 @@ Check that, with proper flag, undefined function calls are havoced. Expecting 2 
              (Ser_heap
                 (0x0000000000000002,
                  { node = Freed; info = (Some glob_struct.c:16:22-23) }));
-             (Ser_globs (x_563, 0x0000000000000001))])]
+             (Ser_globs (x_<id>, 0x0000000000000001))])]
   
   Executed 6 statements
   Verification Success!

--- a/soteria-c/test/cram/simple.t/run.t
+++ b/soteria-c/test/cram/simple.t/run.t
@@ -47,9 +47,9 @@ Symbolic execution of a simple program with symbolic values that fails because o
              [• Invalid memory write: err.c:6:3-10 (cursor: 6:6)], None)]
   
   error: Null pointer dereference in main
-      ┌─ err.c:6:3
-    6 │    *x = 12;
-      │    ^^^^^^^ Invalid memory write
+      --> err.c:6:3
+    6 |    *x = 12;
+      |    ^^^^^^^ Invalid memory write
   Executed 5 statements
   Verification Failure!
   [13]
@@ -142,12 +142,12 @@ Checking that fuel gets exhausted properly
              None)]
   
   error: Failed assertion in main
-      ┌─ while_true.c:6:5
-    6 │      __soteria___assert(0);
-      │      ^^^^^^^^^^^^^^^^^^^^^
-      │      │
-      │      Triggering operation
-      │      1: Called from here
+      --> while_true.c:6:5
+    6 |      __soteria___assert(0);
+      |      ^^^^^^^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      1: Called from here
   Executed 152 statements
   Verification Failure!
   [13]

--- a/soteria-c/test/cram/simple_bi.t/run.t
+++ b/soteria-c/test/cram/simple_bi.t/run.t
@@ -1,7 +1,7 @@
   $ soteria-c gen-summaries load.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for f_560:
+  Summaries for f_562:
     Analysed {
       raw =
       { args = [&(V|1|, V|2|)]; pre = []; pc = [(0x0000000000000000 == V|1|)];
@@ -37,17 +37,6 @@
 NO_COLOR=true is necessary to avoid test output changing in CI. For some reason, Grace doesn't prints a final caret at the end with color, and not without color.
   $ NO_COLOR=true soteria-c gen-summaries manifest.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
-  error: Null pointer dereference in test_np
-      ┌─ manifest.c:51:3
-   51 │    *x = 12;
-      │    ^^^^^^^ Invalid memory write
-  error: Accessing uninitialized memory in test_uninit
-      ┌─ manifest.c:6:10
-    6 │    return *x;
-      │           ^^ Invalid memory load
-      ·  
-   21 │    load(x);
-      │    ------- 1: Called from here
   error: Accessing uninitialized memory in test_np_uninit
       ┌─ manifest.c:6:10
     6 │    return *x;
@@ -62,6 +51,13 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
       ·  
    12 │    load(x);
       │    ------- 1: Called from here
+  error: Accessing uninitialized memory in test_uninit
+      ┌─ manifest.c:6:10
+    6 │    return *x;
+      │           ^^ Invalid memory load
+      ·  
+   21 │    load(x);
+      │    ------- 1: Called from here
   warning: Memory leak in test_leak
       ┌─ manifest.c:26:1
    25 │    
@@ -74,7 +70,11 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
    34 │ │  }
       │ ╰──^ 
    35 │    
-  Summaries for load_563:
+  error: Null pointer dereference in test_np
+      ┌─ manifest.c:51:3
+   51 │    *x = 12;
+      │    ^^^^^^^ Invalid memory write
+  Summaries for load_565:
     Analysed {
       raw =
       { args = [&(V|1|, V|2|)]; pre = []; pc = [(0x0000000000000000 == V|1|)];
@@ -107,30 +107,33 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
         ret = (Ok V|3|) };
       manifest_bugs = []}
   
-  Summaries for test_ok_574:
+  Summaries for test_np_uninit_567:
     Analysed {
-      raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
-      manifest_bugs = []}
-    Analysed {
-      raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000001) };
-      manifest_bugs = []}
-  
-  Summaries for test_np_577:
-    Analysed {
-      raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
-      manifest_bugs = []}
+      raw =
+      { args = []; pre = []; pc = []; post = [];
+        ret =
+        (Error (Accessing uninitialized memory,
+                [• Called from here: manifest.c:12:3-10;
+                 • Invalid memory load: manifest.c:6:10-12 (cursor: 6:10)]))
+        };
+      manifest_bugs =
+      [(Accessing uninitialized memory,
+        [• Called from here: manifest.c:12:3-10;
+         • Invalid memory load: manifest.c:6:10-12 (cursor: 6:10)])]}
     Analysed {
       raw =
       { args = []; pre = []; pc = []; post = [];
         ret =
         (Error (Null pointer dereference,
-                [• Invalid memory write: manifest.c:51:3-10 (cursor: 51:6)]))
+                [• Called from here: manifest.c:12:3-10;
+                 • Invalid memory load: manifest.c:6:10-12 (cursor: 6:10)]))
         };
       manifest_bugs =
       [(Null pointer dereference,
-        [• Invalid memory write: manifest.c:51:3-10 (cursor: 51:6)])]}
+        [• Called from here: manifest.c:12:3-10;
+         • Invalid memory load: manifest.c:6:10-12 (cursor: 6:10)])]}
   
-  Summaries for test_uninit_568:
+  Summaries for test_uninit_570:
     Analysed {
       raw =
       { args = []; pre = []; pc = []; post = [];
@@ -147,33 +150,7 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000001) };
       manifest_bugs = []}
   
-  Summaries for test_np_uninit_565:
-    Analysed {
-      raw =
-      { args = []; pre = []; pc = []; post = [];
-        ret =
-        (Error (Accessing uninitialized memory,
-                [• Called from here: manifest.c:12:3-10;
-                 • Invalid memory load: manifest.c:6:10-12 (cursor: 6:10)]))
-        };
-      manifest_bugs =
-      [(Accessing uninitialized memory,
-        [• Called from here: manifest.c:12:3-10;
-         • Invalid memory load: manifest.c:6:10-12 (cursor: 6:10)])]}
-    Analysed {
-      raw =
-      { args = []; pre = []; pc = []; post = [];
-        ret =
-        (Error (Null pointer dereference,
-                [• Called from here: manifest.c:12:3-10;
-                 • Invalid memory load: manifest.c:6:10-12 (cursor: 6:10)]))
-        };
-      manifest_bugs =
-      [(Null pointer dereference,
-        [• Called from here: manifest.c:12:3-10;
-         • Invalid memory load: manifest.c:6:10-12 (cursor: 6:10)])]}
-  
-  Summaries for test_leak_571:
+  Summaries for test_leak_573:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs =
@@ -184,12 +161,35 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000001) };
       manifest_bugs = []}
   
+  Summaries for test_ok_576:
+    Analysed {
+      raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
+      manifest_bugs = []}
+    Analysed {
+      raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000001) };
+      manifest_bugs = []}
+  
+  Summaries for test_np_579:
+    Analysed {
+      raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
+      manifest_bugs = []}
+    Analysed {
+      raw =
+      { args = []; pre = []; pc = []; post = [];
+        ret =
+        (Error (Null pointer dereference,
+                [• Invalid memory write: manifest.c:51:3-10 (cursor: 51:6)]))
+        };
+      manifest_bugs =
+      [(Null pointer dereference,
+        [• Invalid memory write: manifest.c:51:3-10 (cursor: 51:6)])]}
+  
 The following test case is for regression testing.
 if%sat1 had the wrong semantics and would not correctly backtrack.
   $ soteria-c gen-summaries if_sat_one_ok.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for test_561:
+  Summaries for test_563:
     Analysed {
       raw =
       { args = [V|1|; &(V|2|, V|3|)]; pre = [];
@@ -236,7 +236,7 @@ if%sat1 had the wrong semantics and would not correctly backtrack.
   $ soteria-c gen-summaries array_iter.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for test_561:
+  Summaries for test_563:
     Analysed {
       raw =
       { args = [&(V|1|, V|2|); V|3|]; pre = [];
@@ -363,7 +363,7 @@ if%sat1 had the wrong semantics and would not correctly backtrack.
       ┌─ overflow.c:9:11
     9 │    int c = b + 1;
       │            ^^^^^ Triggering operation
-  Summaries for add_561:
+  Summaries for add_563:
     Analysed {
       raw =
       { args = [V|1|; V|2|]; pre = []; pc = [(V|1| +s_ovf V|2|)]; post = [];
@@ -378,7 +378,7 @@ if%sat1 had the wrong semantics and would not correctly backtrack.
         ret = (Ok (V|1| +ck V|2|)) };
       manifest_bugs = []}
   
-  Summaries for add_ovf_manifest_564:
+  Summaries for add_ovf_manifest_566:
     Analysed {
       raw =
       { args = [V|1|]; pre = []; pc = []; post = [];

--- a/soteria-c/test/cram/simple_bi.t/run.t
+++ b/soteria-c/test/cram/simple_bi.t/run.t
@@ -38,42 +38,42 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
   $ NO_COLOR=true soteria-c gen-summaries manifest.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   error: Accessing uninitialized memory in test_np_uninit
-      ┌─ manifest.c:6:10
-    6 │    return *x;
-      │           ^^ Invalid memory load
-      ·  
-   12 │    load(x);
-      │    ------- 1: Called from here
+      --> manifest.c:6:10
+    6 |    return *x;
+      |           ^^ Invalid memory load
+      .  
+   12 |    load(x);
+      |    ------- 1: Called from here
   error: Null pointer dereference in test_np_uninit
-      ┌─ manifest.c:6:10
-    6 │    return *x;
-      │           ^^ Invalid memory load
-      ·  
-   12 │    load(x);
-      │    ------- 1: Called from here
+      --> manifest.c:6:10
+    6 |    return *x;
+      |           ^^ Invalid memory load
+      .  
+   12 |    load(x);
+      |    ------- 1: Called from here
   error: Accessing uninitialized memory in test_uninit
-      ┌─ manifest.c:6:10
-    6 │    return *x;
-      │           ^^ Invalid memory load
-      ·  
-   21 │    load(x);
-      │    ------- 1: Called from here
+      --> manifest.c:6:10
+    6 |    return *x;
+      |           ^^ Invalid memory load
+      .  
+   21 |    load(x);
+      |    ------- 1: Called from here
   warning: Memory leak in test_leak
-      ┌─ manifest.c:26:1
-   25 │    
-   26 │ ╭  int test_leak()
-   27 │ │  {
-   28 │ │    int *x = (int *)malloc(sizeof(int));
-      │ │                    ------------------- 1: This allocation leaked
-      · │  
-   33 │ │    return 0;
-   34 │ │  }
-      │ ╰──^ 
-   35 │    
+      --> manifest.c:26:1
+   25 |    
+   26 | /  int test_leak()
+   27 | |  {
+   28 | |    int *x = (int *)malloc(sizeof(int));
+      | |                    ------------------- 1: This allocation leaked
+      . |  
+   33 | |    return 0;
+   34 | |  }
+      | \--^ 
+   35 |    
   error: Null pointer dereference in test_np
-      ┌─ manifest.c:51:3
-   51 │    *x = 12;
-      │    ^^^^^^^ Invalid memory write
+      --> manifest.c:51:3
+   51 |    *x = 12;
+      |    ^^^^^^^ Invalid memory write
   Summaries for load_565:
     Analysed {
       raw =
@@ -360,9 +360,9 @@ if%sat1 had the wrong semantics and would not correctly backtrack.
   $ soteria-c gen-summaries overflow.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   error: Integer overflow in add_ovf_manifest
-      ┌─ overflow.c:9:11
-    9 │    int c = b + 1;
-      │            ^^^^^ Triggering operation
+      --> overflow.c:9:11
+    9 |    int c = b + 1;
+      |            ^^^^^ Triggering operation
   Summaries for add_563:
     Analysed {
       raw =

--- a/soteria-c/test/cram/simple_bi.t/run.t
+++ b/soteria-c/test/cram/simple_bi.t/run.t
@@ -1,7 +1,7 @@
   $ soteria-c gen-summaries load.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for f_562:
+  Summaries for f_<id>:
     Analysed {
       raw =
       { args = [&(V|1|, V|2|)]; pre = []; pc = [(0x0000000000000000 == V|1|)];
@@ -74,7 +74,7 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
       --> manifest.c:51:3
    51 |    *x = 12;
       |    ^^^^^^^ Invalid memory write
-  Summaries for load_565:
+  Summaries for load_<id>:
     Analysed {
       raw =
       { args = [&(V|1|, V|2|)]; pre = []; pc = [(0x0000000000000000 == V|1|)];
@@ -107,7 +107,7 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
         ret = (Ok V|3|) };
       manifest_bugs = []}
   
-  Summaries for test_np_uninit_567:
+  Summaries for test_np_uninit_<id>:
     Analysed {
       raw =
       { args = []; pre = []; pc = []; post = [];
@@ -133,7 +133,7 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
         [• Called from here: manifest.c:12:3-10;
          • Invalid memory load: manifest.c:6:10-12 (cursor: 6:10)])]}
   
-  Summaries for test_uninit_570:
+  Summaries for test_uninit_<id>:
     Analysed {
       raw =
       { args = []; pre = []; pc = []; post = [];
@@ -150,7 +150,7 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000001) };
       manifest_bugs = []}
   
-  Summaries for test_leak_573:
+  Summaries for test_leak_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs =
@@ -161,7 +161,7 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000001) };
       manifest_bugs = []}
   
-  Summaries for test_ok_576:
+  Summaries for test_ok_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
@@ -169,7 +169,7 @@ NO_COLOR=true is necessary to avoid test output changing in CI. For some reason,
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000001) };
       manifest_bugs = []}
   
-  Summaries for test_np_579:
+  Summaries for test_np_<id>:
     Analysed {
       raw = { args = []; pre = []; pc = []; post = []; ret = (Ok 0x00000000) };
       manifest_bugs = []}
@@ -189,7 +189,7 @@ if%sat1 had the wrong semantics and would not correctly backtrack.
   $ soteria-c gen-summaries if_sat_one_ok.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for test_563:
+  Summaries for test_<id>:
     Analysed {
       raw =
       { args = [V|1|; &(V|2|, V|3|)]; pre = [];
@@ -236,7 +236,7 @@ if%sat1 had the wrong semantics and would not correctly backtrack.
   $ soteria-c gen-summaries array_iter.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --dump-summaries "out.summaries" ; cat out.summaries
   
   No bugs found
-  Summaries for test_563:
+  Summaries for test_<id>:
     Analysed {
       raw =
       { args = [&(V|1|, V|2|); V|3|]; pre = [];
@@ -363,7 +363,7 @@ if%sat1 had the wrong semantics and would not correctly backtrack.
       --> overflow.c:9:11
     9 |    int c = b + 1;
       |            ^^^^^ Triggering operation
-  Summaries for add_563:
+  Summaries for add_<id>:
     Analysed {
       raw =
       { args = [V|1|; V|2|]; pre = []; pc = [(V|1| +s_ovf V|2|)]; post = [];
@@ -378,7 +378,7 @@ if%sat1 had the wrong semantics and would not correctly backtrack.
         ret = (Ok (V|1| +ck V|2|)) };
       manifest_bugs = []}
   
-  Summaries for add_ovf_manifest_566:
+  Summaries for add_ovf_manifest_<id>:
     Analysed {
       raw =
       { args = [V|1|]; pre = []; pc = []; post = [];

--- a/soteria-c/test/cram/testcomp_api.t/run.t
+++ b/soteria-c/test/cram/testcomp_api.t/run.t
@@ -1,7 +1,7 @@
 Warning and unspported with __VERIFIER enabled 
   $ soteria-c exec test.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
   warning: Test-Comp support is not enabled, but detected use of the __VERIFIER API. Soteria will consider the function as missing a body.
-  error: Analysis gave up: Unsupported: Cannot call external function: __VERIFIER_nondet_int_561 in main
+  error: Analysis gave up: Unsupported: Cannot call external function: __VERIFIER_nondet_int_<id> in main
   Executed 2 statements
   Verification Failure! (Unsupported features)
   [2]

--- a/soteria-c/test/cram/testcomp_api.t/run.t
+++ b/soteria-c/test/cram/testcomp_api.t/run.t
@@ -1,7 +1,7 @@
 Warning and unspported with __VERIFIER enabled 
   $ soteria-c exec test.c --no-ignore-parse-failures --no-ignore-duplicate-symbols
   warning: Test-Comp support is not enabled, but detected use of the __VERIFIER API. Soteria will consider the function as missing a body.
-  error: Analysis gave up: Unsupported: Cannot call external function: __VERIFIER_nondet_int_559 in main
+  error: Analysis gave up: Unsupported: Cannot call external function: __VERIFIER_nondet_int_561 in main
   Executed 2 statements
   Verification Failure! (Unsupported features)
   [2]

--- a/soteria-c/test/cram/testcomp_api.t/run.t
+++ b/soteria-c/test/cram/testcomp_api.t/run.t
@@ -10,12 +10,12 @@ Behaves as expected with the API declared.
   $ soteria-c exec test.c --no-ignore-parse-failures --no-ignore-duplicate-symbols --testcomp-compat
   warning: Test-Comp compatibility mode enabled. Note that Soteria-C is *not* optimised for this test suite, and does not aim to be performant on it.
   error: Failed assertion in main
-      ┌─ test.c:7:3
-    7 │    __assert_fail();
-      │    ^^^^^^^^^^^^^^^
-      │    │
-      │    Triggering operation
-      │    1: Called from here
+      --> test.c:7:3
+    7 |    __assert_fail();
+      |    ^^^^^^^^^^^^^^^
+      |    |
+      |    Triggering operation
+      |    1: Called from here
   Executed 3 statements
   Verification Failure!
   [13]

--- a/soteria-rust.opam
+++ b/soteria-rust.opam
@@ -35,6 +35,7 @@ depends: [
   "dune" {>= "3.14" & build & >= "3.14.0"}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "ocaml-lsp-server" {with-dev-setup}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/soteria-rust/lib/frontend_runtime.ml
+++ b/soteria-rust/lib/frontend_runtime.ml
@@ -244,7 +244,9 @@ module Cmd = struct
           ((Config.get ()).charon_path, charon @ entries)
     in
     let target_flag =
-      Option.fold ~none:[] ~some:(fun t -> [ "--target"; t ]) (Config.get ()).target
+      Option.fold ~none:[]
+        ~some:(fun t -> [ "--target"; t ])
+        (Config.get ()).target
     in
     match mode with
     | Rustc ->

--- a/soteria-rust/lib/frontend_runtime.ml
+++ b/soteria-rust/lib/frontend_runtime.ml
@@ -243,6 +243,9 @@ module Cmd = struct
           let entries = List.concat_map entry_as_flag (attribs @ non_attribs) in
           ((Config.get ()).charon_path, charon @ entries)
     in
+    let target_flag =
+      Option.fold ~none:[] ~some:(fun t -> [ "--target"; t ]) (Config.get ()).target
+    in
     match mode with
     | Rustc ->
         (* If these arguments are passed to the command line, we need to quote
@@ -257,7 +260,7 @@ module Cmd = struct
               else arg)
             rustc
         in
-        (cmd, ("rustc" :: args) @ [ "--" ] @ rustc, [])
+        (cmd, ("rustc" :: args) @ [ "--" ] @ rustc @ target_flag, [])
     | Cargo ->
         let cargo =
           match (Config.get ()).test with
@@ -265,7 +268,7 @@ module Cmd = struct
           | Some test -> [ "--test"; test ]
           | None -> []
         in
-        let cargo = cargo @ cargo_flags () in
+        let cargo = cargo @ cargo_flags () @ target_flag in
         let rustc = flags_for_cargo rustc in
         let env = rustc_as_env () @ flags_as_rustc_env rustc in
         (cmd, ("cargo" :: args) @ [ "--" ] @ cargo, env)

--- a/soteria-rust/test/cram/cargo-test.t/run.t
+++ b/soteria-rust/test/cram/cargo-test.t/run.t
@@ -8,33 +8,33 @@ Test running Soteria Rust on a crate with tests
   => Running tests::test_nok...
   error: tests::test_nok: found issues in <time>, errors in 1 branch (out of 1)
   error: Failed assertion in tests::test_nok
-      ┌─ $RUSTLIB/library/core/src/panicking.rs:394:5
-  394 │      assert_failed_inner(kind, &left, &right, args)
-      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │      │
-      │      Triggering operation
-      │      3: Call trace
-      ┌─ tests/tests.rs:10:5
-    9 │  fn test_nok() {
-      │  ------------- 1: Entry point
-   10 │      assert_eq!(get_answer(), 67);
-      │      ---------------------------- 2: Call trace
+      --> $RUSTLIB/library/core/src/panicking.rs:394:5
+  394 |      assert_failed_inner(kind, &left, &right, args)
+      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      3: Call trace
+      --> tests/tests.rs:10:5
+    9 |  fn test_nok() {
+      |  ------------- 1: Entry point
+   10 |      assert_eq!(get_answer(), 67);
+      |      ---------------------------- 2: Call trace
   PC 1: empty
   
   => Running tests::test_nok_expected...
   error: tests::test_nok_expected: found issues in <time>, errors in 1 branch (out of 1)
   error: Failed assertion in tests::test_nok_expected
-      ┌─ $RUSTLIB/library/core/src/panicking.rs:394:5
-  394 │      assert_failed_inner(kind, &left, &right, args)
-      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │      │
-      │      Triggering operation
-      │      3: Call trace
-      ┌─ tests/tests.rs:17:5
-   16 │  fn test_nok_expected() {
-      │  ---------------------- 1: Entry point
-   17 │      assert_eq!(get_answer(), 67);
-      │      ---------------------------- 2: Call trace
+      --> $RUSTLIB/library/core/src/panicking.rs:394:5
+  394 |      assert_failed_inner(kind, &left, &right, args)
+      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      3: Call trace
+      --> tests/tests.rs:17:5
+   16 |  fn test_nok_expected() {
+      |  ---------------------- 1: Entry point
+   17 |      assert_eq!(get_answer(), 67);
+      |      ---------------------------- 2: Call trace
   PC 1: empty
   
   [1]
@@ -47,18 +47,18 @@ Test running Soteria Rust on a crate with tests
   => Running soteria::tests::test_nok...
   error: soteria::tests::test_nok: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion in soteria::tests::test_nok
-      ┌─ $RUSTLIB/library/core/src/panicking.rs:394:5
-  394 │      assert_failed_inner(kind, &left, &right, args)
-      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │      │
-      │      Triggering operation
-      │      3: Call trace
-      ┌─ tests/soteria.rs:15:9
-   13 │      fn test_nok() {
-      │      ------------- 1: Entry point
-   14 │          let x: i32 = soteria::nondet_bytes();
-   15 │          assert_eq!(x, get_answer());
-      │          --------------------------- 2: Call trace
+      --> $RUSTLIB/library/core/src/panicking.rs:394:5
+  394 |      assert_failed_inner(kind, &left, &right, args)
+      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      3: Call trace
+      --> tests/soteria.rs:15:9
+   13 |      fn test_nok() {
+      |      ------------- 1: Entry point
+   14 |          let x: i32 = soteria::nondet_bytes();
+   15 |          assert_eq!(x, get_answer());
+      |          --------------------------- 2: Call trace
   PC 1: (V|1| != 0x0000002a)
   
   => Running soteria::tests::test_nok_ok...

--- a/soteria-rust/test/cram/cli.t/run.t
+++ b/soteria-rust/test/cram/cli.t/run.t
@@ -88,7 +88,8 @@
   LOGS OPTIONS
          --hide-unstable, --diffable (absent HIDE_UNSTABLE env)
              Do not display unstable values like durations (e.g. for diffing
-             purposes).
+             purposes). Also overrides the profile to disable colors and utf8
+             and ensure that it is reproducible accross runs.
   
          --html
              HTML logging, clashes with --log-kind
@@ -353,7 +354,8 @@
   LOGS OPTIONS
          --hide-unstable, --diffable (absent HIDE_UNSTABLE env)
              Do not display unstable values like durations (e.g. for diffing
-             purposes).
+             purposes). Also overrides the profile to disable colors and utf8
+             and ensure that it is reproducible accross runs.
   
          --html
              HTML logging, clashes with --log-kind

--- a/soteria-rust/test/cram/kani.t/run.t
+++ b/soteria-rust/test/cram/kani.t/run.t
@@ -36,60 +36,60 @@ Test kani::assert
   => Running assert::assert_false...
   error: assert::assert_false: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion: Expected true! in assert::assert_false
-      ┌─ $TESTCASE_ROOT/assert.rs:4:5
-    2 │  fn assert_false() {
-      │  ----------------- 1: Entry point
-    3 │      let b: bool = kani::any();
-    4 │      kani::assert(b, "Expected true!");
-      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │      │
-      │      Triggering operation
-      │      2: Call trace
+      --> $TESTCASE_ROOT/assert.rs:4:5
+    2 |  fn assert_false() {
+      |  ----------------- 1: Entry point
+    3 |      let b: bool = kani::any();
+    4 |      kani::assert(b, "Expected true!");
+      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      2: Call trace
   PC 1: (V|1| == 0x00) /\ (V|1| == 0x00)
   
   => Running assert::fancy_assert_false...
   error: assert::fancy_assert_false: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion: 👻 unicode is 𝒮𝒞𝒜ℛ𝒴 in assert::fancy_assert_false
-      ┌─ $TESTCASE_ROOT/assert.rs:10:5
-    8 │  fn fancy_assert_false() {
-      │  ----------------------- 1: Entry point
-    9 │      let b: bool = kani::any();
-   10 │      kani::assert(b, "👻 unicode is 𝒮𝒞𝒜ℛ𝒴");
-      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │      │
-      │      Triggering operation
-      │      2: Call trace
+      --> $TESTCASE_ROOT/assert.rs:10:5
+    8 |  fn fancy_assert_false() {
+      |  ----------------------- 1: Entry point
+    9 |      let b: bool = kani::any();
+   10 |      kani::assert(b, "👻 unicode is 𝒮𝒞𝒜ℛ𝒴");
+      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      2: Call trace
   PC 1: (V|1| == 0x00) /\ (V|1| == 0x00)
   
   => Running assert::override_assert_macro...
   error: assert::override_assert_macro: found issues in <time>, errors in 1 branch (out of 2)
   error: Panic: I used "assert!" in assert::override_assert_macro
-      ┌─ $TESTCASE_ROOT/assert.rs:16:5
-   14 │  fn override_assert_macro() {
-      │  -------------------------- 1: Entry point
-   15 │      let b: bool = kani::any();
-   16 │      assert!(b, "I used \"assert!\"");
-      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │      │
-      │      Triggering operation
-      │      2: Call trace
+      --> $TESTCASE_ROOT/assert.rs:16:5
+   14 |  fn override_assert_macro() {
+      |  -------------------------- 1: Entry point
+   15 |      let b: bool = kani::any();
+   16 |      assert!(b, "I used \"assert!\"");
+      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      2: Call trace
   PC 1: (V|1| == 0x00) /\ (V|1| == 0x00)
   
   => Running assert::override_asserteq_macro...
   error: assert::override_asserteq_macro: found issues in <time>, errors in 1 branch (out of 2)
   error: Failed assertion in assert::override_asserteq_macro
-      ┌─ $RUSTLIB/library/core/src/panicking.rs:394:5
-  394 │      assert_failed_inner(kind, &left, &right, args)
-      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │      │
-      │      Triggering operation
-      │      3: Call trace
-      ┌─ $TESTCASE_ROOT/assert.rs:23:5
-   20 │  fn override_asserteq_macro() {
-      │  ---------------------------- 1: Entry point
-      ·  
-   23 │      assert_eq!(a, b, "I used \"assert_eq!\"");
-      │      ----------------------------------------- 2: Call trace
+      --> $RUSTLIB/library/core/src/panicking.rs:394:5
+  394 |      assert_failed_inner(kind, &left, &right, args)
+      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      3: Call trace
+      --> $TESTCASE_ROOT/assert.rs:23:5
+   20 |  fn override_asserteq_macro() {
+      |  ---------------------------- 1: Entry point
+      .  
+   23 |      assert_eq!(a, b, "I used \"assert_eq!\"");
+      |      ----------------------------------------- 2: Call trace
   PC 1: (V|1| != V|2|)
   
   [1]
@@ -264,12 +264,12 @@ Test our simple Kani demo works
   => Running demo::saturating_add_overflow...
   error: demo::saturating_add_overflow: found issues in <time>, errors in 1 branch (out of 3)
   error: Overflow in demo::saturating_add_overflow
-      ┌─ $TESTCASE_ROOT/demo.rs:11:8
-    8 │  fn saturating_add_overflow() -> u32 {
-      │  ----------------------------------- 1: Entry point
-      ·  
-   11 │      if a + b < u32::MAX {
-      │         ^^^^^ Triggering operation
+      --> $TESTCASE_ROOT/demo.rs:11:8
+    8 |  fn saturating_add_overflow() -> u32 {
+      |  ----------------------------------- 1: Entry point
+      .  
+   11 |      if a + b < u32::MAX {
+      |         ^^^^^ Triggering operation
   PC 1: (V|1| +u_ovf V|2|)
   
   => Running demo::saturating_add...
@@ -280,41 +280,41 @@ Test our simple Kani demo works
   => Running demo::memory_leak...
   error: demo::memory_leak: found issues in <time>, errors in 1 branch (out of 1)
   warning: Memory leak in demo::memory_leak
-      ┌─ $RUSTLIB/library/alloc/src/alloc.rs:95:9
-   95 │            __rust_alloc(layout.size(), layout.align())
-      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │            │
-      │            Triggering operation
-      │            5: Allocation
-      ·    
-  311 │        const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
-  312 │ ╭          core::intrinsics::const_eval_select(
-  313 │ │              (layout, zeroed),
-  314 │ │              Global::alloc_impl_const,
-  315 │ │              Global::alloc_impl_runtime,
-  316 │ │          )
-      │ ╰──────────' 4: Call trace
-  317 │        }
-      ┌─ $RUSTLIB/library/alloc/src/boxed.rs:265:16
-  265 │            return box_new(x);
-      │                   ---------- 3: Call trace
-      ┌─ $TESTCASE_ROOT/demo.rs:33:21
-   32 │    fn memory_leak() {
-      │    ---------------- 1: Leaking function
-   33 │        let allocated = Box::new(11);
-      │                        ------------ 2: Call trace
+      --> $RUSTLIB/library/alloc/src/alloc.rs:95:9
+   95 |            __rust_alloc(layout.size(), layout.align())
+      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |            |
+      |            Triggering operation
+      |            5: Allocation
+      .    
+  311 |        const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
+  312 | /          core::intrinsics::const_eval_select(
+  313 | |              (layout, zeroed),
+  314 | |              Global::alloc_impl_const,
+  315 | |              Global::alloc_impl_runtime,
+  316 | |          )
+      | \----------' 4: Call trace
+  317 |        }
+      --> $RUSTLIB/library/alloc/src/boxed.rs:265:16
+  265 |            return box_new(x);
+      |                   ---------- 3: Call trace
+      --> $TESTCASE_ROOT/demo.rs:33:21
+   32 |    fn memory_leak() {
+      |    ---------------- 1: Leaking function
+   33 |        let allocated = Box::new(11);
+      |                        ------------ 2: Call trace
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (extract[0-1](V|1|) == 0b00)
   
   => Running demo::uninit_access...
   error: demo::uninit_access: found issues in <time>, errors in 1 branch (out of 2)
   bug: Uninitialized memory access in demo::uninit_access
-      ┌─ $TESTCASE_ROOT/demo.rs:63:26
-   58 │  fn uninit_access() {
-      │  ------------------ 1: Entry point
-      ·  
-   63 │          let value: u32 = *addr_value;
-      │                           ^^^^^^^^^^^ Memory load
+      --> $TESTCASE_ROOT/demo.rs:63:26
+   58 |  fn uninit_access() {
+      |  ------------------ 1: Entry point
+      .  
+   63 |          let value: u32 = *addr_value;
+      |                           ^^^^^^^^^^^ Memory load
   PC 1: (0x00 == V|1|) /\ (0x00 == V|1|)
   
   [1]

--- a/soteria-rust/test/cram/poly.t/run.t
+++ b/soteria-rust/test/cram/poly.t/run.t
@@ -38,14 +38,14 @@ Try creating a generic vec
   => Running vec::with_capacity_wrong...
   error: vec::with_capacity_wrong: found issues in <time>, errors in 1 branch (out of 2)
   error: Panic: core::panicking::panic in vec::with_capacity_wrong
-      ┌─ $TESTCASE_ROOT/vec.rs:6:4
-    3 │    #[soteria::test]
-    4 │ ╭  fn with_capacity_wrong<T>() {
-    5 │ │      let my_vec: Vec<T> = Vec::with_capacity(10);
-    6 │ │      assert!(my_vec.capacity() == 10);
-      │ │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Triggering operation
-      │ ╰───────────────────────────────────────' 1: Entry point
-    7 │    }
+      --> $TESTCASE_ROOT/vec.rs:6:4
+    3 |    #[soteria::test]
+    4 | /  fn with_capacity_wrong<T>() {
+    5 | |      let my_vec: Vec<T> = Vec::with_capacity(10);
+    6 | |      assert!(my_vec.capacity() == 10);
+      | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Triggering operation
+      | \---------------------------------------' 1: Entry point
+    7 |    }
   PC 1: (0x0000000000000000 == V|1|) /\ (0x0000000000000000 == V|1|)
   
   => Running vec::with_capacity...

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -238,7 +238,7 @@ Test exposing function pointers
         (extract[0-3](V|1|) == 0x0)
   
 Test thread local statics; the two warnings due to opaque functions are to be expected, as we do not run the test suite with a sysroot.
-  $ soteria-rust exec thread_local.rs
+  $ soteria-rust exec thread_local.rs --target aarch64-apple-darwin
   Compiling... done in <time>
   => Running thread_local::pub_static_cell...
   note: thread_local::pub_static_cell: done in <time>, ran 1 branch
@@ -250,6 +250,22 @@ Test thread local statics; the two warnings due to opaque functions are to be ex
   
   => Running thread_local::pub_static_from_const_expr...
   warning: thread_local::pub_static_from_const_expr (<time>): unsupported feature, Can't execute function std::sys::thread_local::destructors::list::register: GAst.Missing
+  
+  [2]
+
+This test must be run separtely on linux and macos as it yields different error messages.
+  $ soteria-rust exec thread_local.rs --target x86_64-unknown-linux-gnu
+  Compiling... done in <time>
+  => Running thread_local::pub_static_cell...
+  note: thread_local::pub_static_cell: done in <time>, ran 1 branch
+  PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
+        (extract[0-1](V|1|) == 0b00)
+  
+  => Running thread_local::static_ref_cell...
+  warning: thread_local::static_ref_cell (<time>): unsupported feature, Can't execute function std::sys::thread_local::destructors::linux_like::register: GAst.Missing
+  
+  => Running thread_local::pub_static_from_const_expr...
+  warning: thread_local::pub_static_from_const_expr (<time>): unsupported feature, Can't execute function std::sys::thread_local::destructors::linux_like::register: GAst.Missing
   
   [2]
 

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -4,29 +4,29 @@ Test memory leaks
   => Running leak::main...
   error: leak::main: found issues in <time>, errors in 1 branch (out of 1)
   warning: Memory leak in leak::main
-      ┌─ $RUSTLIB/library/alloc/src/alloc.rs:95:9
-   95 │            __rust_alloc(layout.size(), layout.align())
-      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      │            │
-      │            Triggering operation
-      │            5: Allocation
-      ·    
-  311 │        const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
-  312 │ ╭          core::intrinsics::const_eval_select(
-  313 │ │              (layout, zeroed),
-  314 │ │              Global::alloc_impl_const,
-  315 │ │              Global::alloc_impl_runtime,
-  316 │ │          )
-      │ ╰──────────' 4: Call trace
-  317 │        }
-      ┌─ $RUSTLIB/library/alloc/src/boxed.rs:265:16
-  265 │            return box_new(x);
-      │                   ---------- 3: Call trace
-      ┌─ $TESTCASE_ROOT/leak.rs:2:22
-    1 │    fn main() {
-      │    --------- 1: Leaking function
-    2 │        std::mem::forget(Box::new(11));
-      │                         ------------ 2: Call trace
+      --> $RUSTLIB/library/alloc/src/alloc.rs:95:9
+   95 |            __rust_alloc(layout.size(), layout.align())
+      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |            |
+      |            Triggering operation
+      |            5: Allocation
+      .    
+  311 |        const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
+  312 | /          core::intrinsics::const_eval_select(
+  313 | |              (layout, zeroed),
+  314 | |              Global::alloc_impl_const,
+  315 | |              Global::alloc_impl_runtime,
+  316 | |          )
+      | \----------' 4: Call trace
+  317 |        }
+      --> $RUSTLIB/library/alloc/src/boxed.rs:265:16
+  265 |            return box_new(x);
+      |                   ---------- 3: Call trace
+      --> $TESTCASE_ROOT/leak.rs:2:22
+    1 |    fn main() {
+      |    --------- 1: Leaking function
+    2 |        std::mem::forget(Box::new(11));
+      |                         ------------ 2: Call trace
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (extract[0-1](V|1|) == 0b00)
   
@@ -55,20 +55,20 @@ Splitting and merging, via a union
   
   => Running split_merges::uninit_gap...
   warning: Invalid reference: Uninitialized memory access
-      ┌─ $TESTCASE_ROOT/split_merges.rs:64:9
-   52 │  fn uninit_gap() {
-      │  --------------- 1: Entry point
-      ·  
-   64 │          assert_eq!(x.as_u32, 0x1234_5678);
-      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Triggering operation
+      --> $TESTCASE_ROOT/split_merges.rs:64:9
+   52 |  fn uninit_gap() {
+      |  --------------- 1: Entry point
+      .  
+   64 |          assert_eq!(x.as_u32, 0x1234_5678);
+      |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Triggering operation
   error: split_merges::uninit_gap: found issues in <time>, errors in 1 branch (out of 1)
   bug: Uninitialized memory access in split_merges::uninit_gap
-      ┌─ $TESTCASE_ROOT/split_merges.rs:64:9
-   52 │  fn uninit_gap() {
-      │  --------------- 1: Entry point
-      ·  
-   64 │          assert_eq!(x.as_u32, 0x1234_5678);
-      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Memory load
+      --> $TESTCASE_ROOT/split_merges.rs:64:9
+   52 |  fn uninit_gap() {
+      |  --------------- 1: Entry point
+      .  
+   64 |          assert_eq!(x.as_u32, 0x1234_5678);
+      |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Memory load
   PC 1: empty
   
   [1]
@@ -102,23 +102,23 @@ Test function calls on function pointers
   => Running fn_ptr::fn_ptr_read...
   error: fn_ptr::fn_ptr_read: found issues in <time>, errors in 1 branch (out of 1)
   bug: Accessed function pointer's pointee in fn_ptr::fn_ptr_read
-      ┌─ $TESTCASE_ROOT/fn_ptr.rs:25:18
-   21 │  fn fn_ptr_read() {
-      │  ---------------- 1: Entry point
-      ·  
-   25 │          let _b = *ptr;
-      │                   ^^^^ Memory load
+      --> $TESTCASE_ROOT/fn_ptr.rs:25:18
+   21 |  fn fn_ptr_read() {
+      |  ---------------- 1: Entry point
+      .  
+   25 |          let _b = *ptr;
+      |                   ^^^^ Memory load
   PC 1: empty
   
   => Running fn_ptr::fn_ptr_write...
   error: fn_ptr::fn_ptr_write: found issues in <time>, errors in 1 branch (out of 1)
   bug: Accessed function pointer's pointee in fn_ptr::fn_ptr_write
-      ┌─ $TESTCASE_ROOT/fn_ptr.rs:34:9
-   30 │  fn fn_ptr_write() {
-      │  ----------------- 1: Entry point
-      ·  
-   34 │          *ptr = 0;
-      │          ^^^^^^^^ Memory store
+      --> $TESTCASE_ROOT/fn_ptr.rs:34:9
+   30 |  fn fn_ptr_write() {
+      |  ----------------- 1: Entry point
+      .  
+   34 |          *ptr = 0;
+      |          ^^^^^^^^ Memory store
   PC 1: empty
   
   [1]
@@ -129,15 +129,15 @@ Check strict provenance disables int to ptr casts
   => Running provenance::with_exposed...
   error: provenance::with_exposed: found issues in <time>, errors in 1 branch (out of 1)
   bug: Attempted to cast an integer to an pointer with strict provenance in provenance::with_exposed
-      ┌─ $RUSTLIB/library/core/src/ptr/mod.rs:988:5
-  988 │      addr as *const T
-      │      ^^^^^^^^^^^^^^^^ Casting integer to pointer
-      ┌─ $TESTCASE_ROOT/provenance.rs:6:18
-    2 │  fn with_exposed() {
-      │  ----------------- 1: Entry point
-      ·  
-    6 │      let p_back = std::ptr::with_exposed_provenance::<u8>(p_int) as *mut u8;
-      │                   ---------------------------------------------- 2: Call trace
+      --> $RUSTLIB/library/core/src/ptr/mod.rs:988:5
+  988 |      addr as *const T
+      |      ^^^^^^^^^^^^^^^^ Casting integer to pointer
+      --> $TESTCASE_ROOT/provenance.rs:6:18
+    2 |  fn with_exposed() {
+      |  ----------------- 1: Entry point
+      .  
+    6 |      let p_back = std::ptr::with_exposed_provenance::<u8>(p_int) as *mut u8;
+      |                   ---------------------------------------------- 2: Call trace
   PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd)
   
   [1]
@@ -156,23 +156,23 @@ Check corner cases with permissive provenance, around transmutes
   => Running provenance_transmute::addr_doesnt_expose...
   error: provenance_transmute::addr_doesnt_expose: found issues in <time>, errors in 1 branch (out of 1)
   bug: Dangling pointer in provenance_transmute::addr_doesnt_expose
-      ┌─ $TESTCASE_ROOT/provenance_transmute.rs:9:9
-    2 │  fn addr_doesnt_expose() {
-      │  ----------------------- 1: Entry point
-      ·  
-    9 │          *p_back = 1;
-      │          ^^^^^^^^^^^ Memory store
+      --> $TESTCASE_ROOT/provenance_transmute.rs:9:9
+    2 |  fn addr_doesnt_expose() {
+      |  ----------------------- 1: Entry point
+      .  
+    9 |          *p_back = 1;
+      |          ^^^^^^^^^^^ Memory store
   PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd)
   
   => Running provenance_transmute::transmute_doesnt_restore_provenance...
   error: provenance_transmute::transmute_doesnt_restore_provenance: found issues in <time>, errors in 1 branch (out of 1)
   bug: Dangling pointer in provenance_transmute::transmute_doesnt_restore_provenance
-      ┌─ $TESTCASE_ROOT/provenance_transmute.rs:22:9
-   15 │  fn transmute_doesnt_restore_provenance() {
-      │  ---------------------------------------- 1: Entry point
-      ·  
-   22 │          *p_back = 1;
-      │          ^^^^^^^^^^^ Memory store
+      --> $TESTCASE_ROOT/provenance_transmute.rs:22:9
+   15 |  fn transmute_doesnt_restore_provenance() {
+      |  ---------------------------------------- 1: Entry point
+      .  
+   22 |          *p_back = 1;
+      |          ^^^^^^^^^^^ Memory store
   PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd)
   
   [1]
@@ -208,23 +208,23 @@ Test null and dangling pointers
   => Running dangling_ptrs::null_ptr_not_zst...
   error: dangling_ptrs::null_ptr_not_zst: found issues in <time>, errors in 1 branch (out of 1)
   error: Null dereference in dangling_ptrs::null_ptr_not_zst
-      ┌─ $TESTCASE_ROOT/dangling_ptrs.rs:11:30
-    9 │  fn null_ptr_not_zst() {
-      │  --------------------- 1: Entry point
-   10 │      let ptr: *const u32 = std::ptr::null();
-   11 │      let _val: u32 = unsafe { *ptr };
-      │                               ^^^^ Memory load
+      --> $TESTCASE_ROOT/dangling_ptrs.rs:11:30
+    9 |  fn null_ptr_not_zst() {
+      |  --------------------- 1: Entry point
+   10 |      let ptr: *const u32 = std::ptr::null();
+   11 |      let _val: u32 = unsafe { *ptr };
+      |                               ^^^^ Memory load
   PC 1: empty
   
   => Running dangling_ptrs::dangling_ptr_not_zst...
   error: dangling_ptrs::dangling_ptr_not_zst: found issues in <time>, errors in 1 branch (out of 1)
   bug: Dangling pointer in dangling_ptrs::dangling_ptr_not_zst
-      ┌─ $TESTCASE_ROOT/dangling_ptrs.rs:17:29
-   15 │  fn dangling_ptr_not_zst() {
-      │  ------------------------- 1: Entry point
-   16 │      let ptr: *const u8 = 0xdeadbeef as *const u8;
-   17 │      let _val: u8 = unsafe { *ptr };
-      │                              ^^^^ Memory load
+      --> $TESTCASE_ROOT/dangling_ptrs.rs:17:29
+   15 |  fn dangling_ptr_not_zst() {
+      |  ------------------------- 1: Entry point
+   16 |      let ptr: *const u8 = 0xdeadbeef as *const u8;
+   17 |      let _val: u8 = unsafe { *ptr };
+      |                              ^^^^ Memory load
   PC 1: empty
   
   [1]
@@ -266,15 +266,15 @@ Test cloning ZSTs works; in particular, this generates a function with an empty 
   => Running fail_fast::main...
   error: fail_fast::main: found an issue in <time> after exploring 1 branch -- stopped immediately (fail-fast)
   error: Panic: ok in fail_fast::main
-      ┌─ $TESTCASE_ROOT/fail_fast.rs:4:9
-    1 │  fn main() {
-      │  --------- 1: Entry point
-      ·  
-    4 │          panic!("ok");
-      │          ^^^^^^^^^^^^
-      │          │
-      │          Triggering operation
-      │          2: Call trace
+      --> $TESTCASE_ROOT/fail_fast.rs:4:9
+    1 |  fn main() {
+      |  --------- 1: Entry point
+      .  
+    4 |          panic!("ok");
+      |          ^^^^^^^^^^^^
+      |          |
+      |          Triggering operation
+      |          2: Call trace
   PC 1: (V|1| == 0x01) /\ (V|1| == 0x01)
   
   [1]
@@ -290,24 +290,24 @@ Test recursive validity check for references; disabled
   => Running ref_validity::test_dangling_ref...
   error: ref_validity::test_dangling_ref: found issues in <time>, errors in 1 branch (out of 1)
   bug: Dangling pointer in ref_validity::test_dangling_ref
-      ┌─ $TESTCASE_ROOT/ref_validity.rs:17:38
-   14 │  fn test_dangling_ref() {
-      │  ---------------------- 1: Entry point
-      ·  
-   17 │      let as_ref: &[u32; 2] = unsafe { &*as_ptr };
-      │                                       ^^^^^^^^ Dangling check
+      --> $TESTCASE_ROOT/ref_validity.rs:17:38
+   14 |  fn test_dangling_ref() {
+      |  ---------------------- 1: Entry point
+      .  
+   17 |      let as_ref: &[u32; 2] = unsafe { &*as_ptr };
+      |                                       ^^^^^^^^ Dangling check
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (extract[0-1](V|1|) == 0b00)
   
   => Running ref_validity::test_unaligned_ref...
   error: ref_validity::test_unaligned_ref: found issues in <time>, errors in 1 branch (out of 1)
   bug: Misaligned pointer; expected 0x0000000000000008, received 0x0000000000000004 with offset 0x0000000000000000 in ref_validity::test_unaligned_ref
-      ┌─ $TESTCASE_ROOT/ref_validity.rs:25:33
-   22 │  fn test_unaligned_ref() {
-      │  ----------------------- 1: Entry point
-      ·  
-   25 │      let as_ref: &u64 = unsafe { &*as_ptr };
-      │                                  ^^^^^^^^ Requires well-aligned pointer
+      --> $TESTCASE_ROOT/ref_validity.rs:25:33
+   22 |  fn test_unaligned_ref() {
+      |  ----------------------- 1: Entry point
+      .  
+   25 |      let as_ref: &u64 = unsafe { &*as_ptr };
+      |                                  ^^^^^^^^ Requires well-aligned pointer
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffff6) /\
         (extract[0-1](V|1|) == 0b00)
   
@@ -319,36 +319,36 @@ Test recursive validity check for references; enabled
   => Running ref_validity::test_uninit_ref...
   error: ref_validity::test_uninit_ref: found issues in <time>, errors in 1 branch (out of 1)
   bug: Invalid reference: Uninitialized memory access in ref_validity::test_uninit_ref
-      ┌─ $TESTCASE_ROOT/ref_validity.rs:7:33
-    4 │  fn test_uninit_ref() {
-      │  -------------------- 1: Entry point
-      ·  
-    7 │      let as_ref: &u32 = unsafe { &*as_ptr };
-      │                                  ^^^^^^^^ Fake read
+      --> $TESTCASE_ROOT/ref_validity.rs:7:33
+    4 |  fn test_uninit_ref() {
+      |  -------------------- 1: Entry point
+      .  
+    7 |      let as_ref: &u32 = unsafe { &*as_ptr };
+      |                                  ^^^^^^^^ Fake read
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (extract[0-1](V|1|) == 0b00)
   
   => Running ref_validity::test_dangling_ref...
   error: ref_validity::test_dangling_ref: found issues in <time>, errors in 1 branch (out of 1)
   bug: Dangling pointer in ref_validity::test_dangling_ref
-      ┌─ $TESTCASE_ROOT/ref_validity.rs:17:38
-   14 │  fn test_dangling_ref() {
-      │  ---------------------- 1: Entry point
-      ·  
-   17 │      let as_ref: &[u32; 2] = unsafe { &*as_ptr };
-      │                                       ^^^^^^^^ Dangling check
+      --> $TESTCASE_ROOT/ref_validity.rs:17:38
+   14 |  fn test_dangling_ref() {
+      |  ---------------------- 1: Entry point
+      .  
+   17 |      let as_ref: &[u32; 2] = unsafe { &*as_ptr };
+      |                                       ^^^^^^^^ Dangling check
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (extract[0-1](V|1|) == 0b00)
   
   => Running ref_validity::test_unaligned_ref...
   error: ref_validity::test_unaligned_ref: found issues in <time>, errors in 1 branch (out of 1)
   bug: Misaligned pointer; expected 0x0000000000000008, received 0x0000000000000004 with offset 0x0000000000000000 in ref_validity::test_unaligned_ref
-      ┌─ $TESTCASE_ROOT/ref_validity.rs:25:33
-   22 │  fn test_unaligned_ref() {
-      │  ----------------------- 1: Entry point
-      ·  
-   25 │      let as_ref: &u64 = unsafe { &*as_ptr };
-      │                                  ^^^^^^^^ Requires well-aligned pointer
+      --> $TESTCASE_ROOT/ref_validity.rs:25:33
+   22 |  fn test_unaligned_ref() {
+      |  ----------------------- 1: Entry point
+      .  
+   25 |      let as_ref: &u64 = unsafe { &*as_ptr };
+      |                                  ^^^^^^^^ Requires well-aligned pointer
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffff6) /\
         (extract[0-1](V|1|) == 0b00)
   
@@ -359,12 +359,12 @@ Test recursive validity check for references; warn
   Compiling... done in <time>
   => Running ref_validity::test_uninit_ref...
   warning: Invalid reference: Uninitialized memory access
-      ┌─ $TESTCASE_ROOT/ref_validity.rs:7:33
-    4 │  fn test_uninit_ref() {
-      │  -------------------- 1: Entry point
-      ·  
-    7 │      let as_ref: &u32 = unsafe { &*as_ptr };
-      │                                  ^^^^^^^^ Triggering operation
+      --> $TESTCASE_ROOT/ref_validity.rs:7:33
+    4 |  fn test_uninit_ref() {
+      |  -------------------- 1: Entry point
+      .  
+    7 |      let as_ref: &u32 = unsafe { &*as_ptr };
+      |                                  ^^^^^^^^ Triggering operation
   note: ref_validity::test_uninit_ref: done in <time>, ran 1 branch
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (extract[0-1](V|1|) == 0b00)
@@ -372,24 +372,24 @@ Test recursive validity check for references; warn
   => Running ref_validity::test_dangling_ref...
   error: ref_validity::test_dangling_ref: found issues in <time>, errors in 1 branch (out of 1)
   bug: Dangling pointer in ref_validity::test_dangling_ref
-      ┌─ $TESTCASE_ROOT/ref_validity.rs:17:38
-   14 │  fn test_dangling_ref() {
-      │  ---------------------- 1: Entry point
-      ·  
-   17 │      let as_ref: &[u32; 2] = unsafe { &*as_ptr };
-      │                                       ^^^^^^^^ Dangling check
+      --> $TESTCASE_ROOT/ref_validity.rs:17:38
+   14 |  fn test_dangling_ref() {
+      |  ---------------------- 1: Entry point
+      .  
+   17 |      let as_ref: &[u32; 2] = unsafe { &*as_ptr };
+      |                                       ^^^^^^^^ Dangling check
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (extract[0-1](V|1|) == 0b00)
   
   => Running ref_validity::test_unaligned_ref...
   error: ref_validity::test_unaligned_ref: found issues in <time>, errors in 1 branch (out of 1)
   bug: Misaligned pointer; expected 0x0000000000000008, received 0x0000000000000004 with offset 0x0000000000000000 in ref_validity::test_unaligned_ref
-      ┌─ $TESTCASE_ROOT/ref_validity.rs:25:33
-   22 │  fn test_unaligned_ref() {
-      │  ----------------------- 1: Entry point
-      ·  
-   25 │      let as_ref: &u64 = unsafe { &*as_ptr };
-      │                                  ^^^^^^^^ Requires well-aligned pointer
+      --> $TESTCASE_ROOT/ref_validity.rs:25:33
+   22 |  fn test_unaligned_ref() {
+      |  ----------------------- 1: Entry point
+      .  
+   25 |      let as_ref: &u64 = unsafe { &*as_ptr };
+      |                                  ^^^^^^^^ Requires well-aligned pointer
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffff6) /\
         (extract[0-1](V|1|) == 0b00)
   

--- a/soteria-rust/test/cram/treeborrow.t/run.t
+++ b/soteria-rust/test/cram/treeborrow.t/run.t
@@ -12,12 +12,12 @@ Simple tree borrow violation
   => Running simple_fail::main...
   error: simple_fail::main: found issues in <time>, errors in 1 branch (out of 1)
   bug: Aliasing error in simple_fail::main
-      ┌─ $TESTCASE_ROOT/simple-fail.rs:8:5
-    3 │  fn main() {
-      │  --------- 1: Entry point
-      ·  
-    8 │      *y = 20; // UB: y is disabled
-      │      ^^^^^^^ Memory store
+      --> $TESTCASE_ROOT/simple-fail.rs:8:5
+    3 |  fn main() {
+      |  --------- 1: Entry point
+      .  
+    8 |      *y = 20; // UB: y is disabled
+      |      ^^^^^^^ Memory store
   PC 1: empty
   
   [1]

--- a/soteria-vscode.opam
+++ b/soteria-vscode.opam
@@ -27,6 +27,7 @@ depends: [
   "vscode-interop"
   "vscode-node"
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/soteria.opam
+++ b/soteria.opam
@@ -45,6 +45,7 @@ depends: [
   "ppx_deriving_yojson"
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "ocaml-lsp-server" {with-dev-setup}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/soteria/lib/logs/config.ml
+++ b/soteria/lib/logs/config.ml
@@ -76,7 +76,8 @@ let check_set_and_lock args =
     }
   in
   set_and_lock config;
-  Profile.check_set_and_lock ~no_color:config.no_color ()
+  Profile.check_set_and_lock ~hide_unstable:args.hide_unstable
+    ~no_color:config.no_color ()
 
 let logs_enabled () =
   let conf = get () in

--- a/soteria/lib/logs/config.ml
+++ b/soteria/lib/logs/config.ml
@@ -41,7 +41,8 @@ type cli = {
       [@names [ "hide-unstable"; "diffable" ]]
       [@env "HIDE_UNSTABLE"]
       (** Do not display unstable values like durations (e.g. for diffing
-          purposes). *)
+          purposes). Also overrides the profile to disable colors and utf8 and
+          ensure that it is reproducible accross runs. *)
 }
 [@@deriving subliner]
 

--- a/soteria/lib/logs/profile.ml
+++ b/soteria/lib/logs/profile.ml
@@ -28,16 +28,21 @@ let supports_utf8_from_env () =
 
 type t = { color : bool; utf8 : bool }
 
-let mk_profile () =
-  let utf8 = supports_utf8_from_env () in
-  let color = color_from_env () in
-  { color; utf8 }
+(* Profile that should be supported on all platforms. *)
+let universal = { color = false; utf8 = false }
+
+let mk_profile ~hide_unstable () =
+  if hide_unstable then universal
+  else
+    let utf8 = supports_utf8_from_env () in
+    let color = color_from_env () in
+    { color; utf8 }
 
 let default = { color = false; utf8 = false }
 let get, set_and_lock = Soteria_std.Write_once.make ~name:"Profile" ~default ()
 
-let check_set_and_lock ?(no_color = false) () =
-  let p = mk_profile () in
+let check_set_and_lock ~hide_unstable ?(no_color = false) () =
+  let p = mk_profile ~hide_unstable () in
   let p = if no_color then { p with color = false } else p in
   set_and_lock p;
   Fmt.set_style_renderer Format.std_formatter

--- a/soteria/tutorial/logs.mld
+++ b/soteria/tutorial/logs.mld
@@ -310,6 +310,8 @@ L.info (fun m -> m "Completed at %a"
    hide_unstable = true  -> Completed at <timestamp> *)
 ]}
 
+The [--hide-unstable] flag also makes sure that the printing profile (e.g. support for colors or utf8) is the same independently of the environment, which is useful for making test output deterministic.
+
 {2:performance Performance Considerations}
 
 Logging is designed to be efficient when disabled; avoid doing expensive work for printing before calling the logging function. Instead, do that work inside the logging lambda, so it only runs if the log level is enabled:


### PR DESCRIPTION
Deploy linux packages as well as macos packages. Let's not merge this until I've tested I've updated cargo-soteria (for the artifact name changes), and tested it inside a docker vm.

This opened a whole can of worm about reproducibility of our tests over every platform.
I have made the following modifications:
- `--hide-unstable` also uses a universal profile now (no-color & no-utf8)
- added `__builtin_bswap16` to soteria-c.h, that offset all indexes of symbols, because Cerberus gives a unique indentifier, and this was parsed very early, so it changed all values... 
- to stop all C tests from changing every time I modify soteria-c.h, I print the identifier through `pp_unstable`