### PR TITLE
Bump Charon, fixes, Rust improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ env:
   OCAML_VERSION: 5.4.0
   # [versionsync: OBOL_REPO=soteria-tools/obol]
   OBOL_REPO: soteria-tools/obol
-  # [versionsync: OBOL_COMMIT_HASH=ddea5ca5da4c07301584f47f05ea8615fc365b41]
-  OBOL_COMMIT_HASH: ddea5ca5da4c07301584f47f05ea8615fc365b41
+  # [versionsync: OBOL_COMMIT_HASH=70610866c606acc9b4c3a460ac586d81459d1304]
+  OBOL_COMMIT_HASH: 70610866c606acc9b4c3a460ac586d81459d1304
   # [versionsync: CHARON_REPO=soteria-tools/charon]
   CHARON_REPO: soteria-tools/charon
-  # [versionsync: CHARON_COMMIT_HASH=fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba]
-  CHARON_COMMIT_HASH: fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba
+  # [versionsync: CHARON_COMMIT_HASH=1ec8d4bb0116abf4486bac234ac01acf84e2a83a]
+  CHARON_COMMIT_HASH: 1ec8d4bb0116abf4486bac234ac01acf84e2a83a
 
 jobs:
   build:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -6,8 +6,8 @@ on:
 env:
   # [versionsync: OBOL_REPO=soteria-tools/obol]
   OBOL_REPO: soteria-tools/obol
-  # [versionsync: OBOL_COMMIT_HASH=ddea5ca5da4c07301584f47f05ea8615fc365b41]
-  OBOL_COMMIT_HASH: ddea5ca5da4c07301584f47f05ea8615fc365b41
+  # [versionsync: OBOL_COMMIT_HASH=70610866c606acc9b4c3a460ac586d81459d1304]
+  OBOL_COMMIT_HASH: 70610866c606acc9b4c3a460ac586d81459d1304
 
 jobs:
   test-soteria-c-package:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,11 @@ ocaml-format-check:
 
 .PHONY: check-opam-files
 check-opam-files:
-	@git diff --name-only HEAD | grep -q '\.opam$$' && echo "Error: .opam files have changed since last commit" && exit 1 || exit 0
+	@if git diff --name-only HEAD | grep -q '\.opam$$'; then \
+		echo "Error: .opam files have changed since last commit:"; \
+		git --no-pager diff HEAD -- '*.opam'; \
+		exit 1; \
+	fi
 
 
 .PHONY: ocaml-test

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ We support two frontends: [Obol](https://github.com/soteria-tools/obol) and [Cha
 
 **Manual installation:**
 1. **Clone Obol at the correct commit:**
-   <!-- [versionsync: OBOL_COMMIT_HASH=ddea5ca5da4c07301584f47f05ea8615fc365b41] -->
+   <!-- [versionsync: OBOL_COMMIT_HASH=70610866c606acc9b4c3a460ac586d81459d1304] -->
    ```sh
    cd ..
    git clone https://github.com/soteria-tools/obol.git
    cd obol
-   git checkout ddea5ca5da4c07301584f47f05ea8615fc365b41
+   git checkout 70610866c606acc9b4c3a460ac586d81459d1304
    ```
    > **Note:** The required commit hash can always be found in [`scripts/versions.json`](scripts/versions.json) under `OBOL_COMMIT_HASH`.
 
@@ -168,12 +168,12 @@ We support two frontends: [Obol](https://github.com/soteria-tools/obol) and [Cha
 
 **Manual installation:**
 1. **Clone Charon at the correct commit:**
-   <!-- [versionsync: CHARON_COMMIT_HASH=fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba] -->
+   <!-- [versionsync: CHARON_COMMIT_HASH=1ec8d4bb0116abf4486bac234ac01acf84e2a83a] -->
    ```sh
    cd ..
    git clone https://github.com/soteria-tools/charon.git
    cd charon
-   git checkout fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba
+   git checkout 1ec8d4bb0116abf4486bac234ac01acf84e2a83a
    ```
    > **Note:** The required commit hash can always be found in [`scripts/versions.json`](scripts/versions.json) under `CHARON_COMMIT_HASH`.
 

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Central version configuration for Soteria. Run `scripts/versionsync.py check` to verify versions are in sync, or `scripts/versionsync.py update` to update versions everywhere.",
   "CHARON_REPO": "soteria-tools/charon",
-  "CHARON_COMMIT_HASH": "fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba",
+  "CHARON_COMMIT_HASH": "1ec8d4bb0116abf4486bac234ac01acf84e2a83a",
   "OBOL_REPO": "soteria-tools/obol",
-  "OBOL_COMMIT_HASH": "ddea5ca5da4c07301584f47f05ea8615fc365b41",
+  "OBOL_COMMIT_HASH": "70610866c606acc9b4c3a460ac586d81459d1304",
   "OCAMLFORMAT_VERSION": "0.28.1",
   "OCAML_VERSION": "5.4.0",
   "DUNE_VERSION": "3.23.0"

--- a/soteria-c.opam
+++ b/soteria-c.opam
@@ -33,7 +33,6 @@ depends: [
   "dune" {>= "3.14" & build & >= "3.14.0"}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "ocaml-lsp-server" {with-dev-setup}
-  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/soteria-c.opam
+++ b/soteria-c.opam
@@ -33,6 +33,7 @@ depends: [
   "dune" {>= "3.14" & build & >= "3.14.0"}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "ocaml-lsp-server" {with-dev-setup}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/soteria-rust.opam
+++ b/soteria-rust.opam
@@ -35,6 +35,7 @@ depends: [
   "dune" {>= "3.14" & build & >= "3.14.0"}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "ocaml-lsp-server" {with-dev-setup}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/soteria-rust.opam
+++ b/soteria-rust.opam
@@ -35,7 +35,6 @@ depends: [
   "dune" {>= "3.14" & build & >= "3.14.0"}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "ocaml-lsp-server" {with-dev-setup}
-  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -56,8 +55,8 @@ build: [
 dev-repo: "git+https://github.com/soteria-tools/soteria.git"
 # Versions managed by scripts/versionsync.py - edit scripts/versions.json to change
 pin-depends: [
-  # [versionsync: CHARON_COMMIT_HASH=fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba]
-  ["name_matcher_parser.~dev" "git+https://github.com/soteria-tools/charon#fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba"]
-  # [versionsync: CHARON_COMMIT_HASH=fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba]
-  ["charon.~dev" "git+https://github.com/soteria-tools/charon#fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba"]
+  # [versionsync: CHARON_COMMIT_HASH=1ec8d4bb0116abf4486bac234ac01acf84e2a83a]
+  ["name_matcher_parser.~dev" "git+https://github.com/soteria-tools/charon#1ec8d4bb0116abf4486bac234ac01acf84e2a83a"]
+  # [versionsync: CHARON_COMMIT_HASH=1ec8d4bb0116abf4486bac234ac01acf84e2a83a]
+  ["charon.~dev" "git+https://github.com/soteria-tools/charon#1ec8d4bb0116abf4486bac234ac01acf84e2a83a"]
 ]

--- a/soteria-rust.opam.template
+++ b/soteria-rust.opam.template
@@ -1,7 +1,7 @@
 # Versions managed by scripts/versionsync.py - edit scripts/versions.json to change
 pin-depends: [
-  # [versionsync: CHARON_COMMIT_HASH=fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba]
-  ["name_matcher_parser.~dev" "git+https://github.com/soteria-tools/charon#fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba"]
-  # [versionsync: CHARON_COMMIT_HASH=fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba]
-  ["charon.~dev" "git+https://github.com/soteria-tools/charon#fa7ff7118fc9f695ecde2b4aa8401fe3ea195fba"]
+  # [versionsync: CHARON_COMMIT_HASH=1ec8d4bb0116abf4486bac234ac01acf84e2a83a]
+  ["name_matcher_parser.~dev" "git+https://github.com/soteria-tools/charon#1ec8d4bb0116abf4486bac234ac01acf84e2a83a"]
+  # [versionsync: CHARON_COMMIT_HASH=1ec8d4bb0116abf4486bac234ac01acf84e2a83a]
+  ["charon.~dev" "git+https://github.com/soteria-tools/charon#1ec8d4bb0116abf4486bac234ac01acf84e2a83a"]
 ]

--- a/soteria-rust/lib/analyses/wpst.ml
+++ b/soteria-rust/lib/analyses/wpst.ml
@@ -104,27 +104,30 @@ let exec_crate (crate : Charon.UllbcAst.crate)
   let branches =
     (* If any of the results were "Gave_up", we raise an exception to be caught
        by [print_outcomes] *)
-    let map_first f (x, y) = (f x, y) in
-    List.map
-      (map_first @@ Compo_res.map_error Soteria.Symex.Or_gave_up.unwrap_exn)
-      branches
+    branches
+    |> List.map @@ Pair.map_fst
+       @@ function
+       | Compo_res.Ok v -> Ok v
+       | Missing _ -> execution_err "Miss encountered in WPST"
+       | Error e -> (
+           match Soteria.Symex.Or_gave_up.unwrap_exn e with
+           | (`OkExit, _), st -> Ok (Rust_val.unit_, st)
+           | e -> Error e)
   in
   (* inverse ok and errors if we expect a failure *)
   let branches =
     if not expect_error then branches
     else
-      let open Compo_res in
       let oks, errors =
         branches
         |> List.partition_map @@ function
-           | Ok _, pcs ->
+           | Ok (_, st), pcs ->
                let trace =
                  Soteria.Terminal.Call_trace.singleton
                    ~loc:fun_decl.item_meta.span.data ()
                in
-               Left (Error ((`MetaExpectedError, trace), State.empty), pcs)
-           | Error _, pcs -> Right (Ok (Rust_val.unit_, State.empty), pcs)
-           | v -> Left v
+               Left (Error ((`MetaExpectedError, trace), st), pcs)
+           | Error (_, st), pcs -> Right (Ok (Rust_val.unit_, st), pcs)
       in
       if List.is_empty errors then oks else errors
   in
@@ -143,18 +146,16 @@ let exec_crate (crate : Charon.UllbcAst.crate)
         "Note that at least %a were left unexplored due to fuel exhaustion. \
          Errors may have been missed."
         pp_branches unexplored
-    else Fmt.kstr execution_err "Missed %a" pp_branches unexplored
-  else if List.exists Compo_res.is_missing outcomes then
-    execution_err "Miss encountered in WPST";
+    else Fmt.kstr execution_err "Missed %a" pp_branches unexplored;
 
-  if not (List.exists Compo_res.is_error outcomes) then
+  if not (List.exists Result.is_error outcomes) then
     let pcs = List.map snd branches in
     Ok (pcs, nbranches, unexplored > 0)
   else
     let errors =
       branches
       |> List.filter_map (function
-        | Compo_res.Error (e, _st), pc -> Some (e, pc)
+        | Error (e, _st), pc -> Some (e, pc)
         | _ -> None)
       |> List.group_by ~compare:Error.compare_with_trace
     in

--- a/soteria-rust/lib/builtins/eval.ml
+++ b/soteria-rust/lib/builtins/eval.ml
@@ -56,11 +56,13 @@ type fn =
 (** Extern functions we must implement manually *)
 type extern_fn =
   | Alloc of Extern.Alloc.fn
+  | Libc of Extern.Libc.fn
   | Miri of Extern.Miri.fn
   | Std of Extern.Std.fn
 
 let extern_functions =
   (Extern.Alloc.fn_pats |> List.map @@ Pair.map_snd @@ fun f -> Alloc f)
+  @ (Extern.Libc.fn_pats |> List.map @@ Pair.map_snd @@ fun f -> Libc f)
   @ (Extern.Miri.fn_pats |> List.map @@ Pair.map_snd @@ fun f -> Miri f)
   @ (Extern.Std.fn_pats |> List.map @@ Pair.map_snd @@ fun f -> Std f)
   |> SMap.of_list
@@ -85,6 +87,7 @@ module M (StateM : State.StateM.S) = struct
 
   (* externs *)
   module Alloc = Extern.Alloc.M (StateM)
+  module Libc = Extern.Libc.M (StateM)
   module Miri = Extern.Miri.M (StateM)
   module Std = Extern.Std.M (StateM)
 
@@ -104,6 +107,7 @@ module M (StateM : State.StateM.S) = struct
 
   let[@inline] extern_fn_to_stub = function
     | Alloc f -> Alloc.fn_to_stub f
+    | Libc f -> Libc.fn_to_stub f
     | Miri f -> Miri.fn_to_stub f
     | Std f -> Std.fn_to_stub f
 

--- a/soteria-rust/lib/builtins/extern/alloc.ml
+++ b/soteria-rust/lib/builtins/extern/alloc.ml
@@ -12,6 +12,7 @@ type fn =
   | Dealloc
   | Realloc
   | NoAllocShimIsUnstable
+  | ErrorHandler
 
 let fn_pats =
   [
@@ -20,6 +21,7 @@ let fn_pats =
     ("__rust_dealloc", Dealloc);
     ("__rust_no_alloc_shim_is_unstable_v2", NoAllocShimIsUnstable);
     ("__rust_realloc", Realloc);
+    ("__rust_alloc_error_handler", ErrorHandler);
   ]
 
 module M (StateM : State.StateM.S) = struct
@@ -83,10 +85,12 @@ module M (StateM : State.StateM.S) = struct
     Ptr new_ptr
 
   let no_alloc_shim_is_unstable _ = ok (Tuple [])
+  let error_handler _ = error `InvalidAlloc
 
   let[@inline] fn_to_stub = function
     | Alloc { zeroed } -> alloc ~zeroed
     | Dealloc -> dealloc
     | NoAllocShimIsUnstable -> no_alloc_shim_is_unstable
     | Realloc -> realloc
+    | ErrorHandler -> error_handler
 end

--- a/soteria-rust/lib/builtins/extern/libc.ml
+++ b/soteria-rust/lib/builtins/extern/libc.ml
@@ -1,0 +1,20 @@
+open Rust_val
+open Typed.Syntax
+open Typed.Infix
+
+type fn = Exit
+
+let fn_pats = [ ("exit", Exit) ]
+
+module M (StateM : State.StateM.S) = struct
+  open StateM
+  open Syntax
+
+  let exit args =
+    match args with
+    | [ Int code ] ->
+        if%sat code ==@ U32.(0s) then error `OkExit else error (`Exit code)
+    | _ -> failwith "exit: invalid arguments"
+
+  let[@inline] fn_to_stub = function Exit -> exit
+end

--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -712,6 +712,11 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
   let ptr_guaranteed_cmp ~t:_ ~ptr ~other =
     Core.eval_ptr_binop Eq (Ptr ptr) (Ptr other)
 
+  let ptr_mask ~t:_ ~ptr:(ptr, meta) ~mask =
+    let* addr = Sptr.decay ptr in
+    let addr = addr &@ mask in
+    ok (Sptr.of_address addr, meta)
+
   let ptr_offset_from_ ~unsigned ~t ~ptr:((ptr, _) : full_ptr)
       ~base:((base, _) : full_ptr) : T.sint Typed.t ret =
     let zero = Usize.(0s) in

--- a/soteria-rust/lib/common/charon_util.ml
+++ b/soteria-rust/lib/common/charon_util.ml
@@ -46,13 +46,13 @@ let type_of_operand : Expressions.operand -> Types.ty = function
   | Constant c -> c.ty
   | Copy p | Move p -> p.ty
 
-let lit_to_string = PrintValues.literal_type_to_string
+let lit_to_string = Print.literal_type_to_string
 
 let ty_as_float : Types.ty -> Values.float_type = function
   | TLiteral (TFloat f) -> f
   | _ -> failwith "ty_as_float: not a float type"
 
-let pp_literal_ty = Fmt.of_to_string PrintValues.literal_type_to_string
+let pp_literal_ty = Fmt.of_to_string Print.literal_type_to_string
 
 let rec pp_ty fmt : Types.ty -> unit = function
   | TAdt { id = TAdtId id; generics } ->
@@ -91,14 +91,15 @@ let rec pp_ty fmt : Types.ty -> unit = function
         Fmt.(list ~sep:(any ", ") pp_ty)
         inputs pp_ty output
   | TDynTrait _ -> Fmt.string fmt "dyn <trait>"
-  | TTraitType (tref, name) ->
-      Fmt.pf fmt "Trait<%a>::%s" Crate.pp_trait_ref tref name
+  | TTraitType (tref, type_id) ->
+      Fmt.pf fmt "Trait<%a>::%s" Crate.pp_trait_ref tref
+        (Crate.get_assoc_type_name tref type_id)
   | TFnDef { binder_value = { kind = FunId (FRegular fid); _ }; _ } ->
       let f = Crate.get_fun fid in
       Fmt.pf fmt "fn %a" Crate.pp_name f.item_meta.name
   | TPtrMetadata ty -> Fmt.pf fmt "meta(%a)" pp_ty ty
   | TFnDef _ -> Fmt.string fmt "fn ?"
-  | TVar var -> Fmt.string fmt (PrintTypes.type_db_var_to_pretty_string var)
+  | TVar var -> Fmt.string fmt (Print.type_db_var_to_pretty_string var)
   | TError err -> Fmt.pf fmt "Error(%s)" err
 
 let lit_of_int_ty : Types.integer_type -> Types.literal_type = function
@@ -115,6 +116,11 @@ let lit_ty_of_lit : Values.literal -> Types.literal_type = function
   | VChar _ -> TChar
   | VFloat { float_ty; _ } -> TFloat float_ty
   | VStr _ | VByteStr _ -> failwith "lit_ty_of_lit: not a literal type"
+
+let int_ty_of_lit_ty : Types.literal_type -> Types.integer_type = function
+  | TInt ity -> Signed ity
+  | TUInt uty -> Unsigned uty
+  | _ -> Fmt.failwith "int_ty_of_lit_ty: not an int literal"
 
 let z_of_constant_expr : Types.constant_expr -> Z.t = function
   | { kind = CLiteral (VScalar s); _ } -> z_of_scalar s
@@ -167,7 +173,7 @@ let unit_ptr = Types.TRawPtr (TypesUtils.mk_unit_ty, RShared)
 
 let unit_ref = Types.TRef (RErased, TypesUtils.mk_unit_ty, RShared)
 
-let decl_has_attr (decl : 'a GAst.gfun_decl) attr =
+let decl_has_attr (decl : GAst.fun_decl) attr =
   List.exists
     (function Meta.AttrUnknown { path; _ } -> path = attr | _ -> false)
     decl.item_meta.attr_info.attributes
@@ -178,7 +184,7 @@ let meta_get_attr (meta : Types.item_meta) attr =
       | Meta.AttrUnknown { path; args } when path = attr -> args | _ -> None)
     meta.attr_info.attributes
 
-let decl_get_attr (decl : 'a GAst.gfun_decl) attr =
+let decl_get_attr (decl : GAst.fun_decl) attr =
   meta_get_attr decl.item_meta attr
 
 let adt_is_box (adt : Types.type_decl_ref) =

--- a/soteria-rust/lib/crate.ml
+++ b/soteria-rust/lib/crate.ml
@@ -21,7 +21,7 @@ let as_namematcher_ctx () = NameMatcher.ctx_from_crate (get_crate ())
 
 let as_fmt_env () =
   let crate = get_crate () in
-  PrintUllbcAst.Crate.crate_to_fmt_env crate
+  Print.crate_to_fmt_env crate
 
 let[@inline] mk_pp to_string =
  fun ft v -> Fmt.of_to_string (to_string (as_fmt_env ())) ft v
@@ -31,23 +31,23 @@ let[@inline] mk_pp_indent to_string =
   let to_str = to_string (as_fmt_env ()) "" in
   Fmt.pf ft "%s" (to_str v)
 
-let pp_constant_expr = mk_pp PrintTypes.constant_expr_to_string
-let pp_fn_operand = mk_pp PrintUllbcAst.Ast.fn_operand_to_string
-let pp_fun_decl_ref = mk_pp PrintTypes.fun_decl_ref_to_string
-let pp_generic_args = mk_pp PrintTypes.generic_args_to_string
-let pp_operand = mk_pp PrintExpressions.operand_to_string
+let pp_constant_expr = mk_pp Print.constant_expr_to_string
+let pp_fn_operand = mk_pp Print.fn_operand_to_string
+let pp_fun_decl_ref = mk_pp Print.fun_decl_ref_to_string
+let pp_generic_args = mk_pp Print.generic_args_to_string
+let pp_operand = mk_pp Print.operand_to_string
 
 let pp_generic_params =
   mk_pp (fun env params ->
-      let generics, clauses = PrintTypes.generic_params_to_strings env params in
+      let generics, clauses = Print.generic_params_to_strings env params in
       String.concat " + " (generics @ clauses))
 
-let pp_global_decl_ref = mk_pp PrintTypes.global_decl_ref_to_string
-let pp_name = mk_pp PrintTypes.name_to_string
-let pp_place = mk_pp PrintExpressions.place_to_string
-let pp_trait_ref = mk_pp PrintTypes.trait_ref_to_string
-let pp_statement = mk_pp_indent PrintUllbcAst.Ast.statement_to_string
-let pp_terminator = mk_pp_indent PrintUllbcAst.Ast.terminator_to_string
+let pp_global_decl_ref = mk_pp Print.global_decl_ref_to_string
+let pp_name = mk_pp Print.name_to_string
+let pp_place = mk_pp Print.place_to_string
+let pp_trait_ref = mk_pp Print.trait_ref_to_string
+let pp_statement = mk_pp_indent Print.Ullbc.statement_to_string
+let pp_terminator = mk_pp_indent Print.Ullbc.terminator_to_string
 
 let get_adt_raw id =
   let crate = get_crate () in
@@ -111,6 +111,14 @@ let get_trait_decl (trait_ref : Types.trait_decl_ref) =
   in
   let subst = subst_at_binder_zero subst in
   st_substitute_visitor#visit_trait_decl subst trait
+
+let get_assoc_type_name (trait_ref : Types.trait_ref) type_id =
+  Charon.GAstUtils.get_assoc_type_name (get_crate ())
+    trait_ref.trait_decl_ref.binder_value.id type_id
+
+let get_method_name (trait_ref : Types.trait_ref) method_id =
+  Charon.GAstUtils.get_method_name (get_crate ())
+    trait_ref.trait_decl_ref.binder_value.id method_id
 
 let is_enum (adt_ref : Types.type_decl_ref) =
   match adt_ref.id with

--- a/soteria-rust/lib/error.ml
+++ b/soteria-rust/lib/error.ml
@@ -62,7 +62,13 @@ type t =
     (** Function was marked as expecting an error; none happened *)
   | `InvalidLayout of Types.ty  (** Type is too large for memory *)
   | `InvalidAlloc
-    (** Error in alloc/realloc; a wrong alignment or size was provided *) ]
+    (** Error in alloc/realloc; a wrong alignment or size was provided *)
+  | `OkExit
+    (** Zero (succesful) exit; this is used to have short-circuiting; it should
+        not be reported as an error! *)
+  | `Exit of Typed.T.sint Typed.t
+    (** Exit with a specific (non-zero) code; this should be reported
+        (probably..?). *) ]
 
 type warn_reason = InvalidReference of Typed.T.sloc Typed.t [@@deriving hash]
 
@@ -107,6 +113,8 @@ let rec pp ft : [> t ] -> unit = function
         Typed.ppa exp Typed.ppa got Typed.ppa ofs
   | `NotAFnPointer -> Fmt.string ft "Not a function pointer"
   | `NullDereference -> Fmt.string ft "Null dereference"
+  | `OkExit -> Fmt.string ft "Exited successfully with code 0"
+  | `Exit code -> Fmt.pf ft "Exited with code %a" Typed.ppa code
   | `OutOfBounds -> Fmt.string ft "Out of bounds"
   | `Overflow -> Fmt.string ft "Overflow"
   | `Panic (Some msg) -> Fmt.pf ft "Panic: %s" msg

--- a/soteria-rust/lib/frontend.ml
+++ b/soteria-rust/lib/frontend.ml
@@ -110,11 +110,12 @@ let default () =
       ([
          "--ullbc";
          "--extract-opaque-bodies";
-         "--mir elaborated";
+         "--mir=elaborated";
          "--reconstruct-fallible-operations";
          "--reconstruct-asserts";
          "--desugar-drops";
          "--precise-drops";
+         "--format=postcard";
        ]
       @ opaque_names
       @ if (Config.get ()).polymorphic then [] else [ "--monomorphize" ])
@@ -162,8 +163,8 @@ let miri () =
     included; otherwise, a name is included if it matches any filter and doesn't
     match any exclude. *)
 let filter_name crate name =
-  let fmt_env = PrintUllbcAst.Crate.crate_to_fmt_env crate in
-  let name = PrintTypes.name_to_string fmt_env name in
+  let fmt_env = Print.crate_to_fmt_env crate in
+  let name = Print.name_to_string fmt_env name in
 
   let filters = (Config.get ()).filter in
   let excludes = (Config.get ()).exclude in
@@ -253,22 +254,20 @@ let parse_ullbc ~mode ~cmd ~output ~pwd () =
           err;
     Cleaner.touched output);
   let crate =
-    match
-      output |> Yojson.Basic.from_file |> Charon.UllbcOfJson.crate_of_json
-    with
+    match output |> Charon.OfPostcard.crate_of_postcard_file with
     | Ok crate -> crate
-    | Error _ ->
+    | Error msg ->
         Fmt.kstr frontend_err
           "Failed to parse ULLBC. Do you have the right version of %a \
-           installed?"
-          Config.pp_frontend (Config.get ()).frontend
+           installed?@.Error: %s"
+          Config.pp_frontend (Config.get ()).frontend msg
     | exception Sys_error _ -> frontend_err "File doesn't exist"
     | exception e -> Fmt.kstr frontend_err "Unexpected error: %a" Fmt.exn e
   in
   if (Config.get ()).output_crate then (
     (* save pretty-printed crate to local file *)
     let crate_file = Printf.sprintf "%s.crate" output in
-    let str = Charon.PrintUllbcAst.Crate.crate_to_string crate in
+    let str = Charon.Print.crate_to_string crate in
     let oc = open_out_bin crate_file in
     output_string oc str;
     close_out oc;

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -955,19 +955,20 @@ module Make (StateImpl : State.S) = struct
             map_env (Store.dealloc local)
         | Uninit | Value _ -> map_env (Store.dealloc local)
         | Dead -> ok ())
-    | Assert ({ cond; expected; check_kind = _ }, on_failure) -> (
+    | Assert ({ cond; expected; check_kind = _ }, on_failure) ->
         let* cond = eval_operand cond in
         let cond_int = as_base TBool cond in
         let cond_bool = BV.to_bool cond_int in
         let cond_bool = if expected then cond_bool else Typed.not cond_bool in
-        if%sat cond_bool then ok ()
-        else
+        let err =
           match on_failure with
-          | UndefinedBehavior -> error `UBAbort
-          | UnwindTerminate -> error `UnwindTerminate
+          | UndefinedBehavior -> `UBAbort
+          | UnwindTerminate -> `UnwindTerminate
           | Panic name ->
               let name = Option.map (Fmt.to_to_string Crate.pp_name) name in
-              error (`Panic name))
+              `Panic name
+        in
+        assert_ cond_bool err
     | CopyNonOverlapping { src; dst; count } ->
         let ty = get_pointee (type_of_operand src) in
         let* src = eval_operand src in

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -154,7 +154,7 @@ module Make (StateImpl : State.S) = struct
     let open Fun_kind in
     match fn.kind with
     | FunId (FRegular id) -> ok (Real { id; generics = fn.generics })
-    | TraitMethod (tref, name, _) -> (
+    | TraitMethod (tref, method_id, _) -> (
         let* tref = Poly.subst_tref tref in
         let trait_ref = tref.trait_decl_ref.binder_value in
         let* timplref =
@@ -166,7 +166,8 @@ module Make (StateImpl : State.S) = struct
               | Some "destruct" -> ok (`Synth GenericDropInPlace)
               | Some _ | None ->
                   Fmt.kstr not_impl "trait call %a::%s on generic" Crate.pp_name
-                    trait_decl.item_meta.name name)
+                    trait_decl.item_meta.name
+                    (Crate.get_method_name tref method_id))
           | _ ->
               Fmt.kstr not_impl "Unexpected tref kind, got: %a"
                 Types.pp_trait_ref_kind tref.kind
@@ -176,7 +177,7 @@ module Make (StateImpl : State.S) = struct
         | `Impl timplref -> (
             let timpl = Crate.get_trait_impl timplref in
             match
-              Substitute.lookup_and_subst_trait_impl_method timpl name
+              Substitute.lookup_and_subst_trait_impl_method timpl method_id
                 timplref.generics fn.generics
             with
             | Some fn -> ok (Real fn)
@@ -184,8 +185,8 @@ module Make (StateImpl : State.S) = struct
                 (* get the default method *)
                 let trait_decl = Crate.get_trait_decl trait_ref in
                 match
-                  Substitute.lookup_and_subst_trait_decl_method trait_decl name
-                    tref fn.generics
+                  Substitute.lookup_and_subst_trait_decl_method trait_decl
+                    method_id tref fn.generics
                 with
                 | Some fn -> ok (Real fn)
                 | None -> not_impl "Could not resolve trait method")))
@@ -222,15 +223,28 @@ module Make (StateImpl : State.S) = struct
             let+ () = State.store_str_global str ptr in
             Ptr ptr)
     | CFnDef _ -> ok (Tuple [])
+    | CPtrNoProvenance v -> ok (Ptr (Sptr.of_address (BV.usize v), Thin))
+    | CArray cs ->
+        let+ vals = map_list cs ~f:resolve_constant in
+        Tuple vals
+    | CAdt (None, fields) ->
+        let+ vals = map_list fields ~f:resolve_constant in
+        Tuple vals
+    | CAdt (Some var, fields) ->
+        let variants = Crate.as_enum @@ ty_as_adt const.ty in
+        let variant = Types.VariantId.nth variants var in
+        let discr = BV.of_literal variant.discriminant in
+        let+ vals = map_list fields ~f:resolve_constant in
+        Enum (discr, vals)
     | CLiteral (VByteStr _) -> not_impl "TODO: resolve const ByteStr"
     (* FIXME: this is hacky, but until we get proper monomorphisation this isn't
        too bad *)
-    | CTraitConst (tref, name) -> (
+    | CTraitConst (tref, const_id) -> (
         let* tref = Poly.subst_tref tref in
         match tref.kind with
         | TraitImpl implref ->
             let timpl = Crate.get_trait_impl implref in
-            let _, global = List.find (fun (n, _) -> n = name) timpl.consts in
+            let global = Types.AssocConstId.Map.find const_id timpl.consts in
             let* glob_ptr = resolve_global global in
             let glob = Crate.get_global global.id in
             State.load glob_ptr glob.ty
@@ -307,8 +321,7 @@ module Make (StateImpl : State.S) = struct
     | CVar (Free id) -> State.lookup_const_generic id const.ty
     | CVar (Bound _) -> failwith "Unbound const generic expression"
     | COpaque msg -> Fmt.kstr not_impl "Opaque constant: %s" msg
-    | CAdt _ | CArray _ | CRef _ | CPtr _ | CFnPtr _ | CPtrNoProvenance _
-    | CVTableRef _ ->
+    | CRef _ | CPtr _ | CFnPtr _ | CVTableRef _ ->
         Fmt.kstr not_impl "TODO: complex constant %a" Crate.pp_constant_expr
           const
 
@@ -1056,7 +1069,7 @@ module Make (StateImpl : State.S) = struct
                   list ~sep:comma
                   @@ pair ~sep:(any "->") string UllbcAst.pp_block_id)
                 (List.map
-                   (fun (v, b) -> (PrintValues.literal_to_string v, b))
+                   (fun (v, b) -> (Print.literal_to_string v, b))
                    options)
                 UllbcAst.pp_block_id default pp_rust_val discr];
             let compare_discr =
@@ -1072,50 +1085,30 @@ module Make (StateImpl : State.S) = struct
                       "Didn't know how to compare discriminant %a with scalar \
                        %s"
                       pp_rust_val discr
-                      (PrintValues.literal_to_string v)
+                      (Print.literal_to_string v)
             in
             let*^ block = match_on options ~constr:compare_discr in
             let block = Option.fold ~none:default ~some:snd block in
             let block = UllbcAst.BlockId.nth body.body block in
             exec_block ~body block)
-    | Drop (drop_kind, place, trait_ref, target, on_unwind) -> (
+    | Drop (drop_kind, place, fn_ptr, target, on_unwind) ->
         assert (drop_kind = Precise);
         let* place_ptr = resolve_place place in
-        (* Try to find a drop function that exists; it may be opaque if the drop
-           contains polymorphic types. *)
-        let drop_fn : Fun_kind.t option =
-          match trait_ref.kind with
-          | TraitImpl impl_ref -> (
-              let impl = Crate.get_trait_impl impl_ref in
-              (* The Drop trait will only have the drop function *)
-              let _, drop_ref = List.hd impl.methods in
-              let drop = Crate.get_fun drop_ref.binder_value.id in
-              match drop.body with
-              (* TODO: i don't think we should read [binder_value] here *)
-              | Body _ -> Some (Real drop_ref.binder_value)
-              | _ -> None)
-          | _ -> None
+        let* drop_fn = resolve_fn_ptr fn_ptr in
+        let fun_exec =
+          with_extra_call_trace ~loc:terminator.span.data ~msg:"Drop"
+          @@ with_env ~env:()
+          @@ exec_fun drop_fn [ Ptr place_ptr ]
         in
-        match drop_fn with
-        | Some drop ->
-            let fun_exec =
-              with_extra_call_trace ~loc:terminator.span.data ~msg:"Drop"
-              @@ with_env ~env:()
-              @@ exec_fun drop [ Ptr place_ptr ]
-            in
-            unwind_with fun_exec
-              ~f:(fun _ ->
-                let block = UllbcAst.BlockId.nth body.body target in
-                [%l.info "Dropped with %a" Fun_kind.pp drop];
-                exec_block ~body block)
-              ~fe:(fun err ->
-                let* () = State.add_error err in
-                [%l.info "Unwinding drop from %a" Fun_kind.pp drop];
-                let block = UllbcAst.BlockId.nth body.body on_unwind in
-                exec_block ~body block)
-        | None ->
-            let* () = State.uninit place_ptr place.ty in
+        unwind_with fun_exec
+          ~f:(fun _ ->
             let block = UllbcAst.BlockId.nth body.body target in
+            [%l.info "Dropped with %a" Fun_kind.pp drop_fn];
+            exec_block ~body block)
+          ~fe:(fun err ->
+            let* () = State.add_error err in
+            [%l.info "Unwinding drop from %a" Fun_kind.pp drop_fn];
+            let block = UllbcAst.BlockId.nth body.body on_unwind in
             exec_block ~body block)
     | Abort kind -> (
         match kind with
@@ -1135,10 +1128,10 @@ module Make (StateImpl : State.S) = struct
     let@ generics = Poly.push_generics ~params:fundef.generics ~args:generics in
     let () = Soteria.Stats.As_ctx.incr StatKeys.function_calls in
     match fundef.body with
-    | Intrinsic { name; arg_names = _ } ->
+    | IntrinsicBody (name, _arg_names) ->
         Std_funs.eval_intrinsic fundef name generics exec_fun args
-    | Extern name -> Std_funs.eval_extern name args
-    | Body body -> (
+    | ExternBody name -> Std_funs.eval_extern name args
+    | UnstructuredBody body -> (
         match Std_funs.eval_stub fundef exec_fun generics with
         | Some stub -> stub args
         | None ->
@@ -1163,13 +1156,26 @@ module Make (StateImpl : State.S) = struct
               ~fe:(fun err ->
                 let* () = dealloc_stack protected in
                 error_raw err))
-    | Opaque | TraitMethodWithoutDefault | Missing | Error _ -> (
+    | OpaqueBody | TraitMethodWithoutDefaultBody | MissingBody | ErrorBody _
+      -> (
         match Std_funs.eval_stub fundef exec_fun generics with
         | Some stub -> stub args
         | None ->
-            Fmt.kstr not_impl "Can't execute function %a: %a" Crate.pp_name name
-              (GAst.pp_body Fmt.nop) fundef.body)
-    | TargetDispatch _ -> failwith "Target dispatch not supported"
+            let msg =
+              match fundef.body with
+              | OpaqueBody -> "compilation skipped it"
+              | TraitMethodWithoutDefaultBody -> "this is a trait method stub"
+              | MissingBody ->
+                  "the function's body was not found while compiling; try \
+                   using a sysroot (with --sysroot)"
+              | ErrorBody err ->
+                  "the frontend does not support compiling it (" ^ err.msg ^ ")"
+              | _ -> failwith "impossible"
+            in
+            Fmt.kstr not_impl "can't execute function %a, %s" Crate.pp_name name
+              msg)
+    | TargetDispatchBody _ -> failwith "Target dispatch not supported"
+    | StructuredBody _ -> failwith "Impossibe: encountered LLBC?"
 
   and exec_fun (fn : Fun_kind.t) =
     match fn with

--- a/soteria-rust/lib/layout.ml
+++ b/soteria-rust/lib/layout.ml
@@ -195,61 +195,62 @@ let rec layout_of (ty : Types.ty) : (t, 'e, 'f) Rustsymex.Result.t =
   (* Others (unhandled for now) *)
   | TPtrMetadata _ -> not_impl_layout "pointer metadata" ty
   | TError _ -> not_impl_layout "error" ty
-  | TTraitType (tref, ty_name) ->
-      let** resolved = resolve_trait_ty tref ty_name in
+  | TTraitType (tref, assoc_ty_id) ->
+      let** resolved = resolve_trait_ty tref assoc_ty_id in
       layout_of resolved
+
+and translate_discriminator : Types.discriminator -> Fields_shape.discriminator
+    = function
+  | Known v -> Known v
+  | Invalid -> Invalid
+  | Branch (offset, int_ty, children, fallback) ->
+      let offset = BV.usizei offset in
+      let children =
+        List.map
+          (fun ((from_, to_), discr) ->
+            (BV.of_scalar from_, BV.of_scalar to_, translate_discriminator discr))
+          children
+      in
+      let tag_ty = lit_of_int_ty int_ty in
+      let fallback = translate_discriminator fallback in
+      Branch { offset; tag_ty; children; fallback }
 
 and translate_layout ty (layout : Types.layout) =
   let size = compute_size ty layout.size in
   let align = compute_align ty layout.align in
   let uninhabited = layout.uninhabited in
-  let tag_layout =
-    Option.map
-      (fun (discr_layout : Types.discriminant_layout) : Tag_layout.t ->
-        let tags =
-          List.map
-            (fun (v : Types.variant_layout) -> Option.map BV.of_scalar v.tag)
-            layout.variant_layouts
-        in
-        let tags = Array.of_list tags in
-        let ty = lit_of_int_ty discr_layout.tag_ty in
-        let offset = BV.usizei discr_layout.offset in
-        let encoding : Tag_layout.encoding =
-          match discr_layout.encoding with
-          | Niche v -> Niche v
-          | Direct -> Direct
-        in
-        { offset; ty; tags; encoding })
-      layout.discriminant_layout
-  in
+  let discriminator = Option.map translate_discriminator layout.discriminator in
   let variant_layouts =
     List.mapi
-      (fun i (v : Types.variant_layout) : Fields_shape.t ->
-        if v.uninhabited then Primitive
+      (fun i (v : Types.variant_layout) : (Fields_shape.tagger * Fields_shape.t)
+         ->
+        if v.uninhabited then (None, Primitive)
         else
           let ofs = Array.of_list (List.map BV.usizei v.field_offsets) in
-          Arbitrary (Types.VariantId.of_int i, ofs))
+          let tagger =
+            match v.tagger with
+            | [] -> None
+            | [ (ofs, value) ] -> Some (BV.usizei ofs, BV.of_scalar value)
+            | _ :: _ :: _ -> failwith "unsupported: >1 tagger values"
+          in
+          (tagger, Arbitrary (Types.VariantId.of_int i, ofs)))
       layout.variant_layouts
   in
   let fields : Fields_shape.t =
-    match (tag_layout, variant_layouts) with
+    match (discriminator, variant_layouts) with
     (* tag layouts only exist on enum layouts *)
-    | Some tag_layout, _ -> Enum (tag_layout, Array.of_list variant_layouts)
-    (* no variants, so this is uninhabited; we can use primitive *)
-    | None, [] -> Primitive
-    (* there should be only one inhabited (non-Primitive) variant *)
-    | None, _ -> (
-        let is_inhabited = function
-          | Fields_shape.Arbitrary _ -> true
-          | _ -> false
-        in
-        let inhabited = List.filter is_inhabited variant_layouts in
-        match inhabited with
-        | [] -> Primitive
-        | [ single ] -> single
-        | _ :: _ :: _ -> failwith ">1 inhabited variants with no tag encoding?")
+    | Some (Branch _ as d), _ -> Enum (d, Array.of_list variant_layouts)
+    (* no variants/invalid, so this is uninhabited; we can use primitive *)
+    | _, [] | Some Invalid, _ -> Primitive
+    (* there is only one inhabited (non-Primitive) variant *)
+    | Some (Known v), _ -> snd (Types.VariantId.nth variant_layouts v)
+    (* we didn't translate a discriminator; we hope it's a struct-like! *)
+    | None, [ (_, v) ] -> v
+    | None, _ -> failwith "no discriminator and >1 variant layouts?"
   in
-  ok @@ mk ~size ~align ~uninhabited ~fields ()
+  let layout = mk ~size ~align ~uninhabited ~fields () in
+  [%l.trace "Translated layout for %a:@.%a" pp_ty ty pp layout];
+  ok layout
 
 and compute_size ty size =
   match size with
@@ -308,40 +309,48 @@ and compute_enum_layout ty (variants : Types.variant list) =
   | _ :: _ ->
       let tags =
         List.map
-          (fun (v : Types.variant) -> Some (BV.of_literal v.discriminant))
+          (fun (v : Types.variant) -> BV.of_literal v.discriminant)
           variants
       in
-      let tags = Array.of_list tags in
-      let tag_layout : Tag_layout.t =
+      let tag_ty =
+        match variants with
+        | [] -> Values.TInt I32 (* Shouldn't matter *)
+        | v :: _ -> lit_ty_of_lit v.discriminant
+      in
+      let discriminator : Fields_shape.discriminator =
         (* best effort: we assume direct encoding *)
-        let ty : Types.literal_type =
-          match variants with
-          | [] -> TInt I32 (* Shouldn't matter *)
-          | v :: _ -> lit_ty_of_lit v.discriminant
+        let children =
+          List.map
+            (fun (v : Types.variant) ->
+              let tag = Types.VariantId.nth tags v.id in
+              (tag, tag, Fields_shape.Known v.id))
+            variants
         in
-        { offset = Usize.(0s); ty; tags; encoding = Direct }
+        let offset = Usize.(0s) in
+        Branch { offset; tag_ty; children; fallback = Invalid }
       in
-      let** tag = layout_of (TLiteral tag_layout.ty) in
-      let variants =
-        List.mapi (fun i v -> (Types.VariantId.of_int i, v)) variants
-      in
+      let** tag = layout_of (TLiteral tag_ty) in
       let++ size, align, variants, uninhabited =
         Result.fold_list variants
           ~init:(Usize.(0s), Usize.(1s), [], true)
-          ~f:(fun (size, align, variants, uninhabited) (i, v) ->
+          ~f:(fun (size, align, variants, uninhabited) v ->
             let++ l =
               compute_arbitrary_layout ty ~fst_size:tag.size
-                ~fst_align:tag.align ~variant:i (field_tys v.fields)
+                ~fst_align:tag.align ~variant:v.id (field_tys v.fields)
+            in
+            let tagger =
+              if l.uninhabited then None
+              else Some (BV.usizei 0, Types.VariantId.nth tags v.id)
             in
             ( BV.max ~signed:false size l.size,
               BV.max ~signed:false align l.align,
-              l.fields :: variants,
+              (tagger, l.fields) :: variants,
               uninhabited && l.uninhabited ))
       in
       let variants = List.rev variants in
       let layout =
         mk ~size ~align ~uninhabited
-          ~fields:(Enum (tag_layout, Array.of_list variants))
+          ~fields:(Enum (discriminator, Array.of_list variants))
           ()
       in
       Fmt.kstr layout_warning "Computed an enum layout:@.%a" pp layout ty;
@@ -360,19 +369,14 @@ and compute_union_layout ty members =
   let fields = Array.make (List.length members) (BV.usizei 0) in
   mk ~size ~align ~fields:(Arbitrary (Types.VariantId.zero, fields)) ()
 
-and resolve_trait_ty (tref : Types.trait_ref) ty_name =
+and resolve_trait_ty (tref : Types.trait_ref) assoc_ty_id =
   match tref.kind with
-  | TraitImpl timplref -> (
+  | TraitImpl timplref ->
       let impl = Crate.get_trait_impl timplref in
-      match List.find_opt (fun (n, _) -> ty_name = n) impl.types with
-      | Some (_, ty) -> ok ty.binder_value.value
-      | None ->
-          let msg =
-            Fmt.str "missing type '%s' in impl %a" ty_name Crate.pp_name
-              impl.item_meta.name
-          in
-          not_impl_layout msg (TTraitType (tref, ty_name)))
-  | _ -> not_impl_layout "trait type" (TTraitType (tref, ty_name))
+      let trait_assoc_ty = Types.AssocTypeId.Map.find assoc_ty_id impl.types in
+      (* HACK: we skip the binder here! *)
+      ok trait_assoc_ty.binder_value.value
+  | _ -> not_impl_layout "trait type" (TTraitType (tref, assoc_ty_id))
 
 (** Normalise a type, by substituting any generics with the current generic
     environment, and resolving the trait type if needed. *)

--- a/soteria-rust/lib/layout_common.ml
+++ b/soteria-rust/lib/layout_common.ml
@@ -2,47 +2,49 @@ open Charon
 open Typed
 open Typed.Infix
 
-(** Layout of enum tags in memory. Note tags are distinct from discriminants: a
-    discriminant is user specified and is what [Rvalue.Discriminant] returns,
-    whereas a tag is specific to variant layouts, and may be of smaller size
-    than the discriminant, or not be encoded at all if it is the untagged
-    variant of a niche-optimised enum. *)
-module Tag_layout = struct
-  type encoding = Direct | Niche of Types.variant_id
-
-  and t = {
-    offset : T.sint Typed.t;
-    ty : Types.literal_type; [@printer Common.Charon_util.pp_literal_ty]
-    encoding : encoding;
-    tags : T.sint Typed.t option Array.t;
-        [@printer
-          Fmt.(
-            brackets @@ array ~sep:comma (option ~none:(any "none") Typed.ppa))]
-        (** The tag associated to each variant, indexed by variant ID. If
-            [None], the variant is either uninhabited or the untagged variant.
-        *)
-  }
-  [@@deriving show { with_path = false }]
-
-  let iter_vars { offset; tags; encoding = _; ty = _ } f =
-    Typed.iter_vars offset f;
-    Array.iter (Option.iter (fun t -> Typed.iter_vars t f)) tags
-end
-
 (** We use a custom type for the member offsets for layouts; this allows us to
     use a more efficient representation for arrays [T; N], that doesn't require
     N offsets. *)
 module Fields_shape = struct
+  (** Mirror's MiniRust and Charon's discriminator *)
+  type discriminator =
+    | Invalid
+    | Known of Types.variant_id
+    | Branch of {
+        offset : T.sint Typed.t;
+        tag_ty : Types.literal_type;
+            [@printer Fmt.of_to_string Print.literal_type_to_string]
+        children : (T.sint Typed.t * T.sint Typed.t * discriminator) list;
+        fallback : discriminator;
+      }
+  [@@deriving show { with_path = false }]
+
+  (** The [(offset * tag)] associated to a variant. If [None], the variant is
+      either uninhabited or the untagged variant.
+
+      Note tags are distinct from discriminants: a discriminant is user
+      specified and is what [Rvalue.Discriminant] returns, whereas a tag is
+      specific to variant layouts, and may be of smaller size than the
+      discriminant, or not be encoded at all if it is the untagged variant of a
+      niche-optimised enum. *)
+  type tagger = (T.sint Typed.t * T.sint Typed.t) option
+
+  let pp_tagger =
+    Fmt.(
+      option ~none:(any "none") (fun ft (from_, to_) ->
+          Fmt.pf ft "[%a, %a]" Typed.ppa from_ Typed.ppa to_))
+
   type t =
     | Primitive  (** No fields present *)
     | Arbitrary of Types.variant_id * T.sint Typed.t Array.t
         (** Arbitrary field placement (structs, unions...), with the variant
             (e.g. enums with a single inhabited variant) *)
-    | Enum of Tag_layout.t * t Array.t
-        (** Enum fields: encodes a tag, and an array of field shapes for each
-            variant (indexed by variant ID). Using [offset_of] on this isn't
-            valid; one must first retrieve the fields shape of the corresponding
-            variant. *)
+    | Enum of discriminator * (tagger * t) Array.t
+        (** Enum fields: for each variant, a possible tag with [tagger], along
+            with an array of field shapes for each variant (indexed by variant
+            ID). The [discriminator] allows calculating the current variant.
+            Using [offset_of] on this isn't valid; one must first retrieve the
+            fields shape of the corresponding variant. *)
     | Array of T.sint Typed.t
         (** All fields are equally spaced (arrays, slices) *)
 
@@ -52,9 +54,9 @@ module Fields_shape = struct
         Fmt.pf ft "{%a: %a}" Types.VariantId.pp_id var
           Fmt.(braces @@ array ~sep:comma Typed.ppa)
           arr
-    | Enum (tag_layout, shapes) ->
-        Fmt.pf ft "Enum (%a, %a)" Tag_layout.pp tag_layout
-          Fmt.(brackets @@ array ~sep:comma pp)
+    | Enum (discriminator, shapes) ->
+        Fmt.pf ft "Enum (%a, %a)" pp_discriminator discriminator
+          Fmt.(brackets @@ array ~sep:comma (pair ~sep:comma pp_tagger pp))
           shapes
     | Array stride -> Fmt.pf ft "Array(%a)" Typed.ppa stride
 
@@ -65,19 +67,43 @@ module Fields_shape = struct
     | Array stride -> BV.usizei f *!!@ stride
 
   let shape_for_variant variant = function
-    | Enum (_, shapes) -> shapes.(Types.VariantId.to_int variant)
+    | Enum (_, shapes) -> snd shapes.(Types.VariantId.to_int variant)
     | Arbitrary (v, _) as fs when Types.VariantId.equal_id v variant -> fs
     | s ->
         Fmt.failwith "Shape %a has no variant %a" pp s Types.VariantId.pp_id
           variant
 
+  let rec iter_vars_discriminator (d : discriminator) f : unit =
+    match d with
+    | Invalid | Known _ -> ()
+    | Branch { offset; tag_ty = _; children; fallback } ->
+        iter_vars offset f;
+        List.iter
+          (fun (from_, to_, child) ->
+            iter_vars from_ f;
+            iter_vars to_ f;
+            iter_vars_discriminator child f)
+          children;
+        iter_vars_discriminator fallback f
+
+  let iter_vars_tagger (t : tagger) f : unit =
+    match t with
+    | None -> ()
+    | Some (from_, to_) ->
+        iter_vars from_ f;
+        iter_vars to_ f
+
   let rec iter_vars fields f : unit =
     match fields with
     | Primitive -> ()
     | Arbitrary (_, fields) -> Array.iter (fun v -> Typed.iter_vars v f) fields
-    | Enum (tl, layouts) ->
-        Array.iter (fun v -> iter_vars v f) layouts;
-        Tag_layout.iter_vars tl f
+    | Enum (discr, layouts) ->
+        iter_vars_discriminator discr f;
+        Array.iter
+          (fun (t, v) ->
+            iter_vars_tagger t f;
+            iter_vars v f)
+          layouts
     | Array v -> Typed.iter_vars v f
 end
 

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -490,7 +490,19 @@ module Make (Borrows : Tree_borrows.T) = struct
     let is_aligned =
       ofs %@ exp_align ==@ Usize.(0s) &&@ (align %@ exp_align ==@ Usize.(0s))
     in
-    assert_or_error is_aligned (`MisalignedPointer (exp_align, align, ofs))
+    if%sat Typed.not is_aligned then
+      (* If we can't guarantee the pointer is aligned from the type's alignment,
+         we try decaying it and seeing if its (symbolic) address **implies** its
+         alignment. Note this is not OX sound; we only take the ok path if the
+         pointer **must** be aligned, rather than also when it may be aligned.
+
+         This avoids going through extra branches, as a pointer can pretty much
+         always be aligned; what matters most is whether it is guaranteed to be
+         aligned. *)
+      let* address = with_pointers_sym @@ Sptr_base.decay ptr in
+      if%sure address %@ exp_align ==@ Usize.(0s) then Result.ok ()
+      else Result.error (`MisalignedPointer (exp_align, align, ofs))
+    else Result.ok ()
 
   and check_non_dangling_untyped ((ptr : Sptr_base.t), _) size =
     if%sat size ==@ Usize.(0s) then Result.ok ()

--- a/soteria-rust/lib/typed.ml
+++ b/soteria-rust/lib/typed.ml
@@ -104,7 +104,7 @@ module BitVec = struct
     | VBool b -> of_bool (Bool.of_bool b)
     | l ->
         Fmt.failwith "Cannot convert non-scalar literal %s to bitvector"
-          (PrintValues.literal_to_string l)
+          (Print.literal_to_string l)
 
   let of_constant_expr : Types.constant_expr -> [> T.sint ] t = function
     | { kind = CLiteral lit; _ } -> of_literal lit

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -13,16 +13,10 @@ let variant_for_discr discr adt =
   let open Rustsymex in
   let open Syntax in
   let variants = Crate.as_enum adt in
-  let variants = List.mapi (fun i v -> (i, v)) variants in
   let* variant =
-    match_on variants ~constr:(fun (_, v) ->
-        BV.of_literal v.discriminant ==@ discr)
+    match_on variants ~constr:(fun v -> BV.of_literal v.discriminant ==@ discr)
   in
-  let+ i, variant =
-    of_opt_not_impl "no matching variant for enum discriminant" variant
-  in
-  let vid = Types.VariantId.of_int i in
-  (vid, variant)
+  of_opt_not_impl "no matching variant for enum discriminant" variant
 
 (** Iterator over the fields and offsets of a type; for primitive types, returns
     a singleton iterator for that value. *)
@@ -69,7 +63,7 @@ let iter_fields ?variant ?(meta = Thin) layout (ty : Types.ty) =
   | Arbitrary (variant, _) -> aux ~variant layout.fields
   | Enum (_, variant_layouts) ->
       let variant = Option.get ~msg:"variant required for enum" variant in
-      let fields = variant_layouts.(Types.VariantId.to_int variant) in
+      let _, fields = variant_layouts.(Types.VariantId.to_int variant) in
       aux ~variant fields
 
 let size_of =
@@ -197,30 +191,38 @@ struct
   let variant_of_enum ~offset ty : Types.variant_id ParserMonad.t =
     let open ParserMonad in
     let open ParserMonad.Syntax in
+    let rec exec ?(pp_info = Fmt.nop) :
+        Fields_shape.discriminator -> Types.variant_id ParserMonad.t = function
+      | Known v -> ok v
+      | Branch { offset = tag_ofs; tag_ty; children; fallback } ->
+          let* tag = query (TLiteral tag_ty, offset +!!@ tag_ofs) in
+          let tag = as_base tag_ty tag in
+          let pp_info ft () =
+            Fmt.pf ft ", read %a: %s at offset %a" Typed.ppa tag
+              (Print.literal_type_to_string tag_ty)
+              Typed.ppa offset
+          in
+          let rec aux = function
+            | [] -> exec fallback
+            | (from_, to_, discr) :: rest when Typed.equal from_ to_ ->
+                if%sat tag ==@ from_ then exec ~pp_info discr else aux rest
+            | (from_, to_, discr) :: rest ->
+                if%sat from_ <=@ tag &&@ (tag <=@ to_) then exec ~pp_info discr
+                else aux rest
+          in
+          aux children
+      | Invalid ->
+          let adt = ty_as_adt ty in
+          let adt = Crate.get_adt adt in
+          error
+            (`UBTransmute
+               (Fmt.str "No valid variant for enum %a%a" Crate.pp_name
+                  adt.item_meta.name pp_info ()))
+    in
     let* layout = layout_of ty in
     match layout.fields with
     | Arbitrary (vid, _) -> ok vid
-    | Enum (tag_layout, _) -> (
-        let offset = offset +!!@ tag_layout.offset in
-        let* tag = query (TLiteral tag_layout.ty, offset) in
-        let tag = as_base tag_layout.ty tag in
-        let tags = Array.to_seqi tag_layout.tags |> List.of_seq in
-        let*^ res =
-          match_on tags ~constr:(function
-            | _, None -> Typed.v_false
-            | _, Some t -> tag ==@ t)
-        in
-        match (tag_layout.encoding, res) with
-        | _, Some (vid, _) -> ok (Types.VariantId.of_int vid)
-        | Niche untagged, None -> ok untagged
-        | Direct, None ->
-            let adt = ty_as_adt ty in
-            let adt = Crate.get_adt adt in
-            let msg =
-              Fmt.str "Unmatched discriminant for enum %a: %a" Crate.pp_name
-                adt.item_meta.name Typed.ppa tag
-            in
-            error (`UBTransmute msg))
+    | Enum (discriminator, _) -> exec discriminator
     | Array _ | Primitive -> failwith "Unexpected layout for enum"
 
   (** [decode ~meta ~offset ty] Parses a rust value of type [ty] at the given
@@ -326,15 +328,15 @@ module Encoder (Sptr : Sptr.S) = struct
           ok (Iter.of_list blocks |> Iter.map (fun (v, o) -> (v, offset +!!@ o)))
       | Primitive, _ -> ok (Iter.singleton (value, offset))
       | Array _, _ | Arbitrary (_, _), _ -> chain (iter_fields layout ty)
-      | Enum (tag_layout, _), Enum (disc, _) -> (
+      | Enum (_, layouts), Enum (disc, _) -> (
           let adt = ty_as_adt ty in
-          let* variant, _ = variant_for_discr disc adt in
-          let i = Types.VariantId.to_int variant in
+          let* variant = variant_for_discr disc adt in
+          let variant = variant.id in
           let++ fields = chain (iter_fields ~variant layout ty) in
-          match tag_layout.tags.(i) with
+          match fst layouts.(Types.VariantId.to_int variant) with
           | None -> fields
-          | Some tag ->
-              let offset = tag_layout.offset +!!@ offset in
+          | Some (ofs, tag) ->
+              let offset = ofs +!!@ offset in
               Iter.cons (Int tag, offset) fields)
       | Enum _, _ ->
           Fmt.kstr not_impl "encode: expected enum value for enum type %a" pp_ty
@@ -421,7 +423,7 @@ module Encoder (Sptr : Sptr.S) = struct
     | Tuple _, TAdt { id = TBuiltin TStr; _ } -> ok ()
     (* undefined.validity.enum *)
     | Enum (discr, vs), TAdt adt ->
-        let* _, variant = variant_for_discr discr adt in
+        let* variant = variant_for_discr discr adt in
         List.combine (field_tys variant.fields) vs
         |> iter_list ~f:(fun (ty, v) -> validity ~check_ref ty v f)
     (* undefined.validity.struct *)

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -382,10 +382,10 @@ module Encoder (Sptr : Sptr.S) = struct
       | Len len, LenKind ->
           if is_raw_ptr then ok ()
           else f Usize.(0s <=$@ len) (`UBTransmute "Negative slice length")
-      | VTable _, VTableKind ->
+      | VTable vt, VTableKind ->
           (* TODO: the vtable must always match the trait type of the pointee.
              Will require a new input to this function (?) *)
-          ok ()
+          f (Typed.not (Sptr.is_null vt)) (`UBTransmute "Null vtable pointer")
       | Thin, (LenKind | VTableKind) ->
           f Typed.v_false (`UBTransmute "Thin pointer to DST")
       | (Len _ | VTable _), NoneKind ->

--- a/soteria-rust/scripts/test_exclusions.py
+++ b/soteria-rust/scripts/test_exclusions.py
@@ -32,6 +32,7 @@ KNOWN_ISSUES = {
     "fail/function_calls/arg_inplace_mutate.rs": "We don't check that arguments aren't mutated in place",
     "fail/function_calls/return_pointer_aliasing_read.rs": "We don't check arguments don't alias with the return place",
     "fail/function_calls/return_pointer_aliasing_write.rs": "We don't check arguments don't alias with the return place",
+    "fail/function_calls/return_pointer_on_unwind.rs": "We model printing as a no-op so the dereference doesn't occur",
     "fail/overlapping_assignment.rs": "MIR-only check for assignment overlap (we don't do this atm)",
     "fail/validity/cast_fn_ptr_invalid_caller_ret.rs": "We don't use a fn ptr's type for checking validity",
     "fail/validity/nonzero.rs": "The valid_range_start attribute isn't parsed by Charon?",

--- a/soteria-rust/test/cram/simple.t/assumed_align.rs
+++ b/soteria-rust/test/cram/simple.t/assumed_align.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let x = &mut [0u8; 3];
+    let base_addr = x as *mut _ as usize;
+    let base_addr_aligned = if base_addr % 2 == 0 {
+        base_addr
+    } else {
+        base_addr + 1
+    };
+    let u16_ptr = base_addr_aligned as *mut u16;
+    unsafe {
+        *u16_ptr = 2;
+    }
+}

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -246,10 +246,10 @@ Test thread local statics; the two warnings due to opaque functions are to be ex
         (extract[0-1](V|1|) == 0b00)
   
   => Running thread_local::static_ref_cell...
-  warning: thread_local::static_ref_cell (<time>): unsupported feature, Can't execute function std::sys::thread_local::destructors::list::register: GAst.Missing
+  warning: thread_local::static_ref_cell (<time>): unsupported feature, can't execute function std::sys::thread_local::destructors::list::register, the function's body was not found while compiling; try using a sysroot (with --sysroot)
   
   => Running thread_local::pub_static_from_const_expr...
-  warning: thread_local::pub_static_from_const_expr (<time>): unsupported feature, Can't execute function std::sys::thread_local::destructors::list::register: GAst.Missing
+  warning: thread_local::pub_static_from_const_expr (<time>): unsupported feature, can't execute function std::sys::thread_local::destructors::list::register, the function's body was not found while compiling; try using a sysroot (with --sysroot)
   
   [2]
 
@@ -262,10 +262,10 @@ This test must be run separtely on linux and macos as it yields different error 
         (extract[0-1](V|1|) == 0b00)
   
   => Running thread_local::static_ref_cell...
-  warning: thread_local::static_ref_cell (<time>): unsupported feature, Can't execute function std::sys::thread_local::destructors::linux_like::register: GAst.Missing
+  warning: thread_local::static_ref_cell (<time>): unsupported feature, can't execute function std::sys::thread_local::destructors::linux_like::register, the function's body was not found while compiling; try using a sysroot (with --sysroot)
   
   => Running thread_local::pub_static_from_const_expr...
-  warning: thread_local::pub_static_from_const_expr (<time>): unsupported feature, Can't execute function std::sys::thread_local::destructors::linux_like::register: GAst.Missing
+  warning: thread_local::pub_static_from_const_expr (<time>): unsupported feature, can't execute function std::sys::thread_local::destructors::linux_like::register, the function's body was not found while compiling; try using a sysroot (with --sysroot)
   
   [2]
 

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -493,3 +493,14 @@ Print the callgraph
     n1 -> n16;
     n1 -> n17;
   }
+
+Check we trust addresses for pointer alignment
+  $ soteria-rust exec assumed_align.rs
+  Compiling... done in <time>
+  => Running assumed_align::main...
+  note: assumed_align::main: done in <time>, ran 2 branches
+  PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffb) /\
+        (extract[0-0](V|1|) == 0b0)
+  PC 2: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffb) /\
+        (extract[0-0](V|1|) == 0b1)
+  

--- a/soteria.opam
+++ b/soteria.opam
@@ -44,7 +44,6 @@ depends: [
   "ppx_deriving_yojson"
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "ocaml-lsp-server" {with-dev-setup}
-  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/soteria.opam
+++ b/soteria.opam
@@ -44,6 +44,7 @@ depends: [
   "ppx_deriving_yojson"
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "ocaml-lsp-server" {with-dev-setup}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -637,15 +637,20 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
     | Some false -> else_ () f
     | None ->
         Symex_state.save ();
-        Solver.add_constraints ~simplified:true [ Value.(not guard) ];
+        Solver.add_constraints ~simplified:true [ Value.not guard ];
         let neg_unsat = Solver_result.is_unsat (Solver.sat ()) in
-        if neg_unsat then then_ () f;
         Symex_state.backtrack_n 1;
-        if not neg_unsat then (
+        if neg_unsat then (
           (* Adding this constraint is technically redundant, but it's still
              worth having it in the PC for simplifications. *)
-          Solver.add_constraints [ guard ];
-          else_ () f)
+          Solver.add_constraints ~simplified:true [ guard ];
+          then_ () f)
+        else
+          (* Don't add anything to the PC: [else_] is the general fallback that
+             must cover both cases (per the contract that [then_] and [else_]
+             agree when [guard] holds). Constraining the PC either way would
+             drop paths. *)
+          else_ () f
 
   let branch_on_take_one_ux ?left_branch_name:_ ?right_branch_name:_ guard
       ~then_ ~else_ : 'a t =

--- a/soteria/tests/symex/if_sure.ml
+++ b/soteria/tests/symex/if_sure.ml
@@ -19,6 +19,18 @@ let if_guaranteed =
   let* () = assume [ x >@ one ] in
   if%sure x >@ zero then return 42 else return (-1)
 
+let if_sure_runs_then_with_consistent_pc =
+  let* x = nondet t_int in
+  let* y = nondet t_int in
+  let* () = assume [ (x *@ x) +@ (y *@ y) ==@ zero ] in
+  if%sure x ==@ zero then return 42 else return (-1)
+
+let if_sure_else_preserves_both_arms =
+  let* x = nondet t_int in
+  if%sure x ==@ zero then return 0
+  else if%sat x ==@ zero then return 1
+  else return 2
+
 (* ============================================================================
    Helper
    ============================================================================ *)
@@ -45,6 +57,16 @@ let if_guaranteed_produces_42 () =
   let results = get_results if_guaranteed in
   Alcotest.(check (list int)) "result" [ 42 ] results
 
+let if_sure_runs_then_with_consistent_pc_test () =
+  let results = get_results if_sure_runs_then_with_consistent_pc in
+  Alcotest.(check (list int)) "result" [ 42 ] results
+
+let if_sure_else_preserves_both_arms_test () =
+  let results =
+    get_results if_sure_else_preserves_both_arms |> List.sort Stdlib.compare
+  in
+  Alcotest.(check (list int)) "result" [ 1; 2 ] results
+
 (* ============================================================================
    Test Runner
    ============================================================================ *)
@@ -59,5 +81,9 @@ let () =
           Alcotest.test_case "if_maybe_produces_42" `Quick if_maybe_produces_42;
           Alcotest.test_case "if_guaranteed_produces_42" `Quick
             if_guaranteed_produces_42;
+          Alcotest.test_case "if_sure_runs_then_with_consistent_pc" `Quick
+            if_sure_runs_then_with_consistent_pc_test;
+          Alcotest.test_case "if_sure_else_preserves_both_arms" `Quick
+            if_sure_else_preserves_both_arms_test;
         ] );
     ]


### PR DESCRIPTION
- Bump Charon, and switch to using the Postcard serialization format by default (Obol now only supports that one).
- Check addresses when checking alignment; closes #285
- Support the `exit` libc call (which enables `std::process::exit`)
- Fix `if%sure` being completely wrong

And for my own pleasure: a comparison chart of running Soteria Rust against Kani and Miri on their test suites, before and after the switch to postcard format :) 

| Before | After |
| ----- | ----- |
| <img width="1664" height="662" src="https://github.com/user-attachments/assets/2a04bbb7-d2c0-4068-a0b7-3fbfd6278821" /> | <img width="1632" height="658" src="https://github.com/user-attachments/assets/34052680-23f6-4211-8409-26ffe6a58245" /> |

<img width="816" height="329" src="https://github.com/user-attachments/assets/36745ec5-294c-4e9e-b774-86ca76397097" />

> Superimposed (lighter color is old)