### PR TITLE
Improve aliasing logic in stubs

### DIFF
--- a/soteria-rust/lib/builtins/optim/impl.ml
+++ b/soteria-rust/lib/builtins/optim/impl.ml
@@ -114,13 +114,13 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
   let panic_fmt ~fmt:_ = do_panic ()
   let panic_nounwind_fmt ~fmt:_ ~force_no_backtrace:_ = do_panic ()
 
-  let panicking_begin_panic ~m:_ ~msg =
+  let begin_panic ~m:_ ~msg =
     match msg with Ptr msg -> do_panic ~msg () | _ -> do_panic ()
 
   (* ---- I/O (no-ops) ---- *)
 
   let _eprint ~args:_ = ok ()
-  let stdio__print ~args:_ = ok ()
+  let _print ~args:_ = ok ()
   let print_to ~t:_ ~args:_ ~global_s:_ ~label:_ = ok ()
   let print_to_buffer_if_capture_used ~args:_ = ok Typed.v_true
 end

--- a/soteria-rust/lib/builtins/optim/intf.ml
+++ b/soteria-rust/lib/builtins/optim/intf.ml
@@ -16,6 +16,7 @@ module M (StateM : State.StateM.S) = struct
 
   module type S = sig
     val _eprint : args:rust_val -> unit ret
+    val _print : args:rust_val -> unit ret
 
     val alloc_impl :
       self:full_ptr ->
@@ -29,6 +30,13 @@ module M (StateM : State.StateM.S) = struct
       right:full_ptr ->
       args:rust_val ->
       unit ret
+
+    (** {@markdown[
+          This is the entry point of panicking for the non-format-string variants of
+           panic!() and assert!(). In particular, this is the only entry point that supports
+           arbitrary payloads, not just format strings.
+        ]} *)
+    val begin_panic : m:Types.ty -> msg:rust_val -> unit ret
 
     (** {@markdown[
           Returns `true` if this number is neither infinite nor NaN.
@@ -713,13 +721,6 @@ module M (StateM : State.StateM.S) = struct
     val panic_nounwind_fmt :
       fmt:rust_val -> force_no_backtrace:[< Typed.T.sbool ] Typed.t -> unit ret
 
-    (** {@markdown[
-          This is the entry point of panicking for the non-format-string variants of
-           panic!() and assert!(). In particular, this is the only entry point that supports
-           arbitrary payloads, not just format strings.
-        ]} *)
-    val panicking_begin_panic : m:Types.ty -> msg:rust_val -> unit ret
-
     val print_to :
       t:Types.ty ->
       args:rust_val ->
@@ -731,6 +732,5 @@ module M (StateM : State.StateM.S) = struct
       args:rust_val -> Typed.T.sbool Typed.t ret
 
     val result_unwrap_failed : msg:full_ptr -> error:full_ptr -> unit ret
-    val stdio__print : args:rust_val -> unit ret
   end
 end

--- a/soteria-rust/lib/builtins/optim/optim.ml
+++ b/soteria-rust/lib/builtins/optim/optim.ml
@@ -89,9 +89,9 @@ let fn_pats : (string * fn) list =
     ("core::panicking::panic_fmt", CorePanickingPanicFmt);
     ("core::panicking::panic_nounwind_fmt", CorePanickingPanicNounwindFmt);
     ("core::result::unwrap_failed", CoreResultUnwrapFailed);
-    ("std::io::_print", StdIoStdioPrint);
     ("std::io::stdio::_eprint", StdIoStdioEprint);
     ("std::io::stdio::_print", StdIoStdioPrint);
+    ("std::io::_print", StdIoStdioPrint);
     ("std::io::stdio::print_to", StdIoStdioPrintTo);
     ( "std::io::stdio::print_to_buffer_if_capture_used",
       StdIoStdioPrintToBufferIfCaptureUsed );
@@ -276,14 +276,11 @@ module M (StateM : State.StateM.S) = struct
         let error = as_ptr error in
         let+ () = result_unwrap_failed ~msg ~error in
         Tuple []
-    | StdIoStdioPrint, [], [], [ args ] ->
-        let+ () = stdio__print ~args in
-        Tuple []
     | StdIoStdioEprint, [], [], [ args ] ->
         let+ () = _eprint ~args in
         Tuple []
     | StdIoStdioPrint, [], [], [ args ] ->
-        let+ () = stdio__print ~args in
+        let+ () = _print ~args in
         Tuple []
     | StdIoStdioPrintTo, [ t ], [], [ args; global_s; label ] ->
         let global_s = as_ptr global_s in
@@ -294,10 +291,7 @@ module M (StateM : State.StateM.S) = struct
         let+ ret = print_to_buffer_if_capture_used ~args in
         Int (Typed.BitVec.of_bool ret)
     | StdPanickingBeginPanic, [ m ], [], [ msg ] ->
-        let+ () = panicking_begin_panic ~m ~msg in
-        Tuple []
-    | StdPanickingBeginPanic, [ m ], [], [ msg ] ->
-        let+ () = panicking_begin_panic ~m ~msg in
+        let+ () = begin_panic ~m ~msg in
         Tuple []
     | _, tys, cs, args ->
         Fmt.kstr not_impl

--- a/soteria-rust/lib/builtins/stubs.json
+++ b/soteria-rust/lib/builtins/stubs.json
@@ -19,6 +19,7 @@
     },
     {
       "pattern": "std::thread::functions::available_parallelism",
+      "aliases": ["std::thread::available_parallelism"],
       "extra_args": ["sig"]
     },
     "std::sys::time::unix::Instant::now",
@@ -57,18 +58,13 @@
       "core::f128::_::is_sign_positive",
       "core::f128::_::is_subnormal",
       "std::io::stdio::_eprint",
-      "std::io::stdio::_print",
       {
-        "pattern": "std::io::_print",
-        "alias": "std::io::stdio::_print"
+        "pattern": "std::io::stdio::_print",
+        "aliases": ["std::io::_print"]
       },
       "std::io::stdio::print_to",
       "std::io::stdio::print_to_buffer_if_capture_used",
       "alloc::raw_vec::handle_error",
-      {
-        "pattern": "std::rt::begin_panic",
-        "alias": "std::panicking::begin_panic"
-      },
       "core::panicking::panic",
       "core::panicking::panic_fmt",
       "core::panicking::panic_nounwind_fmt",
@@ -76,7 +72,10 @@
       "alloc::alloc::handle_alloc_error",
       "core::option::unwrap_failed",
       "core::result::unwrap_failed",
-      "std::panicking::begin_panic"
+      {
+        "pattern": "std::panicking::begin_panic",
+        "aliases": ["std::rt::begin_panic"]
+      }
     ]
   },
   "Fixme": {

--- a/soteria-rust/lib/builtins/stubs.schema.json
+++ b/soteria-rust/lib/builtins/stubs.schema.json
@@ -37,7 +37,6 @@
         "patterns": {
           "type": "array",
           "items": { "$ref": "#/$defs/entry" },
-          "required": true,
           "description": "Patterns for functions to stub out in this category."
         },
         "dependencies": {
@@ -71,15 +70,10 @@
               "items": { "$ref": "#/$defs/extra_arg" },
               "uniqueItems": true
             },
-            "alias": {
-              "oneOf": [
-                { "$ref": "#/$defs/pattern" },
-                {
-                  "type": "array",
-                  "items": { "$ref": "#/$defs/pattern" },
-                  "description": "Alternative patterns to match the same stub implementation. Useful for functions that have multiple names because of re-exports. Avoid using this if possible."
-                }
-              ]
+            "aliases": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/pattern" },
+              "description": "Additional Rust paths to register as fn_pats keys pointing to the same stub. Useful for re-exports. The pattern itself is what resolves the signature."
             },
             "include": {
               "oneOf": [

--- a/soteria-rust/lib/builtins/system/system.ml
+++ b/soteria-rust/lib/builtins/system/system.ml
@@ -22,6 +22,8 @@ let fn_pats : (string * fn) list =
     ("std::sys::time::unix::Instant::now", StdSysTimeUnixInstantNow);
     ( "std::thread::functions::available_parallelism",
       StdThreadFunctionsAvailableParallelism );
+    ( "std::thread::available_parallelism",
+      StdThreadFunctionsAvailableParallelism );
   ]
 
 module M (StateM : State.StateM.S) = struct

--- a/soteria-rust/scripts/stubs.py
+++ b/soteria-rust/scripts/stubs.py
@@ -444,6 +444,7 @@ class ItemInfo(TypedDict):
 class StubInfo(ItemInfo):
     variant_name: str
     is_dummy: bool
+    aliases: list[str]
 
 
 def make_args_and_tys(
@@ -1069,6 +1070,7 @@ def generate_custom_stubs() -> None:
                     "rust_path": pattern.pattern,
                     "variant_name": variant_name,
                     "is_dummy": False,
+                    "aliases": list(pattern.aliases),
                 }
             )
 
@@ -1099,6 +1101,7 @@ def generate_custom_stubs() -> None:
                     "types": [],
                     "consts": [],
                     "ret": ("unknown", None),
+                    "aliases": list(pattern.aliases),
                 }
             )
 
@@ -1119,6 +1122,8 @@ def generate_custom_stubs() -> None:
         for info in infos:
             fn_variants.add(info["variant_name"])
             fn_map_entries += f"(\"{info['rust_path']}\", {info['variant_name']});"
+            for alias in info.get("aliases", []):
+                fn_map_entries += f"(\"{alias}\", {info['variant_name']});"
             args_and_tys = make_args_and_tys(info)
             intf_entries.add(make_val_entry(info, args_and_tys))
 

--- a/soteria-rust/scripts/stubs.py
+++ b/soteria-rust/scripts/stubs.py
@@ -114,7 +114,7 @@ TypeNever = Literal["Never"]
 
 
 class TypeArray(TypedDict):
-    Array: tuple[UniqueType, UniqueType]
+    Array: tuple["UniqueType", "UniqueType"]
 
 
 Type = TypeAdt | TypeLiteral | TypeTypeVar | TypeRef | TypePtr | TypeNever | TypeArray
@@ -845,8 +845,8 @@ class Pattern:
                     raise ValueError(
                         f"Invalid extra '{extra}' in pattern '{self.pattern}'"
                     )
-            if "alias" in entry:
-                self.aliases = json_as_str_list(entry["alias"])
+            if "aliases" in entry:
+                self.aliases = json_as_str_list(entry["aliases"])
             if "include" in entry:
                 self.include = json_as_str_list(entry["include"])
 
@@ -865,7 +865,7 @@ class Pattern:
         return meta_args
 
     def include_pats(self) -> list[str]:
-        return [self.pattern, *self.aliases, *self.include]
+        return [self.pattern, *self.include]
 
 
 class CategorySpec:
@@ -1002,11 +1002,6 @@ def generate_custom_stubs() -> None:
                     missing_patterns.remove(pattern)
                     categories[category].append((pattern, fun))
                     break
-                for alias in pattern.aliases:
-                    if matches_pattern(name, alias):
-                        missing_patterns.remove(pattern)
-                        categories[category].append((pattern, fun))
-                        break
 
     if missing_patterns:
         pprint(
@@ -1116,14 +1111,13 @@ def generate_custom_stubs() -> None:
 
         intf_entries: set[str] = set()
         fn_variants: set[str] = set()
-        fn_map_entries = ""
+        fn_map_pairs: dict[str, str] = {}
         eval_entries = ""
 
         for info in infos:
             fn_variants.add(info["variant_name"])
-            fn_map_entries += f"(\"{info['rust_path']}\", {info['variant_name']});"
-            for alias in info.get("aliases", []):
-                fn_map_entries += f"(\"{alias}\", {info['variant_name']});"
+            for path in [info["rust_path"], *info.get("aliases", [])]:
+                fn_map_pairs.setdefault(path, info["variant_name"])
             args_and_tys = make_args_and_tys(info)
             intf_entries.add(make_val_entry(info, args_and_tys))
 
@@ -1149,6 +1143,9 @@ def generate_custom_stubs() -> None:
 
         intf_entries_str = "\n\n".join(sorted(intf_entries, key=intf_entry_key))
         fn_variants_str = " | ".join(sorted(fn_variants))
+        fn_map_entries = "".join(
+            f'("{path}", {variant});' for path, variant in fn_map_pairs.items()
+        )
 
         # intf.ml — generated module type that impl.ml must satisfy
         intf_generated = f"""


### PR DESCRIPTION
## Summary

  - Rework how `aliases` work in `stubs.json`: an alias is now a list (`aliases: [...]`) of extra `fn_pats` keys that route to the same stub variant as the canonical `pattern`. Signature resolution is driven only by the `pattern`.
  - Dedupe `fn_pats` entries so a path appearing as both a pattern and another entry's alias yields a single mapping.
  - Drop the now-redundant standalone `std::panicking::begin_panic` and `std::io::stdio::_print` entries; merge them into the aliases of their respective canonical patterns.
  - Fix the JSON schema: replace the old `alias` (string|array) definition with a list-only `aliases`, and remove an invalid `"required": true` inside the `patterns` property (it now validates against jsonschema spec draft 2020-12).
  - Quote the `tuple[UniqueType, UniqueType]` forward reference so `stubs.py` parses on Python 3.11 (it only worked on Python 3.14+)
  - Rename the corresponding stub functions in `optim/impl.ml` (`stdio__print` → `_print`, `panicking_begin_panic` → `begin_panic`) since `unique_name` no longer needs to disambiguate them.