### PR TITLE
Auto-sync website API doc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,5 +167,17 @@ jobs:
         # We do this on linux because linux runners are cheaper.
         if: runner.os == 'linux'
 
+      - name: Build JSON documentation
+        run: make doc-json
+        if: runner.os == 'linux'
+
+      - name: Upload JSON documentation artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: odoc-json
+          path: _build/default/_doc/_html
+          if-no-files-found: error
+        if: runner.os == 'linux'
+
       - name: Opam Cleanup
         run: opam clean -a -r

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,38 @@ jobs:
           destination_dir: ./api/main
 
       - run: echo "Successfully published documentation to https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/api/main"
+
+  publish-doc-json:
+    name: Publish JSON docs to branch
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Download JSON documentation artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: odoc-json
+          path: odoc-json
+
+      - name: Push to docs-json branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./odoc-json
+          publish_branch: docs-json
+          force_orphan: true
+          commit_message: "Update JSON docs from soteria@${{ github.sha }}"
+
+  trigger-website-update:
+    name: Trigger website docs update
+    runs-on: ubuntu-latest
+    needs: publish-doc-json
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Dispatch to website repo
+        run: |
+          gh api repos/soteria-tools/website/dispatches \
+            -f event_type=docs-updated \
+            -F client_payload[sha]=${{ github.sha }}
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_PAT }}

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ doc:
 	chmod u+w _build/default/_doc/_html/odoc.support/odoc.css
 	cp doc/odoc-theme/odoc.css _build/default/_doc/_html/odoc.support/odoc.css
 
+.PHONY: doc-json
+doc-json:
+	$(DUNE) build @doc-json --only-packages soteria
+
 ##### Packaging soteria-c #####
 
 # From inside the package folder one can run:


### PR DESCRIPTION
Add a new CI step; when pushing to main, the JSON docs are pushed to an orphan branch `docs-json`, and a workflow is triggered on the website to pull that branch with the updated docs

Closes #333 
Website docs: https://soteria-tools.com/docs/library