### PR TITLE
Minor doc improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
         run: make ocaml
       - name: Check formatting
         run: make ocaml-format-check
+      - name: Check mld formatting
+        run: find . -name "*.mld" -not -path "./_opam/*" -not -path "./_build/*" -exec ocamlformat --doc --check {} \;
       - name: Check that opam files were up to date
         run: make check-opam-files
 

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_benchmarks: ${{ steps.parse.outputs.run_benchmarks }}
-      build_doc:      ${{ steps.parse.outputs.build_doc }}
-      run_bv_fuzzer:  ${{ steps.parse.outputs.run_bv_fuzzer }}
-      any:            ${{ steps.parse.outputs.any }}
-      needs_ci:       ${{ steps.parse.outputs.needs_ci }}
+      build_doc: ${{ steps.parse.outputs.build_doc }}
+      run_bv_fuzzer: ${{ steps.parse.outputs.run_bv_fuzzer }}
+      any: ${{ steps.parse.outputs.any }}
+      needs_ci: ${{ steps.parse.outputs.needs_ci }}
     steps:
       - id: parse
         uses: actions/github-script@v9
@@ -203,7 +203,7 @@ jobs:
             const lines = commands.map(c => {
               const ok = c.result === 'success';
               if (!ok) allOk = false;
-              return `- ${ok ? '✅' : '❌'} ${ok ? c.ok : c.fail}.`;
+              return `- ${ok ? '✅' : '❌'} ${ok ? c.ok : c.fail}`;
             });
             if (process.env.DISPATCH_RESULT !== 'success') {
               lines.unshift('- ❌ Could not locate the PR build; commands did not run.');

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ ocaml:
 ocaml-format-check:
 	$(DUNE) build @fmt
 
+.PHONY: mld-format
+mld-format:
+	find . -name "*.mld" -not -path "./_opam/*" -not -path "./_build/*" -exec $(OPAMX) ocamlformat --doc --inplace {} \;
+
 .PHONY: check-opam-files
 check-opam-files:
 	@if git diff --name-only HEAD | grep -q '\.opam$$'; then \

--- a/soteria-c/lib/abductor.ml
+++ b/soteria-c/lib/abductor.ml
@@ -11,7 +11,7 @@ let default_abductor_fuel =
   Soteria.Symex.Fuel_gauge.{ steps = Finite 1000; branching = Finite 4 }
 
 (** Generates summaries for a function given a function definitions. Has to be
-    run within {{!Soteria.Stats.As_ctx.with_stats}[with_stats]} *)
+    run within {{!Soteria.Stats.As_ctx.with_}[Stats.As_ctx.with_]} *)
 let generate_summaries_for (fundef : fundef) =
   let open Syntaxes.List in
   let fid, (floc, _, _, _, _) = fundef in

--- a/soteria-c/lib/abductor.ml
+++ b/soteria-c/lib/abductor.ml
@@ -11,7 +11,7 @@ let default_abductor_fuel =
   Soteria.Symex.Fuel_gauge.{ steps = Finite 1000; branching = Finite 4 }
 
 (** Generates summaries for a function given a function definitions. Has to be
-    run within {{!Soteria.Stats.As_ctx.with_stats}with_stats} *)
+    run within {{!Soteria.Stats.As_ctx.with_stats}[with_stats]} *)
 let generate_summaries_for (fundef : fundef) =
   let open Syntaxes.List in
   let fid, (floc, _, _, _, _) = fundef in

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -152,7 +152,7 @@ module D_abstr = Soteria.Data.Abstr.M (DecayMap.SM)
 
 (** The base type of pointers, permitting simple operations on the pointer type.
     The majority of relevant operations are exposed via the state monad's
-    pointer module, {!Rust_state_m.S.Sptr}. *)
+    pointer module, {{!State.StateM.S.Sptr}Sptr}. *)
 module type S = sig
   (** pointer type *)
   type t [@@mixins D_abstr.S_with_syn]

--- a/soteria/lib/data/s_map.mli
+++ b/soteria/lib/data/s_map.mli
@@ -1,5 +1,5 @@
 (** A symbolic map abstraction. The main function of the
-    {{!S.S}symbolic map module type} is {{!S.S.find_opt}find_opt}, which allows
+    {{!S.S}symbolic map module type} is {{!S.S.find_opt}[find_opt]}, which allows
     symbolically looking up a key in the map (possibly branching), and returns
     the value at that key if any, along with the key to be used for future
     {i concrete} operations on the map. *)
@@ -11,7 +11,7 @@ module S = S_map_intf.M
 module Mk_concrete_key (Symex : Symex.Base) (K : Soteria_std.Ordered_type.S) :
   Key(Symex).S with type t = K.t
 
-(** Makes a symbolic map. The algorithm for {{!S.S.find_opt}find_opt} will first
+(** Makes a symbolic map. The algorithm for {{!S.S.find_opt}[find_opt]} will first
     look for a syntactic match, and otherwise attempt checking for equality on
     all keys. *)
 module Make (Symex : Symex.Base) (Key : Key(Symex).S) : S(Symex)(Key).S
@@ -23,9 +23,9 @@ module Make_patricia_tree
     (Symex : Symex.Base)
     (Key : Key(Symex).S_patricia_tree) : S(Symex)(Key).S
 
-(** Makes a symbolic map. The algorithm for {{!S.S.find_opt}find_opt} will first
+(** Makes a symbolic map. The algorithm for {{!S.S.find_opt}[find_opt]} will first
     look for a syntactic match. If none is found, it will check if the given key
-    is {{!Key.S.distinct}distinct} from all other existing keys (in which case
+    is {{!Key.S.distinct}[distinct]} from all other existing keys (in which case
     [None] is returned) before iterating over all entries. *)
 module Direct_access (Symex : Symex.Base) (Key : Key(Symex).S) : S(Symex)(Key).S
 

--- a/soteria/lib/data/s_map.mli
+++ b/soteria/lib/data/s_map.mli
@@ -1,8 +1,8 @@
 (** A symbolic map abstraction. The main function of the
-    {{!S.S}symbolic map module type} is {{!S.S.find_opt}[find_opt]}, which allows
-    symbolically looking up a key in the map (possibly branching), and returns
-    the value at that key if any, along with the key to be used for future
-    {i concrete} operations on the map. *)
+    {{!S.S}symbolic map module type} is {{!S.S.find_opt}[find_opt]}, which
+    allows symbolically looking up a key in the map (possibly branching), and
+    returns the value at that key if any, along with the key to be used for
+    future {i concrete} operations on the map. *)
 
 module Key = S_map_intf.Key
 module S = S_map_intf.M
@@ -11,9 +11,9 @@ module S = S_map_intf.M
 module Mk_concrete_key (Symex : Symex.Base) (K : Soteria_std.Ordered_type.S) :
   Key(Symex).S with type t = K.t
 
-(** Makes a symbolic map. The algorithm for {{!S.S.find_opt}[find_opt]} will first
-    look for a syntactic match, and otherwise attempt checking for equality on
-    all keys. *)
+(** Makes a symbolic map. The algorithm for {{!S.S.find_opt}[find_opt]} will
+    first look for a syntactic match, and otherwise attempt checking for
+    equality on all keys. *)
 module Make (Symex : Symex.Base) (Key : Key(Symex).S) : S(Symex)(Key).S
 
 (** Same as {!Make}, but backed by a
@@ -23,10 +23,10 @@ module Make_patricia_tree
     (Symex : Symex.Base)
     (Key : Key(Symex).S_patricia_tree) : S(Symex)(Key).S
 
-(** Makes a symbolic map. The algorithm for {{!S.S.find_opt}[find_opt]} will first
-    look for a syntactic match. If none is found, it will check if the given key
-    is {{!Key.S.distinct}[distinct]} from all other existing keys (in which case
-    [None] is returned) before iterating over all entries. *)
+(** Makes a symbolic map. The algorithm for {{!S.S.find_opt}[find_opt]} will
+    first look for a syntactic match. If none is found, it will check if the
+    given key is {{!Key.S.distinct_seq}distinct} from all other existing keys
+    (in which case [None] is returned) before iterating over all entries. *)
 module Direct_access (Symex : Symex.Base) (Key : Key(Symex).S) : S(Symex)(Key).S
 
 (** Same as {!Direct_access}, but backed by a

--- a/soteria/lib/solvers/solver_interface.ml
+++ b/soteria/lib/solvers/solver_interface.ml
@@ -1,13 +1,13 @@
 (** The interface that SMT solver backends must implement to be used with the
     symbolic execution engine. This signature assumes the solver is mutable.
 
-    This is different from {{!Symex.Solver.Mutable_incremental}Symex.Solver},
+    This is different from {{!Symex.Solver.Mutable_incremental}[Symex.Solver]},
     which represents a solver at a more abstract level (where a solver is
     broadly a path condition). Here instead, a solver is an interface into an
     actual SMT-LIB solver, and exposes the usual operations to declare
     variables, assert values, and check satisfiability.
 
-    To make usage of solvers easier in {{!Soteria_std.Reversible}Reversible}
+    To make usage of solvers easier in {{!Soteria_std.Reversible}[Reversible]}
     contexts, this signature also includes the usual reversible functions.
     {{!Soteria_std.Reversible.Mutable.save}[save]} is [push 1], and
     {{!Soteria_std.Reversible.Mutable.backtrack_n}[backtrack_n]} is [pop n]. *)

--- a/soteria/lib/stats/stats.mli
+++ b/soteria/lib/stats/stats.mli
@@ -158,7 +158,7 @@ val output : t -> unit
 module As_ctx : sig
   (** Module for manipulating statistics as a context using algebraic effects
       (that are hidden). All calls to any function in this module should happen
-      only inside a function wrapped with {!val-with_stats}, ensuring that the
+      only inside a function wrapped with {!val:with_}, ensuring that the
       statistics are properly passed around. *)
 
   include Effects.Bookkeeping with type arg := unit and type t := t

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -350,9 +350,9 @@ module type S = sig
         handled and ignored by this function (default).
       - [flamegraph] specifies whether a flamegraph should be created from this
         symbolic process or if it should be ignored (default). The value passed
-        in the {{!effect_handling.Dump}[Dump]} variant is the name of the created
-        file (while the {{!Profiling.Config}configuration} for flamegraphs
-        specifies the directory in which flamegraphs are saved).
+        in the {{!effect_handling.Dump}[Dump]} variant is the name of the
+        created file (while the {{!Profiling.Config}configuration} for
+        flamegraphs specifies the directory in which flamegraphs are saved).
 
       @raise Symex.Gave_up
         if the symbolic process calls [give_up] and the mode is
@@ -369,9 +369,9 @@ module type S = sig
     include module type of Result
 
     (** Same as {{!Symex.S.run}[run]}, but receives a symbolic process that
-        returns a {!Symex.Compo_res.t} and maps the result to an
-        {!Symex.Or_gave_up.t}, potentially adding any path that gave up to the
-        list. *)
+        returns a {{!Soteria_std.Compo_res.t}[Compo_res.t]} and maps the result
+        to an {{!Symex.Or_gave_up.t}[Or_gave_up.t]}, potentially adding any path
+        that gave up to the list. *)
     val run :
       ?flamegraph:string effect_handling ->
       ?stats:unit effect_handling ->

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -350,7 +350,7 @@ module type S = sig
         handled and ignored by this function (default).
       - [flamegraph] specifies whether a flamegraph should be created from this
         symbolic process or if it should be ignored (default). The value passed
-        in the {{!effect_handling.Dump}Dump} variant is the name of the created
+        in the {{!effect_handling.Dump}[Dump]} variant is the name of the created
         file (while the {{!Profiling.Config}configuration} for flamegraphs
         specifies the directory in which flamegraphs are saved).
 
@@ -368,7 +368,7 @@ module type S = sig
   module Result : sig
     include module type of Result
 
-    (** Same as {{!Symex.S.run}run}, but receives a symbolic process that
+    (** Same as {{!Symex.S.run}[run]}, but receives a symbolic process that
         returns a {!Symex.Compo_res.t} and maps the result to an
         {!Symex.Or_gave_up.t}, potentially adding any path that gave up to the
         list. *)

--- a/soteria/lib/symex/value.ml
+++ b/soteria/lib/symex/value.ml
@@ -6,9 +6,10 @@ module type Expr = sig
       ['a v]. Syntactic objects, unlike semantic values, can contain "free"
       variables and operations such as substitution have meaning.
 
-      [Expr.t] objects are used in, for instance, assertions ({!Logic}). They
-      can be substituted through a {!Symex.S.Producer} monad or learned through
-      a {!Symex.S.Consumer} monad. *)
+      [Expr.t] objects are used in, for instance, assertions
+      ({{!Soteria.Logic}[Logic]}). They can be substituted through a
+      {{!Soteria.Symex.S.Producer}[Producer]} monad or learned through a
+      {{!Soteria.Symex.S.Consumer}[Consumer]} monad. *)
 
   type 'a ty
   type 'a v
@@ -69,8 +70,8 @@ module type S = sig
   (** The type of symbolic values, parameterized by their type. For example,
       [sbool t] represents a symbolic boolean.
 
-      Values also expose an {!Expr} module for their syntactic representation.
-  *)
+      Values also expose an {!module:Expr} module for their syntactic
+      representation. *)
   type +'a t
 
   (** Type of values. *)

--- a/soteria/smt/soteria_smt.ml
+++ b/soteria/smt/soteria_smt.ml
@@ -355,7 +355,7 @@ type solver = {
 (** Send a command and verify the solver acknowledged it with [success].
 
     This goes through {!field:ack_command}, so it is synchronous: prefer
-    {!command} on the hot path where the acknowledgement can be deferred. *)
+    {!val:command} on the hot path where the acknowledgement can be deferred. *)
 let ack_command (s : solver) cmd =
   match s.ack_command cmd with
   | Atom "success" -> ()

--- a/soteria/tutorial/core_symex.mld
+++ b/soteria/tutorial/core_symex.mld
@@ -1,6 +1,7 @@
 {0 Soteria Symbolic Execution Tutorial}
 
-Welcome to the Soteria tutorial! This tutorial will guide you through the basics of writing a symbolic execution engine.
+Welcome to the Soteria tutorial! This tutorial will guide you through the basics
+of writing a symbolic execution engine.
 
 Today you'll be learning how to:
 - {{!instantiate}Instantiate} the {{!Soteria.Symex.Make}Symex} functor
@@ -11,27 +12,38 @@ Today you'll be learning how to:
 
 {2:instantiate Instantiating the [Symex.Make] functor}
 
-The main utility of the Soteria library is the {{!Soteria.Symex.Make}[Symex.Make]} functor, which provides the necessary infrastructure to define and run a symbolic execution engine.
-To instantiate it, you need to provide a {{!Soteria.Symex.Solver.Mutable_incremental}[Solver]} module, which defines {e symbolic values} and the solver interface to decide whether a symbolic expression of type {{!Soteria.Symex.Value.S.sbool}[Value.sbool]} is satisfiable.
+The main utility of the Soteria library is the
+{{!Soteria.Symex.Make}[Symex.Make]} functor, which provides the necessary
+infrastructure to define and run a symbolic execution engine. To instantiate it,
+you need to provide a {{!Soteria.Symex.Solver.Mutable_incremental}[Solver]}
+module, which defines {e symbolic values} and the solver interface to decide
+whether a symbolic expression of type
+{{!Soteria.Symex.Value.S.sbool}[Value.sbool]} is satisfiable.
 
 {@ocaml[
-module Symex = Symex.Make (Tiny_solver.Z3_solver)
+  module Symex = Symex.Make (Tiny_solver.Z3_solver)
 ]}
-
 
 {2:return Write your first symbolic process}
 
-Soteria is a library made for writing {e symbolic processes}. A symbolic process is a value of the type {{!Soteria.Symex.S.t}[Symex.t]}, which is effectively a symbolic computation waiting to be executed. It is an execution that may depend on {e symbolic variables}, and therefore may branch into multiple paths depending on the values of these variables.
+Soteria is a library made for writing {e symbolic processes}. A symbolic process
+is a value of the type {{!Soteria.Symex.S.t}[Symex.t]}, which is effectively a
+symbolic computation waiting to be executed. It is an execution that may depend
+on {e symbolic variables}, and therefore may branch into multiple paths
+depending on the values of these variables.
 
-The simplest such process is the symbolic process just returns a single branch with a given value, say the integer [0].
+The simplest such process is the symbolic process just returns a single branch
+with a given value, say the integer [0].
 
 {@ocaml[
-# Symex.return 0;;
-- : int Symex.t = <abstr>
+  # Symex.return 0;;
+  - : int Symex.t = <abstr>
 ]}
 
-This process has type [int Symex.t], that is, a symbolic process that returns a value of type [int]. Again, this is a symbolic process, so it is {e not yet executed}.
-Executing a symbolic process is done using the {{!Soteria.Symex.S.run}[run]} function:
+This process has type [int Symex.t], that is, a symbolic process that returns a
+value of type [int]. Again, this is a symbolic process, so it is
+{e not yet executed}. Executing a symbolic process is done using the
+{{!Soteria.Symex.S.run}[run]} function:
 {@ocaml[
 # Symex.run
 - : ?flamegraph:string Symex.effect_handling ->
@@ -43,25 +55,36 @@ Executing a symbolic process is done using the {{!Soteria.Symex.S.run}[run]} fun
 
 The function receives a symbolic process to execute, an {{!Soteria.Symex.Approx.t}approximation mode}; an optional {{!Soteria.Symex.Fuel_gauge.t}fuel gauge} should the user desire to limit the breadth or depth of execution; and an optional path to write down a flamegraph {{:https://github.com/brendangregg/flamegraph}`.collapsed`} file (will not generate any flamegraph if [None]) summarising where is execution time spent across the analysed functions. It returns a list of branches, where each branch is a pair of the value returned by the symbolic process and the path condition that leads to this branch (in the form of a list of expressions). Note that the path condition uses {{!Soteria.Symex.Value.Expr}[Value.Expr]}, as this path condition is {e syntactic} now that it has left the context of the symbolic process.
 
-For instance, let's execute the symbolic process we just created, using the {{!Soteria.Symex.Approx.OX}over-approximation} mode, and without providing any fuel limitation. Both fuel and approximation mode are irrelevant for the simple processes we will be writing in this tutorial, and become interesting when analyzing real-world programs.
+For instance, let's execute the symbolic process we just created, using the
+{{!Soteria.Symex.Approx.OX}over-approximation} mode, and without providing any
+fuel limitation. Both fuel and approximation mode are irrelevant for the simple
+processes we will be writing in this tutorial, and become interesting when
+analyzing real-world programs.
 
 {@ocaml[
 # Symex.return 0 |> Symex.run ~mode:OX;;
 - : (int * Typed.Expr.t list) list = [(0, [])]]}
 ]}
 
-As expected the result of the symbolic process is a single branch with the value [0] and an empty path condition [[]], which means that there is no condition for taking this branch, i.e., it is always taken.
+As expected the result of the symbolic process is a single branch with the value
+[0] and an empty path condition [[]], which means that there is no condition for
+taking this branch, i.e., it is always taken.
 
 {2:nondet Introducing fresh symbolic values}
 
-A core necessity of symbolic execution is the ability to introduce fresh symbolic values. Soteria provides a convenient way to do this using the {{!Soteria.Symex.S.nondet}[nondet]} function, which creates a fresh symbolic value of a given type. It is called {e nondet} because it "abstracts over" a nondeterministic choice of any value of that given type:
+A core necessity of symbolic execution is the ability to introduce fresh
+symbolic values. Soteria provides a convenient way to do this using the
+{{!Soteria.Symex.S.nondet}[nondet]} function, which creates a fresh symbolic
+value of a given type. It is called {e nondet} because it "abstracts over" a
+nondeterministic choice of any value of that given type:
 
 {@ocaml[
-# Symex.nondet;;
-- : 'a Typed.ty -> 'a Typed.t Symex.t = <fun>
+  # Symex.nondet;;
+  - : 'a Typed.ty -> 'a Typed.t Symex.t = <fun>
 ]}
 
-{{!Soteria.Symex.S.nondet}[nondet]} receives a type [ty] and returns a symbolic process that produces a fresh symbolic value of that type.
+{{!Soteria.Symex.S.nondet}[nondet]} receives a type [ty] and returns a symbolic
+process that produces a fresh symbolic value of that type.
 
 Let's run this process:
 
@@ -70,38 +93,46 @@ Let's run this process:
 - : ([> Typed.T.sint ] Typed.t * Typed.Expr.t list) list = [(V|1|, [])]
 ]}
 
-We obtain a single branch with the fresh symbolic integer denoted [V|1|], which is a pretty-printing for the symbolic variable named "1". Again, the path condition is empty, meaning that this branch is always taken.
-
+We obtain a single branch with the fresh symbolic integer denoted [V|1|], which
+is a pretty-printing for the symbolic variable named "1". Again, the path
+condition is empty, meaning that this branch is always taken.
 
 {2:bind Compose symbolic processes together}
 
-On their own, [nondet] and [return] are not very useful. What we really want is to compose symbolic processes together in order to build more complex symbolic computations.
-Without going into details about monads, Soteria provides a {{:https://ocaml.org/manual/5.0/bindingops.html#s:binding-operators}binding operators} ([let*]) to do exactly that.
+On their own, [nondet] and [return] are not very useful. What we really want is
+to compose symbolic processes together in order to build more complex symbolic
+computations. Without going into details about monads, Soteria provides a
+{{:https://ocaml.org/manual/5.0/bindingops.html#s:binding-operators}binding
+ operators} ([let*]) to do exactly that.
 
 {@ocaml[
-(* Puts the let* operator in scope *)
-open Symex.Syntax
+  (* Puts the let* operator in scope *)
+  open Symex.Syntax
 
-(* Puts infix operators for symbolic values in scope.
-   These operators are postifixed with "@" to avoid
-   conflicts with the standard library. *)
-open Typed.Infix
+  (* Puts infix operators for symbolic values in scope. These operators are
+     postifixed with "@" to avoid conflicts with the standard library. *)
+  open Typed.Infix
 
-(* Puts the symbolic integer syntax in scope,
-   so that we can write "2s" for the symbolic integer 2,
-   instead of "Typed.int 2" *)
-open Typed.Syntax
+  (* Puts the symbolic integer syntax in scope, so that we can write "2s" for
+     the symbolic integer 2, instead of "Typed.int 2" *)
+  open Typed.Syntax
 ]}
 
 {@ocaml[
-# let process =
-  let* x = Symex.nondet Typed.t_int in
-  Symex.return (x +@ 2s);;
-val process : ([> Typed.T.sint ] as '_weak1) Typed.t Symex.t = <abstr>
+  # let process =
+    let* x = Symex.nondet Typed.t_int in
+    Symex.return (x +@ 2s);;
+  val process : ([> Typed.T.sint ] as '_weak1) Typed.t Symex.t = <abstr>
 ]}
 
-The above code snippet creates a symbolic process that first introduces a fresh symbolic variable [x] of type [int], and then returns the symbolic expression [x +@ 2s].
-Note how familiar the syntax is: effectively, this just looks like regular OCaml code. Using the [let*] operator, the value [Symex.nondet Typed.t_int] (which is of type [int Symex.t]) is "unwrapped", and [x] is not the process, but the {e value returned by the process}. Effectively, Soteria takes care of the symbolic execution under the hood, so that you can write code that looks like regular OCaml code.
+The above code snippet creates a symbolic process that first introduces a fresh
+symbolic variable [x] of type [int], and then returns the symbolic expression
+[x +@ 2s]. Note how familiar the syntax is: effectively, this just looks like
+regular OCaml code. Using the [let*] operator, the value
+[Symex.nondet Typed.t_int] (which is of type [int Symex.t]) is "unwrapped", and
+[x] is not the process, but the {e value returned by the process}. Effectively,
+Soteria takes care of the symbolic execution under the hood, so that you can
+write code that looks like regular OCaml code.
 
 Running this symbolic process yields a single branch with no path condition:
 
@@ -111,47 +142,60 @@ Running this symbolic process yields a single branch with no path condition:
 [((V|1| + 2), [])]
 ]}
 
-We can now build more complex symbolic processes, and make use of other basic operations such as {{!Soteria.Symex.S.assume}[assume]} and {{!Soteria.Symex.S.assert_}[assert_]}.
+We can now build more complex symbolic processes, and make use of other basic
+operations such as {{!Soteria.Symex.S.assume}[assume]} and
+{{!Soteria.Symex.S.assert_}[assert_]}.
 
-For instance, we can create a symbolic process that introduces a nondeterministic integer, and then asserts that this integer is positive:
+For instance, we can create a symbolic process that introduces a
+nondeterministic integer, and then asserts that this integer is positive:
 
 {@ocaml[
-# let process =
-  let* x = Symex.nondet Typed.t_int in
-  Symex.assert_ (x >@ 0s);;
-val process : bool Symex.t = <abstr>
+  # let process =
+    let* x = Symex.nondet Typed.t_int in
+    Symex.assert_ (x >@ 0s);;
+  val process : bool Symex.t = <abstr>
 
 # Symex.run ~mode:OX process;;
 - : (bool * Typed.Expr.t list) list = [(false, [])]
 ]}
 
-This process returns a single branch with the value [false], as it is not *always* guaranteed that the symbolic integer [x] is positive. Now, if we add an assumption that, say, [x] is greater than 10, we get a different result:
+This process returns a single branch with the value [false], as it is not
+*always* guaranteed that the symbolic integer [x] is positive. Now, if we add an
+assumption that, say, [x] is greater than 10, we get a different result:
 
 {@ocaml[
-# let process =
-  let* x = Symex.nondet Typed.t_int in
-  let* () = Symex.assume [ x >@ 10s ] in
-  Symex.assert_ (x >@ 0s);;
-val process : bool Symex.t = <abstr>
+  # let process =
+    let* x = Symex.nondet Typed.t_int in
+    let* () = Symex.assume [ x >@ 10s ] in
+    Symex.assert_ (x >@ 0s);;
+  val process : bool Symex.t = <abstr>
 
 # Symex.run ~mode:OX process;;
 - : (bool * Typed.Expr.t list) list = [(true, [(11 <= V|1|)])]
 ]}
 
-This time, the assertion is satisfied, and the symbolic process returns a single branch with value [true], and a path condition that corresponds to the assumption we made, i.e. that [V|1|] (the symbolic integer) is greater than or equal to 11 (which is equivalent to the assumption we wrote).
+This time, the assertion is satisfied, and the symbolic process returns a single
+branch with value [true], and a path condition that corresponds to the
+assumption we made, i.e. that [V|1|] (the symbolic integer) is greater than or
+equal to 11 (which is equivalent to the assumption we wrote).
 
 {2:branching Introduce branching in symbolic processes}
 
-A more interesting symbolic process is one that introduces conditional branching. For instance, the following process introduces a nondeterministic integer, and then branches on whether this integer is even or odd. Soteria provides convenient syntactic sugar (accessed when we opened {{!Soteria.Symex.S.Syntax}Symex.Syntax}), which overrides the standard OCaml [if] statement to work with symbolic values:
+A more interesting symbolic process is one that introduces conditional
+branching. For instance, the following process introduces a nondeterministic
+integer, and then branches on whether this integer is even or odd. Soteria
+provides convenient syntactic sugar (accessed when we opened
+{{!Soteria.Symex.S.Syntax}Symex.Syntax}), which overrides the standard OCaml
+[if] statement to work with symbolic values:
 
 {@ocaml[
-# let process =
-    let* x = Symex.nondet Typed.t_int in
-    if%sat (x %@ 2s) ==@ 0s then
-      Symex.return (Fmt.str "%a is even" Typed.ppa x)
-    else
-      Symex.return (Fmt.str "%a is odd" Typed.ppa x)
-val process : string Symex.t = <abstr>
+  # let process =
+      let* x = Symex.nondet Typed.t_int in
+      if%sat (x %@ 2s) ==@ 0s then
+        Symex.return (Fmt.str "%a is even" Typed.ppa x)
+      else
+        Symex.return (Fmt.str "%a is odd" Typed.ppa x)
+  val process : string Symex.t = <abstr>
 
 # Symex.run ~mode:OX process;;
 - : (string * Typed.Expr.t list) list =
@@ -159,9 +203,14 @@ val process : string Symex.t = <abstr>
  ("V|1| is odd", [(0 != (V|1| mod 2))])]
 ]}
 
-
-As expected, the symbolic process returns two branches, one for the case where the symbolic integer is even, and one for the case where it is odd. In each case, the path condition is a symbolic expression that describes the corresponding condition on the symbolic variable created (called [V|1|] here).
+As expected, the symbolic process returns two branches, one for the case where
+the symbolic integer is even, and one for the case where it is odd. In each
+case, the path condition is a symbolic expression that describes the
+corresponding condition on the symbolic variable created (called [V|1|] here).
 
 {2 That's it!}
 
-That's it, that's about all there is to know about the core Soteria symbolic execution. Of course, Soteria provides many more features, such as convenient symbolic-ready data-structure, logging facilities for symbolic processes, and more. You can find more information in the rest of this documentation.
+That's it, that's about all there is to know about the core Soteria symbolic
+execution. Of course, Soteria provides many more features, such as convenient
+symbolic-ready data-structure, logging facilities for symbolic processes, and
+more. You can find more information in the rest of this documentation.

--- a/soteria/tutorial/core_symex.mld
+++ b/soteria/tutorial/core_symex.mld
@@ -45,15 +45,26 @@ value of type [int]. Again, this is a symbolic process, so it is
 {e not yet executed}. Executing a symbolic process is done using the
 {{!Soteria.Symex.S.run}[run]} function:
 {@ocaml[
-# Symex.run
-- : ?flamegraph:string Symex.effect_handling ->
-    ?stats:unit Symex.effect_handling ->
-    ?fuel:Symex.Fuel_gauge.t ->
-    mode:Symex.Approx.t -> 'a Symex.t -> ('a * Typed.Expr.t list) list
-= <fun>
+  # Symex.run
+  - : ?flamegraph:string Symex.effect_handling ->
+      ?stats:unit Symex.effect_handling ->
+      ?fuel:Symex.Fuel_gauge.t ->
+      mode:Symex.Approx.t -> 'a Symex.t -> ('a * Typed.Expr.t list) list
+  = <fun>
 ]}
 
-The function receives a symbolic process to execute, an {{!Soteria.Symex.Approx.t}approximation mode}; an optional {{!Soteria.Symex.Fuel_gauge.t}fuel gauge} should the user desire to limit the breadth or depth of execution; and an optional path to write down a flamegraph {{:https://github.com/brendangregg/flamegraph}`.collapsed`} file (will not generate any flamegraph if [None]) summarising where is execution time spent across the analysed functions. It returns a list of branches, where each branch is a pair of the value returned by the symbolic process and the path condition that leads to this branch (in the form of a list of expressions). Note that the path condition uses {{!Soteria.Symex.Value.Expr}[Value.Expr]}, as this path condition is {e syntactic} now that it has left the context of the symbolic process.
+The function receives a symbolic process to execute, an
+{{!Soteria.Symex.Approx.t}approximation mode}; an optional
+{{!Soteria.Symex.Fuel_gauge.t}fuel gauge} should the user desire to limit the
+breadth or depth of execution; and an optional path to write down a flamegraph
+{{:https://github.com/brendangregg/flamegraph}[.collapsed]} file (will not
+generate any flamegraph if [None]) summarising where is execution time spent
+across the analysed functions. It returns a list of branches, where each branch
+is a pair of the value returned by the symbolic process and the path condition
+that leads to this branch (in the form of a list of expressions). Note that the
+path condition uses {{!Soteria.Symex.Value.Expr}[Value.Expr]}, as this path
+condition is {e syntactic} now that it has left the context of the symbolic
+process.
 
 For instance, let's execute the symbolic process we just created, using the
 {{!Soteria.Symex.Approx.OX}over-approximation} mode, and without providing any
@@ -62,8 +73,8 @@ processes we will be writing in this tutorial, and become interesting when
 analyzing real-world programs.
 
 {@ocaml[
-# Symex.return 0 |> Symex.run ~mode:OX;;
-- : (int * Typed.Expr.t list) list = [(0, [])]]}
+  # Symex.return 0 |> Symex.run ~mode:OX;;
+  - : (int * Typed.Expr.t list) list = [(0, [])]
 ]}
 
 As expected the result of the symbolic process is a single branch with the value
@@ -89,8 +100,8 @@ process that produces a fresh symbolic value of that type.
 Let's run this process:
 
 {@ocaml[
-# Symex.nondet Typed.t_int |> Symex.run ~mode:OX;;
-- : ([> Typed.T.sint ] Typed.t * Typed.Expr.t list) list = [(V|1|, [])]
+  # Symex.nondet Typed.t_int |> Symex.run ~mode:OX;;
+  - : ([> Typed.T.sint ] Typed.t * Typed.Expr.t list) list = [(V|1|, [])]
 ]}
 
 We obtain a single branch with the fresh symbolic integer denoted [V|1|], which
@@ -137,9 +148,9 @@ write code that looks like regular OCaml code.
 Running this symbolic process yields a single branch with no path condition:
 
 {@ocaml[
-# Symex.run ~mode:OX process;;
-- : (([> Typed.T.sint ] as '_weak1) Typed.t * Typed.Expr.t list) list =
-[((V|1| + 2), [])]
+  # Symex.run ~mode:OX process;;
+  - : (([> Typed.T.sint ] as '_weak1) Typed.t * Typed.Expr.t list) list =
+  [((V|1| + 2), [])]
 ]}
 
 We can now build more complex symbolic processes, and make use of other basic
@@ -150,13 +161,13 @@ For instance, we can create a symbolic process that introduces a
 nondeterministic integer, and then asserts that this integer is positive:
 
 {@ocaml[
-  # let process =
-    let* x = Symex.nondet Typed.t_int in
-    Symex.assert_ (x >@ 0s);;
-  val process : bool Symex.t = <abstr>
+    # let process =
+      let* x = Symex.nondet Typed.t_int in
+      Symex.assert_ (x >@ 0s);;
+    val process : bool Symex.t = <abstr>
 
-# Symex.run ~mode:OX process;;
-- : (bool * Typed.Expr.t list) list = [(false, [])]
+  # Symex.run ~mode:OX process;;
+  - : (bool * Typed.Expr.t list) list = [(false, [])]
 ]}
 
 This process returns a single branch with the value [false], as it is not
@@ -164,14 +175,14 @@ This process returns a single branch with the value [false], as it is not
 assumption that, say, [x] is greater than 10, we get a different result:
 
 {@ocaml[
-  # let process =
-    let* x = Symex.nondet Typed.t_int in
-    let* () = Symex.assume [ x >@ 10s ] in
-    Symex.assert_ (x >@ 0s);;
-  val process : bool Symex.t = <abstr>
+    # let process =
+      let* x = Symex.nondet Typed.t_int in
+      let* () = Symex.assume [ x >@ 10s ] in
+      Symex.assert_ (x >@ 0s);;
+    val process : bool Symex.t = <abstr>
 
-# Symex.run ~mode:OX process;;
-- : (bool * Typed.Expr.t list) list = [(true, [(11 <= V|1|)])]
+  # Symex.run ~mode:OX process;;
+  - : (bool * Typed.Expr.t list) list = [(true, [(11 <= V|1|)])]
 ]}
 
 This time, the assertion is satisfied, and the symbolic process returns a single
@@ -189,18 +200,18 @@ provides convenient syntactic sugar (accessed when we opened
 [if] statement to work with symbolic values:
 
 {@ocaml[
-  # let process =
-      let* x = Symex.nondet Typed.t_int in
-      if%sat (x %@ 2s) ==@ 0s then
-        Symex.return (Fmt.str "%a is even" Typed.ppa x)
-      else
-        Symex.return (Fmt.str "%a is odd" Typed.ppa x)
-  val process : string Symex.t = <abstr>
+    # let process =
+        let* x = Symex.nondet Typed.t_int in
+        if%sat (x %@ 2s) ==@ 0s then
+          Symex.return (Fmt.str "%a is even" Typed.ppa x)
+        else
+          Symex.return (Fmt.str "%a is odd" Typed.ppa x)
+    val process : string Symex.t = <abstr>
 
-# Symex.run ~mode:OX process;;
-- : (string * Typed.Expr.t list) list =
-[("V|1| is even", [(0 == (V|1| mod 2))]);
- ("V|1| is odd", [(0 != (V|1| mod 2))])]
+  # Symex.run ~mode:OX process;;
+  - : (string * Typed.Expr.t list) list =
+  [("V|1| is even", [(0 == (V|1| mod 2))]);
+   ("V|1| is odd", [(0 != (V|1| mod 2))])]
 ]}
 
 As expected, the symbolic process returns two branches, one for the case where

--- a/soteria/tutorial/core_symex.mld
+++ b/soteria/tutorial/core_symex.mld
@@ -161,10 +161,10 @@ For instance, we can create a symbolic process that introduces a
 nondeterministic integer, and then asserts that this integer is positive:
 
 {@ocaml[
-    # let process =
-      let* x = Symex.nondet Typed.t_int in
-      Symex.assert_ (x >@ 0s);;
-    val process : bool Symex.t = <abstr>
+  # let process =
+    let* x = Symex.nondet Typed.t_int in
+    Symex.assert_ (x >@ 0s);;
+  val process : bool Symex.t = <abstr>
 
   # Symex.run ~mode:OX process;;
   - : (bool * Typed.Expr.t list) list = [(false, [])]
@@ -175,11 +175,11 @@ This process returns a single branch with the value [false], as it is not
 assumption that, say, [x] is greater than 10, we get a different result:
 
 {@ocaml[
-    # let process =
-      let* x = Symex.nondet Typed.t_int in
-      let* () = Symex.assume [ x >@ 10s ] in
-      Symex.assert_ (x >@ 0s);;
-    val process : bool Symex.t = <abstr>
+  # let process =
+    let* x = Symex.nondet Typed.t_int in
+    let* () = Symex.assume [ x >@ 10s ] in
+    Symex.assert_ (x >@ 0s);;
+  val process : bool Symex.t = <abstr>
 
   # Symex.run ~mode:OX process;;
   - : (bool * Typed.Expr.t list) list = [(true, [(11 <= V|1|)])]
@@ -200,13 +200,13 @@ provides convenient syntactic sugar (accessed when we opened
 [if] statement to work with symbolic values:
 
 {@ocaml[
-    # let process =
-        let* x = Symex.nondet Typed.t_int in
-        if%sat (x %@ 2s) ==@ 0s then
-          Symex.return (Fmt.str "%a is even" Typed.ppa x)
-        else
-          Symex.return (Fmt.str "%a is odd" Typed.ppa x)
-    val process : string Symex.t = <abstr>
+  # let process =
+      let* x = Symex.nondet Typed.t_int in
+      if%sat (x %@ 2s) ==@ 0s then
+        Symex.return (Fmt.str "%a is even" Typed.ppa x)
+      else
+        Symex.return (Fmt.str "%a is odd" Typed.ppa x)
+  val process : string Symex.t = <abstr>
 
   # Symex.run ~mode:OX process;;
   - : (string * Typed.Expr.t list) list =

--- a/soteria/tutorial/core_symex.mld
+++ b/soteria/tutorial/core_symex.mld
@@ -11,8 +11,8 @@ Today you'll be learning how to:
 
 {2:instantiate Instantiating the [Symex.Make] functor}
 
-The main utility of the Soteria library is the {{!Soteria.Symex.Make} Symex.Make} functor, which provides the necessary infrastructure to define and run a symbolic execution engine.
-To instantiate it, you need to provide a {{!Soteria.Symex.Solver.Mutable_incremental} Solver} module, which defines {e symbolic values} and the solver interface to decide whether a symbolic expression of type {{!Soteria.Symex.Value.S.sbool}Value.sbool} is satisfiable.
+The main utility of the Soteria library is the {{!Soteria.Symex.Make}[Symex.Make]} functor, which provides the necessary infrastructure to define and run a symbolic execution engine.
+To instantiate it, you need to provide a {{!Soteria.Symex.Solver.Mutable_incremental}[Solver]} module, which defines {e symbolic values} and the solver interface to decide whether a symbolic expression of type {{!Soteria.Symex.Value.S.sbool}[Value.sbool]} is satisfiable.
 
 {@ocaml[
 module Symex = Symex.Make (Tiny_solver.Z3_solver)
@@ -21,7 +21,7 @@ module Symex = Symex.Make (Tiny_solver.Z3_solver)
 
 {2:return Write your first symbolic process}
 
-Soteria is a library made for writing {e symbolic processes}. A symbolic process is a value of the type {{!Soteria.Symex.S.t}Symex.t}, which is effectively a symbolic computation waiting to be executed. It is an execution that may depend on {e symbolic variables}, and therefore may branch into multiple paths depending on the values of these variables.
+Soteria is a library made for writing {e symbolic processes}. A symbolic process is a value of the type {{!Soteria.Symex.S.t}[Symex.t]}, which is effectively a symbolic computation waiting to be executed. It is an execution that may depend on {e symbolic variables}, and therefore may branch into multiple paths depending on the values of these variables.
 
 The simplest such process is the symbolic process just returns a single branch with a given value, say the integer [0].
 
@@ -31,7 +31,7 @@ The simplest such process is the symbolic process just returns a single branch w
 ]}
 
 This process has type [int Symex.t], that is, a symbolic process that returns a value of type [int]. Again, this is a symbolic process, so it is {e not yet executed}.
-Executing a symbolic process is done using the {{!Soteria.Symex.S.run}run} function:
+Executing a symbolic process is done using the {{!Soteria.Symex.S.run}[run]} function:
 {@ocaml[
 # Symex.run
 - : ?flamegraph:string Symex.effect_handling ->
@@ -54,7 +54,7 @@ As expected the result of the symbolic process is a single branch with the value
 
 {2:nondet Introducing fresh symbolic values}
 
-A core necessity of symbolic execution is the ability to introduce fresh symbolic values. Soteria provides a convenient way to do this using the {{!Soteria.Symex.S.nondet}nondet} function, which creates a fresh symbolic value of a given type. It is called {e nondet} because it "abstracts over" a nondeterministic choice of any value of that given type:
+A core necessity of symbolic execution is the ability to introduce fresh symbolic values. Soteria provides a convenient way to do this using the {{!Soteria.Symex.S.nondet}[nondet]} function, which creates a fresh symbolic value of a given type. It is called {e nondet} because it "abstracts over" a nondeterministic choice of any value of that given type:
 
 {@ocaml[
 # Symex.nondet;;
@@ -111,7 +111,7 @@ Running this symbolic process yields a single branch with no path condition:
 [((V|1| + 2), [])]
 ]}
 
-We can now build more complex symbolic processes, and make use of other basic operations such as {{!Soteria.Symex.S.assume}assume} and {{!Soteria.Symex.S.assert_}assert_}.
+We can now build more complex symbolic processes, and make use of other basic operations such as {{!Soteria.Symex.S.assume}[assume]} and {{!Soteria.Symex.S.assert_}[assert_]}.
 
 For instance, we can create a symbolic process that introduces a nondeterministic integer, and then asserts that this integer is positive:
 

--- a/soteria/tutorial/index.mld
+++ b/soteria/tutorial/index.mld
@@ -1,32 +1,37 @@
 {0 Soteria Documentation}
 
-{!Soteria} is a comprehensive library for writing symbolic execution engines. The library is very parametric and allows for defining one's own notion of {{!Soteria.Symex.Value.S} symbolic value} or {{!Soteria.Symex.Solver.Mutable_incremental}solver}, enabling arbitrary language-specific optimisations. Our goal is for symbolic execution engines to be easy to write, easy to read, highly customisable and efficient.
+{!Soteria} is a comprehensive library for writing symbolic execution engines.
+The library is very parametric and allows for defining one's own notion of
+{{!Soteria.Symex.Value.S}symbolic value} or
+{{!Soteria.Symex.Solver.Mutable_incremental}solver}, enabling arbitrary
+language-specific optimisations. Our goal is for symbolic execution engines to
+be easy to write, easy to read, highly customisable and efficient.
 
 {2 Manual contents}
 
-- The {{!page-core_symex}symbolic execution tutorial} walks you through the basics of doing symbolic execution with Soteria.
-- The {{!page-logs}logging tutorial} explains how to use the Logs module for debugging and monitoring your analyses.
-- The {{!page-stats}statistics tutorial} shows how to track and report metrics during symbolic execution.
-- The {{!page-sym_state_ppx}sym_state PPX tutorial} explains how to derive symbolic state boilerplate.
+- The {{!page-core_symex}symbolic execution tutorial} walks you through the
+  basics of doing symbolic execution with Soteria.
+- The {{!page-logs}logging tutorial} explains how to use the Logs module for
+  debugging and monitoring your analyses.
+- The {{!page-stats}statistics tutorial} shows how to track and report metrics
+  during symbolic execution.
+- The {{!page-sym_state_ppx}sym_state PPX tutorial} explains how to derive
+  symbolic state boilerplate.
 
 {2 Library}
 
-Core components of Soteria, enabling symbolic execution, solver-interaction, user-friendly reporting, and more.
+Core components of Soteria, enabling symbolic execution, solver-interaction,
+user-friendly reporting, and more.
 
-{!modules:
-  Soteria.Symex
-  Soteria.Data
-  Soteria.Sym_states
-  Soteria.Logic
-  Soteria.Solvers
-  Soteria.Logs
-  Soteria.Terminal
-  Soteria.Stats
-  Soteria.Config
-  Soteria.Soteria_std}
+{!modules:Soteria.Symex Soteria.Data Soteria.Sym_states Soteria.Logic
+Soteria.Solvers Soteria.Logs Soteria.Terminal Soteria.Stats Soteria.Config
+Soteria.Soteria_std}
 
-The two built-in symbolic value implementations, to get started; you can also define your own!
+The two built-in symbolic value implementations, to get started; you can also
+define your own!
 
-{!modules:
-  Soteria.Tiny_values
-  Soteria.Bv_values}
+{!modules:Soteria.Tiny_values Soteria.Bv_values}
+
+Our built-in library to interact with SMT-LIB solvers.
+
+{!modules:Soteria_smt}

--- a/soteria/tutorial/index.mld
+++ b/soteria/tutorial/index.mld
@@ -1,7 +1,7 @@
 {0 Soteria Documentation}
 
 {!Soteria} is a comprehensive library for writing symbolic execution engines.
-The library is very parametric and allows for defining one's own notion of
+The library is parametric and allows for defining one's own notion of
 {{!Soteria.Symex.Value.S}symbolic value} or
 {{!Soteria.Symex.Solver.Mutable_incremental}solver}, enabling arbitrary
 language-specific optimisations. Our goal is for symbolic execution engines to

--- a/soteria/tutorial/logs.mld
+++ b/soteria/tutorial/logs.mld
@@ -1,6 +1,6 @@
 {0 Soteria Logging Tutorial}
 
-Welcome to the Soteria logging tutorial! This tutorial will guide you through using the {{!Soteria.Logs}Logs} module for debugging and analyzing your symbolic execution programs.
+Welcome to the Soteria logging tutorial! This tutorial will guide you through using the {{!Soteria.Logs}[Logs]} module for debugging and analyzing your symbolic execution programs.
 
 Soteria's logging interface is inspired by the {{:https://opam.ocaml.org/packages/logs/}[logs]} library, but its implementation is adapted to integrate with symbolic execution and produce structured HTML output.
 
@@ -14,7 +14,7 @@ Today you'll be learning how to:
 
 {2:basic Basic Logging}
 
-The Soteria logging system provides a simple, flexible way to output diagnostic information. To get started, you need to open the {{!Soteria.Logs.Import}Logs.Import} module, which brings the [L] logging module into scope:
+The Soteria logging system provides a simple, flexible way to output diagnostic information. To get started, you need to open the {{!Soteria.Logs.Import}[Logs.Import]} module, which brings the [L] logging module into scope:
 
 {@ocaml[
 open Soteria.Logs.Import;;
@@ -26,7 +26,7 @@ To ensure this import is always available in your project, you can instead also 
 (flags :standard -open Soteria.Logs.Import)
 ]}
 
-The [L] module provides logging functions for different severity levels. The most common one is {{!Soteria.Logs.L.info}info}, which logs informational messages:
+The [L] module provides logging functions for different severity levels. The most common one is {{!Soteria.Logs.L.info}[info]}, which logs informational messages:
 
 {@ocaml[
 L.info (fun m -> m "Starting symbolic execution");;
@@ -47,12 +47,12 @@ L.info (fun m -> m "The answer is %d" x);;
 
 Soteria provides six log levels, from most verbose to least verbose:
 
-- {{!Soteria.Logs.Level.Smt}Smt}: For messages about SMT solver interactions (queries, results)
-- {{!Soteria.Logs.Level.Trace}Trace}: For very detailed execution traces
-- {{!Soteria.Logs.Level.Debug}Debug}: For debugging information
-- {{!Soteria.Logs.Level.Info}Info}: For general informational messages
-- {{!Soteria.Logs.Level.Warn}Warn}: For warnings about potential issues
-- {{!Soteria.Logs.Level.Error}Error}: For errors and exceptions
+- {{!Soteria.Logs.Level.Smt}[Smt]}: For messages about SMT solver interactions (queries, results)
+- {{!Soteria.Logs.Level.Trace}[Trace]}: For very detailed execution traces
+- {{!Soteria.Logs.Level.Debug}[Debug]}: For debugging information
+- {{!Soteria.Logs.Level.Info}[Info]}: For general informational messages
+- {{!Soteria.Logs.Level.Warn}[Warn]}: For warnings about potential issues
+- {{!Soteria.Logs.Level.Error}[Error]}: For errors and exceptions
 
 Each level has a corresponding logging function in the [L] module:
 
@@ -69,7 +69,7 @@ L.error (fun m -> m "Failed to parse input");
 (* -> [ERROR] Failed to parse input *)
 ]}
 
-The {{!Soteria.Logs.L.smt}smt} level is special: it's designed for logging SMT solver interactions, which can be extremely verbose but crucial for understanding solver behavior. Unless you're implementing a solver backend, you usually shouldn't need this level:
+The {{!Soteria.Logs.L.smt}[smt]} level is special: it's designed for logging SMT solver interactions, which can be extremely verbose but crucial for understanding solver behavior. Unless you're implementing a solver backend, you usually shouldn't need this level:
 
 {@ocaml[
 L.smt (fun m -> m "Querying solver: (assert (> x 0))");;
@@ -78,7 +78,7 @@ L.smt (fun m -> m "Querying solver: (assert (> x 0))");;
 
 {2:config Configuration}
 
-Logging behavior is controlled by {{!Soteria.Logs.Config}Logs.Config}. You can configure:
+Logging behavior is controlled by {{!Soteria.Logs.Config}[Logs.Config]}. You can configure:
 
 - The maximum verbosity level to display
 - The output format (text to stderr or HTML)
@@ -100,14 +100,14 @@ Soteria.Logs.Config.set_and_lock log_config;
 
 {b Important:} configuration is global and can only be set once. After calling [set_and_lock], trying to set it again will raise an exception.
 
-For command-line applications, Soteria provides Cmdliner integration via {{!Soteria.Logs.Config.cmdliner_term}Logs.Config.cmdliner_term}.
+For command-line applications, Soteria provides Cmdliner integration via {{!Soteria.Logs.Config.cmdliner_term}[Logs.Config.cmdliner_term]}.
 
 {2:html HTML Output}
 
 Soteria natively supports outputting logs in HTML format. This allows you to
 view logs in a browser, with a search/filter bar, and {i collapsible sections}.
 
-You can organize output into collapsible sections using {{!Soteria.Logs.L.with_section}with_section}:
+You can organize output into collapsible sections using {{!Soteria.Logs.L.with_section}[with_section]}:
 
 {@ocaml[
 L.with_section "Analyzing Module" (fun () ->
@@ -245,17 +245,17 @@ In HTML mode, each call to [with_section] renders as a collapsible block that ca
 
 {b Important:} Do not use [with_section] inside symbolic processes (functions that return ['a Symex.t]) that may branch, because the section will be opened once but closed multiple times. Soteria will automatically create sections when branching occurs inside a process.
 
-{b Note:} {{!Soteria.Logs.L.with_section}with_section} has a [?is_branch] parameter, that is meant only for use when writing your own {{!Soteria.Symex.S}Symex} implementation; most users should {i never} use this parameter.
+{b Note:} {{!Soteria.Logs.L.with_section}[with_section]} has a [?is_branch] parameter, that is meant only for use when writing your own {{!Soteria.Symex.S}[Symex]} implementation; most users should {i never} use this parameter.
 
 {2:printers Pretty Printing and Formatting}
 
-The {{!Soteria.Logs.Printers}Logs.Printers} module provides utilities for formatting output with colors, styles, and special formatting:
+The {{!Soteria.Logs.Printers}[Logs.Printers]} module provides utilities for formatting output with colors, styles, and special formatting:
 
 {3 Colors and Styles}
 
 {b Note:} colored text only works in stderr mode ([~kind:Stderr]); colors are not applied in HTML mode.
 
-You can print colored text using {{!Soteria.Logs.Printers.pp_clr}pp_clr}, apply text styles with {{!Soteria.Logs.Printers.pp_style}pp_style}, or combine both with {{!Soteria.Logs.Printers.pp_clr2}pp_clr2}:
+You can print colored text using {{!Soteria.Logs.Printers.pp_clr}[pp_clr]}, apply text styles with {{!Soteria.Logs.Printers.pp_style}[pp_style]}, or combine both with {{!Soteria.Logs.Printers.pp_clr2}[pp_clr2]}:
 
 {@ocaml[
 let open Soteria.Logs.Printers in
@@ -282,10 +282,10 @@ L.info (fun m -> m "%a, %a, %a, %a"
 
 The following formatters are available for common value types:
 
-- {{!Soteria.Logs.Printers.pp_time}pp_time}: formats float seconds as [12ms] or [1.54s]
-- {{!Soteria.Logs.Printers.pp_percent}pp_percent}: formats a [(total, part)] float pair as a percentage, and {{!Soteria.Logs.Printers.pp_percenti}pp_percenti} does the same with integers
-- {{!Soteria.Logs.Printers.pp_plural}pp_plural}: handles singular/plural forms based on count
-- {{!Soteria.Logs.Printers.pp_unstable}pp_unstable}: hides values that change between runs (when [hide_unstable] is set in config)
+- {{!Soteria.Logs.Printers.pp_time}[pp_time]}: formats float seconds as [12ms] or [1.54s]
+- {{!Soteria.Logs.Printers.pp_percent}[pp_percent]}: formats a [(total, part)] float pair as a percentage, and {{!Soteria.Logs.Printers.pp_percenti}[pp_percenti]} does the same with integers
+- {{!Soteria.Logs.Printers.pp_plural}[pp_plural]}: handles singular/plural forms based on count
+- {{!Soteria.Logs.Printers.pp_unstable}[pp_unstable]}: hides values that change between runs (when [hide_unstable] is set in config)
 
 {@ocaml[
 let open Soteria.Logs.Printers in
@@ -298,7 +298,7 @@ L.info (fun m -> m "Time: %a, Coverage: %a, Found: %a"
 
 {3 Unstable Values}
 
-When writing tests or generating reproducible output, you can hide values that change between runs (like timestamps or durations) using {{!Soteria.Logs.Printers.pp_unstable}pp_unstable}. Note that {{!Soteria.Logs.Printers.pp_time}pp_time} is already predefined as an unstable printer.
+When writing tests or generating reproducible output, you can hide values that change between runs (like timestamps or durations) using {{!Soteria.Logs.Printers.pp_unstable}[pp_unstable]}. Note that {{!Soteria.Logs.Printers.pp_time}[pp_time]} is already predefined as an unstable printer.
 
 {@ocaml[
 let open Soteria.Logs.Printers in

--- a/soteria/tutorial/logs.mld
+++ b/soteria/tutorial/logs.mld
@@ -1,8 +1,13 @@
 {0 Soteria Logging Tutorial}
 
-Welcome to the Soteria logging tutorial! This tutorial will guide you through using the {{!Soteria.Logs}[Logs]} module for debugging and analyzing your symbolic execution programs.
+Welcome to the Soteria logging tutorial! This tutorial will guide you through
+using the {{!Soteria.Logs}[Logs]} module for debugging and analyzing your
+symbolic execution programs.
 
-Soteria's logging interface is inspired by the {{:https://opam.ocaml.org/packages/logs/}[logs]} library, but its implementation is adapted to integrate with symbolic execution and produce structured HTML output.
+Soteria's logging interface is inspired by the
+{{:https://opam.ocaml.org/packages/logs/}[logs]} library, but its implementation
+is adapted to integrate with symbolic execution and produce structured HTML
+output.
 
 Today you'll be learning how to:
 - {{!basic}Log messages} at different levels
@@ -14,40 +19,50 @@ Today you'll be learning how to:
 
 {2:basic Basic Logging}
 
-The Soteria logging system provides a simple, flexible way to output diagnostic information. To get started, you need to open the {{!Soteria.Logs.Import}[Logs.Import]} module, which brings the [L] logging module into scope:
+The Soteria logging system provides a simple, flexible way to output diagnostic
+information. To get started, you need to open the
+{{!Soteria.Logs.Import}[Logs.Import]} module, which brings the [L] logging
+module into scope:
 
 {@ocaml[
-open Soteria.Logs.Import;;
+  open Soteria.Logs.Import
 ]}
 
-To ensure this import is always available in your project, you can instead also add it to your [dune] file:
+To ensure this import is always available in your project, you can instead also
+add it to your [dune] file:
 
 {@dune[
-(flags :standard -open Soteria.Logs.Import)
+  (flags :standard -open Soteria.Logs.Import)
 ]}
 
-The [L] module provides logging functions for different severity levels. The most common one is {{!Soteria.Logs.L.info}[info]}, which logs informational messages:
+The [L] module provides logging functions for different severity levels. The
+most common one is {{!Soteria.Logs.L.info}[info]}, which logs informational
+messages:
 
 {@ocaml[
-L.info (fun m -> m "Starting symbolic execution");;
-(* -> Starting symbolic execution *)
+  L.info (fun m -> m "Starting symbolic execution")
+  (* -> Starting symbolic execution *)
 ]}
 
-The logging API uses a callback pattern: you pass a function that receives a formatter function [m], which you then call with a format string and arguments. This design allows the logging system to avoid formatting work when a log level is disabled.
+The logging API uses a callback pattern: you pass a function that receives a
+formatter function [m], which you then call with a format string and arguments.
+This design allows the logging system to avoid formatting work when a log level
+is disabled.
 
 Let's log a message with a value:
 
 {@ocaml[
-let x = 42 in
-L.info (fun m -> m "The answer is %d" x);;
-(* -> The answer is 42 *)
+  let x = 42 in
+  L.info (fun m -> m "The answer is %d" x)
+  (* -> The answer is 42 *)
 ]}
 
 {2:levels Log Levels}
 
 Soteria provides six log levels, from most verbose to least verbose:
 
-- {{!Soteria.Logs.Level.Smt}[Smt]}: For messages about SMT solver interactions (queries, results)
+- {{!Soteria.Logs.Level.Smt}[Smt]}: For messages about SMT solver interactions
+  (queries, results)
 - {{!Soteria.Logs.Level.Trace}[Trace]}: For very detailed execution traces
 - {{!Soteria.Logs.Level.Debug}[Debug]}: For debugging information
 - {{!Soteria.Logs.Level.Info}[Info]}: For general informational messages
@@ -57,28 +72,32 @@ Soteria provides six log levels, from most verbose to least verbose:
 Each level has a corresponding logging function in the [L] module:
 
 {@ocaml[
-L.trace (fun m -> m "Detailed trace: entering function");
-(* -> [TRACE] Detailed trace: entering function *)
-L.debug (fun m -> m "Variable x = %d" 10);
-(* -> [DEBUG] Variable x = 10 *)
-L.info (fun m -> m "Processing completed successfully");
-(* -> [INFO ] Processing completed successfully *)
-L.warn (fun m -> m "This operation may be slow");
-(* -> [WARN ] This operation may be slow *)
-L.error (fun m -> m "Failed to parse input");
-(* -> [ERROR] Failed to parse input *)
+  L.trace (fun m -> m "Detailed trace: entering function");
+  (* -> [TRACE] Detailed trace: entering function *)
+  L.debug (fun m -> m "Variable x = %d" 10);
+  (* -> [DEBUG] Variable x = 10 *)
+  L.info (fun m -> m "Processing completed successfully");
+  (* -> [INFO ] Processing completed successfully *)
+  L.warn (fun m -> m "This operation may be slow");
+  (* -> [WARN ] This operation may be slow *)
+  L.error (fun m -> m "Failed to parse input")
+  (* -> [ERROR] Failed to parse input *)
 ]}
 
-The {{!Soteria.Logs.L.smt}[smt]} level is special: it's designed for logging SMT solver interactions, which can be extremely verbose but crucial for understanding solver behavior. Unless you're implementing a solver backend, you usually shouldn't need this level:
+The {{!Soteria.Logs.L.smt}[smt]} level is special: it's designed for logging SMT
+solver interactions, which can be extremely verbose but crucial for
+understanding solver behavior. Unless you're implementing a solver backend, you
+usually shouldn't need this level:
 
 {@ocaml[
-L.smt (fun m -> m "Querying solver: (assert (> x 0))");;
-(* -> [SMT  ] Querying solver: (assert (> x 0)) *)
+  L.smt (fun m -> m "Querying solver: (assert (> x 0))")
+  (* -> [SMT ] Querying solver: (assert (> x 0)) *)
 ]}
 
 {2:config Configuration}
 
-Logging behavior is controlled by {{!Soteria.Logs.Config}[Logs.Config]}. You can configure:
+Logging behavior is controlled by {{!Soteria.Logs.Config}[Logs.Config]}. You can
+configure:
 
 - The maximum verbosity level to display
 - The output format (text to stderr or HTML)
@@ -89,47 +108,48 @@ Logging behavior is controlled by {{!Soteria.Logs.Config}[Logs.Config]}. You can
 Here's how to configure logging programmatically:
 
 {@ocaml[
-(* Create a configuration that logs at Debug level and above *)
-let log_config = Soteria.Logs.Config.make
-  ~level:(Some Debug)
-  ~kind:Stderr
-  ~no_color:false
-  ();;
-Soteria.Logs.Config.set_and_lock log_config;
+  (* Create a configuration that logs at Debug level and above *)
+  let log_config =
+    Soteria.Logs.Config.make ~level:(Some Debug) ~kind:Stderr ~no_color:false ()
+  ;;
+
+  Soteria.Logs.Config.set_and_lock log_config
 ]}
 
-{b Important:} configuration is global and can only be set once. After calling [set_and_lock], trying to set it again will raise an exception.
+{b Important:} configuration is global and can only be set once. After calling
+[set_and_lock], trying to set it again will raise an exception.
 
-For command-line applications, Soteria provides Cmdliner integration via {{!Soteria.Logs.Config.cmdliner_term}[Logs.Config.cmdliner_term]}.
+For command-line applications, Soteria provides Cmdliner integration via
+{{!Soteria.Logs.Config.cmdliner_term}[Logs.Config.cmdliner_term]}.
 
 {2:html HTML Output}
 
 Soteria natively supports outputting logs in HTML format. This allows you to
 view logs in a browser, with a search/filter bar, and {i collapsible sections}.
 
-You can organize output into collapsible sections using {{!Soteria.Logs.L.with_section}[with_section]}:
+You can organize output into collapsible sections using
+{{!Soteria.Logs.L.with_section}[with_section]}:
 
 {@ocaml[
-L.with_section "Analyzing Module" (fun () ->
-  L.info (fun m -> m "Starting analysis");
+  L.with_section "Analyzing Module" (fun () ->
+      L.info (fun m -> m "Starting analysis");
 
-  L.with_section "Function: main" (fun () ->
-    L.debug (fun m -> m "Analyzing function body");
-    L.trace (fun m -> m "Thinking about it...");
-    L.debug (fun m -> m "Found 3 branches")
-  );
+      L.with_section "Function: main" (fun () ->
+          L.debug (fun m -> m "Analyzing function body");
+          L.trace (fun m -> m "Thinking about it...");
+          L.debug (fun m -> m "Found 3 branches"));
 
-  L.with_section "Function: helper" (fun () ->
-    L.debug (fun m -> m "Analyzing function body");
-    L.warn (fun m -> m "Something bad is brewing...");
-    L.error (fun m -> m "Oh no!")
-  );
+      L.with_section "Function: helper" (fun () ->
+          L.debug (fun m -> m "Analyzing function body");
+          L.warn (fun m -> m "Something bad is brewing...");
+          L.error (fun m -> m "Oh no!"));
 
-  L.info (fun m -> m "Analysis complete")
-);;
+      L.info (fun m -> m "Analysis complete"))
 ]}
 
-In HTML mode, each call to [with_section] renders as a collapsible block that can be expanded or collapsed in the browser. For instance, the above code would generate the following HTML (you can click around!):
+In HTML mode, each call to [with_section] renders as a collapsible block that
+can be expanded or collapsed in the browser. For instance, the above code would
+generate the following HTML (you can click around!):
 
 {%html:
     <!-- This is copied from a generated .html file, if we update the HTML output we must update it here. -->
@@ -243,107 +263,137 @@ In HTML mode, each call to [with_section] renders as a collapsible block that ca
     </div>
 %}
 
-{b Important:} Do not use [with_section] inside symbolic processes (functions that return ['a Symex.t]) that may branch, because the section will be opened once but closed multiple times. Soteria will automatically create sections when branching occurs inside a process.
+{b Important:} Do not use [with_section] inside symbolic processes (functions
+that return ['a Symex.t]) that may branch, because the section will be opened
+once but closed multiple times. Soteria will automatically create sections when
+branching occurs inside a process.
 
-{b Note:} {{!Soteria.Logs.L.with_section}[with_section]} has a [?is_branch] parameter, that is meant only for use when writing your own {{!Soteria.Symex.S}[Symex]} implementation; most users should {i never} use this parameter.
+{b Note:} {{!Soteria.Logs.L.with_section}[with_section]} has a [?is_branch]
+parameter, that is meant only for use when writing your own
+{{!Soteria.Symex.S}[Symex]} implementation; most users should {i never} use this
+parameter.
 
 {2:printers Pretty Printing and Formatting}
 
-The {{!Soteria.Logs.Printers}[Logs.Printers]} module provides utilities for formatting output with colors, styles, and special formatting:
+The {{!Soteria.Logs.Printers}[Logs.Printers]} module provides utilities for
+formatting output with colors, styles, and special formatting:
 
 {3 Colors and Styles}
 
-{b Note:} colored text only works in stderr mode ([~kind:Stderr]); colors are not applied in HTML mode.
+{b Note:} colored text only works in stderr mode ([~kind:Stderr]); colors are
+not applied in HTML mode.
 
-You can print colored text using {{!Soteria.Logs.Printers.pp_clr}[pp_clr]}, apply text styles with {{!Soteria.Logs.Printers.pp_style}[pp_style]}, or combine both with {{!Soteria.Logs.Printers.pp_clr2}[pp_clr2]}:
+You can print colored text using {{!Soteria.Logs.Printers.pp_clr}[pp_clr]},
+apply text styles with {{!Soteria.Logs.Printers.pp_style}[pp_style]}, or combine
+both with {{!Soteria.Logs.Printers.pp_clr2}[pp_clr2]}:
 
 {@ocaml[
-let open Soteria.Logs.Printers in
-L.info (fun m -> m "%a, %a, %a"
-  (pp_clr `Green) "Success"
-  (pp_style `Bold) "Important"
-  (pp_clr2 `Red `Bold) "Critical");;
+  let open Soteria.Logs.Printers in
+  L.info (fun m ->
+      m "%a, %a, %a" (pp_clr `Green) "Success" (pp_style `Bold) "Important"
+        (pp_clr2 `Red `Bold) "Critical")
 ]}
 
 {3 Semantic Colors}
 
-For common message types, use semantic color functions ([pp_ok], [pp_warn], [pp_err], [pp_fatal]):
+For common message types, use semantic color functions ([pp_ok], [pp_warn],
+[pp_err], [pp_fatal]):
 
 {@ocaml[
-let open Soteria.Logs.Printers in
-L.info (fun m -> m "%a, %a, %a, %a"
-  pp_ok "OK"
-  pp_warn "Warning"
-  pp_err "Error"
-  pp_fatal "Fatal");;
+  let open Soteria.Logs.Printers in
+  L.info (fun m ->
+      m "%a, %a, %a, %a" pp_ok "OK" pp_warn "Warning" pp_err "Error" pp_fatal
+        "Fatal")
 ]}
 
 {3 Special Formatters}
 
 The following formatters are available for common value types:
 
-- {{!Soteria.Logs.Printers.pp_time}[pp_time]}: formats float seconds as [12ms] or [1.54s]
-- {{!Soteria.Logs.Printers.pp_percent}[pp_percent]}: formats a [(total, part)] float pair as a percentage, and {{!Soteria.Logs.Printers.pp_percenti}[pp_percenti]} does the same with integers
-- {{!Soteria.Logs.Printers.pp_plural}[pp_plural]}: handles singular/plural forms based on count
-- {{!Soteria.Logs.Printers.pp_unstable}[pp_unstable]}: hides values that change between runs (when [hide_unstable] is set in config)
+- {{!Soteria.Logs.Printers.pp_time}[pp_time]}: formats float seconds as [12ms]
+  or [1.54s]
+- {{!Soteria.Logs.Printers.pp_percent}[pp_percent]}: formats a [(total, part)]
+  float pair as a percentage, and
+  {{!Soteria.Logs.Printers.pp_percenti}[pp_percenti]} does the same with
+  integers
+- {{!Soteria.Logs.Printers.pp_plural}[pp_plural]}: handles singular/plural forms
+  based on count
+- {{!Soteria.Logs.Printers.pp_unstable}[pp_unstable]}: hides values that change
+  between runs (when [hide_unstable] is set in config)
 
 {@ocaml[
-let open Soteria.Logs.Printers in
-L.info (fun m -> m "Time: %a, Coverage: %a, Found: %a"
-  pp_time 1.543
-  pp_percent (10.0, 2.5)
-  (pp_plural ~sing:"branch" ~plur:"branches") 5);;
-(* -> Time: 1.54s, Coverage: 25.00%, Found: 5 branches *)
+  let open Soteria.Logs.Printers in
+  L.info (fun m ->
+      m "Time: %a, Coverage: %a, Found: %a" pp_time 1.543 pp_percent (10.0, 2.5)
+        (pp_plural ~sing:"branch" ~plur:"branches")
+        5)
+  (* -> Time: 1.54s, Coverage: 25.00%, Found: 5 branches *)
 ]}
 
 {3 Unstable Values}
 
-When writing tests or generating reproducible output, you can hide values that change between runs (like timestamps or durations) using {{!Soteria.Logs.Printers.pp_unstable}[pp_unstable]}. Note that {{!Soteria.Logs.Printers.pp_time}[pp_time]} is already predefined as an unstable printer.
+When writing tests or generating reproducible output, you can hide values that
+change between runs (like timestamps or durations) using
+{{!Soteria.Logs.Printers.pp_unstable}[pp_unstable]}. Note that
+{{!Soteria.Logs.Printers.pp_time}[pp_time]} is already predefined as an unstable
+printer.
 
 {@ocaml[
-let open Soteria.Logs.Printers in
-let current_time = Unix.gettimeofday () in
+  let open Soteria.Logs.Printers in
+  let current_time = Unix.gettimeofday () in
 
-L.info (fun m -> m "Completed at %a"
-  (pp_unstable ~name:"timestamp" Fmt.float) current_time);;
-(* hide_unstable = false -> Completed at 1775127711.926
-   hide_unstable = true  -> Completed at <timestamp> *)
+  L.info (fun m ->
+      m "Completed at %a" (pp_unstable ~name:"timestamp" Fmt.float) current_time)
+  (* hide_unstable = false -> Completed at 1775127711.926 hide_unstable = true
+     -> Completed at <timestamp> *)
 ]}
 
-The [--hide-unstable] flag also makes sure that the printing profile (e.g. support for colors or utf8) is the same independently of the environment, which is useful for making test output deterministic.
+The [--hide-unstable] flag also makes sure that the printing profile (e.g.
+support for colors or utf8) is the same independently of the environment, which
+is useful for making test output deterministic.
 
 {2:performance Performance Considerations}
 
-Logging is designed to be efficient when disabled; avoid doing expensive work for printing before calling the logging function. Instead, do that work inside the logging lambda, so it only runs if the log level is enabled:
+Logging is designed to be efficient when disabled; avoid doing expensive work
+for printing before calling the logging function. Instead, do that work inside
+the logging lambda, so it only runs if the log level is enabled:
 
 {@ocaml[
-(* BAD: Always computes the string, even if logging is disabled *)
-let expensive_string = String.concat ", " (List.init 1000 string_of_int) in
-L.trace (fun m -> m "Generated: %s" expensive_string);;
-
-(* GOOD: Only computes if needed *)
-L.trace (fun m ->
+  (* BAD: Always computes the string, even if logging is disabled *)
   let expensive_string = String.concat ", " (List.init 1000 string_of_int) in
-  m "Generated: %s" expensive_string
-);;
+  L.trace (fun m -> m "Generated: %s" expensive_string)
+  ;;
+
+  (* GOOD: Only computes if needed *)
+  L.trace (fun m ->
+      let expensive_string =
+        String.concat ", " (List.init 1000 string_of_int)
+      in
+      m "Generated: %s" expensive_string)
 ]}
 
 {2:ppx PPX Extension}
 
-Writing calls to the logging function can be a bit verbose, with the need to wrap everything in a lambda. Soteria provides a PPX extension that allows you to write more concise logging statements using [[%l.info]], [[%l.debug]], etc. To use it, first add the PPX dependency to your [dune] file:
+Writing calls to the logging function can be a bit verbose, with the need to
+wrap everything in a lambda. Soteria provides a PPX extension that allows you to
+write more concise logging statements using [[%l.info]], [[%l.debug]], etc. To
+use it, first add the PPX dependency to your [dune] file:
 
 {@dune[
-(preprocess (pps ppx_symex))
+  (preprocess (pps ppx_symex))
 ]}
 
-This is purely syntactic sugar to save some typing and improve readability. It does not supporting declarations within the logging statement, so if you need to do any let-bindings or computations, you should still use the full lambda form.
+This is purely syntactic sugar to save some typing and improve readability. It
+does not supporting declarations within the logging statement, so if you need to
+do any let-bindings or computations, you should still use the full lambda form.
 
 {@ocaml[
-[%l.info "Starting symbolic execution"];;
-[%l.debug "Variable x = %d" 67];;
-(* Expands to: *)
-L.info (fun m -> m "Starting symbolic execution");;
-L.debug (fun m -> m "Variable x = %d" 67);;
+  [%l.info "Starting symbolic execution"];;
+  [%l.debug "Variable x = %d" 67];;
+
+  (* Expands to: *)
+  L.info (fun m -> m "Starting symbolic execution");;
+  L.debug (fun m -> m "Variable x = %d" 67)
 ]}
 
 {2 That's it!}

--- a/soteria/tutorial/stats.mld
+++ b/soteria/tutorial/stats.mld
@@ -1,6 +1,8 @@
 {0 Soteria Statistics Tutorial}
 
-Welcome to the Soteria statistics tutorial! This tutorial will guide you through using the {{!Soteria.Stats}[Stats]} module for tracking, aggregating, and reporting metrics during symbolic execution and program analysis.
+Welcome to the Soteria statistics tutorial! This tutorial will guide you through
+using the {{!Soteria.Stats}[Stats]} module for tracking, aggregating, and
+reporting metrics during symbolic execution and program analysis.
 
 Today you'll be learning how to:
 - {{!basic}Track basic statistics} like counters and timers
@@ -10,13 +12,16 @@ Today you'll be learning how to:
 
 {2:intro Introduction}
 
-The Soteria statistics system provides a flexible way to collect, aggregate, and report metrics during program analysis. It's particularly useful for:
+The Soteria statistics system provides a flexible way to collect, aggregate, and
+report metrics during program analysis. It's particularly useful for:
 
 - Counting events (branches explored, functions called, etc.)
 - Recording sequences of events (errors found, assumptions made, etc.)
 - Tracking performance metrics (execution time, solver queries, etc.)
 
-A key feature of the statistics system is that it automatically {e merges} statistics from different branches of symbolic execution, using appropriate merge strategies for each statistic type.
+A key feature of the statistics system is that it automatically {e merges}
+statistics from different branches of symbolic execution, using appropriate
+merge strategies for each statistic type.
 
 {2:basic Getting Started with Statistics}
 
@@ -30,178 +35,201 @@ Also note that stats are {b only recorded} if the [--dump-stats] flag is used (o
 ]}
 
 {@ocaml[
-# let computation () =
-    Stats.As_ctx.incr "operations";
-    Stats.As_ctx.incr "operations";
-    Stats.As_ctx.incr "operations";
-    42
-val computation : unit -> int = <fun>
-# Stats.As_ctx.with_ () computation;;
-- : int * Stats.t = (42, <stats>)
+  # let computation () =
+      Stats.As_ctx.incr "operations";
+      Stats.As_ctx.incr "operations";
+      Stats.As_ctx.incr "operations";
+      42
+  val computation : unit -> int = <fun>
+  # Stats.As_ctx.with_ () computation;;
+  - : int * Stats.t = (42, <stats>)
 ]}
 
-
-Because wrapper functions are a regular pattern in Soteria, we recommend defining some syntax sugar to make this code nicer; this particular syntax is also provided by Soteria's {{!Soteria.Soteria_std.Syntaxes.FunctionWrap}[Syntaxes.FunctionWrap]} module.
+Because wrapper functions are a regular pattern in Soteria, we recommend
+defining some syntax sugar to make this code nicer; this particular syntax is
+also provided by Soteria's
+{{!Soteria.Soteria_std.Syntaxes.FunctionWrap}[Syntaxes.FunctionWrap]} module.
 {@ocaml[
-# let ( let@ ) = ( @@ );;
-val ( let@ ) : ('a -> 'b) -> 'a -> 'b = <fun>
-# let@ () = Stats.As_ctx.with_ () in
-  computation ();;
-- : int * Stats.t = (42, <stats>)
+  # let ( let@ ) = ( @@ );;
+  val ( let@ ) : ('a -> 'b) -> 'a -> 'b = <fun>
+  # let@ () = Stats.As_ctx.with_ () in
+    computation ();;
+  - : int * Stats.t = (42, <stats>)
 ]}
 
 {3 Basic Counter Operations}
 
-The simplest statistics are integer counters. Use {{!Soteria.Stats.As_ctx.incr}[incr]} to increment by 1 or {{!Soteria.Stats.As_ctx.add_int}[add_int]} to add any amount:
+The simplest statistics are integer counters. Use
+{{!Soteria.Stats.As_ctx.incr}[incr]} to increment by 1 or
+{{!Soteria.Stats.As_ctx.add_int}[add_int]} to add any amount:
 
 {@ocaml[
-# let count_things () =
-    (* Increment a counter *)
-    Stats.As_ctx.incr "items_processed";
-    Stats.As_ctx.incr "items_processed";
-    Stats.As_ctx.incr "items_processed";
+  # let count_things () =
+      (* Increment a counter *)
+      Stats.As_ctx.incr "items_processed";
+      Stats.As_ctx.incr "items_processed";
+      Stats.As_ctx.incr "items_processed";
 
-    (* Add a specific amount *)
-    Stats.As_ctx.add_int "bytes_read" 1024;
-    Stats.As_ctx.add_int "bytes_read" 2048;
+      (* Add a specific amount *)
+      Stats.As_ctx.add_int "bytes_read" 1024;
+      Stats.As_ctx.add_int "bytes_read" 2048;
 
-    "done";;
-val count_things : unit -> string = <fun>
+      "done";;
+  val count_things : unit -> string = <fun>
 
-# let result, stats = Stats.As_ctx.with_ () count_things;;
-val result : string = "done"
-val stats : Stats.t = <stats>
+  # let result, stats = Stats.As_ctx.with_ () count_things;;
+  val result : string = "done"
+  val stats : Stats.t = <stats>
 ]}
 
-Now we can read the statistics back; {!Soteria.Stats} exposes several helper getter functions to retrieve values of the correct type:
+Now we can read the statistics back; {!Soteria.Stats} exposes several helper
+getter functions to retrieve values of the correct type:
 
 {@ocaml[
-# Stats.get_int stats "items_processed";;
-- : int = 3
-# Stats.get_int stats "bytes_read";;
-- : int = 3072
+  # Stats.get_int stats "items_processed";;
+  - : int = 3
+  # Stats.get_int stats "bytes_read";;
+  - : int = 3072
 ]}
 
 {3 Tracking Time}
 
-Use {{!Soteria.Stats.As_ctx.add_time_of_to}[add_time_of_to]} to measure how long an operation takes:
+Use {{!Soteria.Stats.As_ctx.add_time_of_to}[add_time_of_to]} to measure how long
+an operation takes:
 
 {@ocaml skip[
-# let slow_computation () =
-    let rec fib n = if n <= 1 then n else fib (n-1) + fib (n-2) in
-    fib 30
-  in
-  let res, stats =
-    let@ () = Stats.As_ctx.with_ () in
-    Stats.As_ctx.add_time_of_to "compute_time" slow_computation
-  in
-  res, Stats.get_float stats "compute_time";;
-- : int * float = (832040, 0.0228359699249267578)
+  # let slow_computation () =
+      let rec fib n = if n <= 1 then n else fib (n-1) + fib (n-2) in
+      fib 30
+    in
+    let res, stats =
+      let@ () = Stats.As_ctx.with_ () in
+      Stats.As_ctx.add_time_of_to "compute_time" slow_computation
+    in
+    res, Stats.get_float stats "compute_time";;
+  - : int * float = (832040, 0.0228359699249267578)
 ]}
 
 {2:types Statistic Types}
 
-The {{!Soteria.Stats.stat_entry}[stat_entry]} type supports five kinds of statistics:
+The {{!Soteria.Stats.stat_entry}[stat_entry]} type supports five kinds of
+statistics:
 
 - {{!Soteria.Stats.stat_entry.Int}[Int]}: Integer values (merged by addition)
-- {{!Soteria.Stats.stat_entry.Float}[Float]}: Floating-point values (merged by addition)
-- {{!Soteria.Stats.stat_entry.StrSeq}[StrSeq]}: Sequences of strings (merged by concatenation)
-- {{!Soteria.Stats.stat_entry.Map}[Map]}: Nested maps of statistics (merged recursively)
-- {{!Soteria.Stats.stat_entry.Yojson}[Yojson]}: Arbitrary JSON data (merged into arrays)
+- {{!Soteria.Stats.stat_entry.Float}[Float]}: Floating-point values (merged by
+  addition)
+- {{!Soteria.Stats.stat_entry.StrSeq}[StrSeq]}: Sequences of strings (merged by
+  concatenation)
+- {{!Soteria.Stats.stat_entry.Map}[Map]}: Nested maps of statistics (merged
+  recursively)
+- {{!Soteria.Stats.stat_entry.Yojson}[Yojson]}: Arbitrary JSON data (merged into
+  arrays)
 
 {3 String Sequences}
 
 String sequences are useful for recording events or messages:
 
 {@ocaml[
-# let log_events () =
-    Stats.As_ctx.push_str "warnings" "Missing type annotation";
-    Stats.As_ctx.push_str "warnings" "Unused variable x";
-    Stats.As_ctx.push_str "warnings" "Deprecated function called";
-    ()
-  in
-  let _, stats = Stats.As_ctx.with_ () log_events in
-  Stats.get_strseq stats "warnings";;
-- : string Dynarray.t =
-["Missing type annotation", "Unused variable x",
- "Deprecated function called"]
+  # let log_events () =
+      Stats.As_ctx.push_str "warnings" "Missing type annotation";
+      Stats.As_ctx.push_str "warnings" "Unused variable x";
+      Stats.As_ctx.push_str "warnings" "Deprecated function called";
+      ()
+    in
+    let _, stats = Stats.As_ctx.with_ () log_events in
+    Stats.get_strseq stats "warnings";;
+  - : string Dynarray.t =
+  ["Missing type annotation", "Unused variable x",
+   "Deprecated function called"]
 ]}
 
 {3 Nested Maps}
 
-Maps allow you to organize statistics hierarchically. Use {{!Soteria.Stats.As_ctx.push_binding}[push_binding]} to add entries to a map. A binding's value is any {{!Soteria.Stats.stat_entry}statistic type}.
+Maps allow you to organize statistics hierarchically. Use
+{{!Soteria.Stats.As_ctx.push_binding}[push_binding]} to add entries to a map. A
+binding's value is any {{!Soteria.Stats.stat_entry}statistic type}.
 
 {@ocaml[
-# let track_by_function () =
-    Stats.As_ctx.push_binding "function_calls" "main" (Int 5);
-    Stats.As_ctx.push_binding "function_calls" "helper" (Int 12);
-    Stats.As_ctx.push_binding "function_calls" "main" (Int 3);
-    ()
-  in
-  let _, stats = Stats.As_ctx.with_ () track_by_function in
-  Stats.get_map stats "function_calls";;
-- : Stats.stat_entry Soteria_std.Hashtbl.Hstring.t =
-  main -> Stats.Int 8
-  helper -> Stats.Int 12
+  # let track_by_function () =
+      Stats.As_ctx.push_binding "function_calls" "main" (Int 5);
+      Stats.As_ctx.push_binding "function_calls" "helper" (Int 12);
+      Stats.As_ctx.push_binding "function_calls" "main" (Int 3);
+      ()
+    in
+    let _, stats = Stats.As_ctx.with_ () track_by_function in
+    Stats.get_map stats "function_calls";;
+  - : Stats.stat_entry Soteria_std.Hashtbl.Hstring.t =
+    main -> Stats.Int 8
+    helper -> Stats.Int 12
 ]}
 
 {2:custom Custom Printers}
 
-By default, statistics are printed in a generic format. You can register custom printers to make output more readable and context-aware.
+By default, statistics are printed in a generic format. You can register custom
+printers to make output more readable and context-aware.
 
-The generic reigstration function is {{!Soteria.Stats.register_printer}[register_printer]}, but there are also type-specific helpers for common types.
+The generic reigstration function is
+{{!Soteria.Stats.register_printer}[register_printer]}, but there are also
+type-specific helpers for common types.
 
-For instance, use {{!Soteria.Stats.register_int_printer}[register_int_printer]} for integer statistics:
+For instance, use {{!Soteria.Stats.register_int_printer}[register_int_printer]}
+for integer statistics:
 
 {@ocaml[
-# Stats.register_int_printer "operations"
-    ~name:"Total Operations"
-    (fun _stats ft count -> Fmt.pf ft "%d ops" count);
+  # Stats.register_int_printer "operations"
+      ~name:"Total Operations"
+      (fun _stats ft count -> Fmt.pf ft "%d ops" count);
 
-  let _, stats = Stats.As_ctx.with_ () (fun () ->
-      Stats.As_ctx.add_int "operations" 42)
-  in
-  Fmt.pr "%a" Stats.pp stats;;
-Statistics:
-• Total Operations: 42 ops
+    let _, stats = Stats.As_ctx.with_ () (fun () ->
+        Stats.As_ctx.add_int "operations" 42)
+    in
+    Fmt.pr "%a" Stats.pp stats;;
+  Statistics:
+  • Total Operations: 42 ops
 
-- : unit = ()
+  - : unit = ()
 ]}
 
-You can use {{!Soteria.Stats.disable_printer}[disable_printer]} to hide certain statistics from output if you don't want them to be printed by default.
+You can use {{!Soteria.Stats.disable_printer}[disable_printer]} to hide certain
+statistics from output if you don't want them to be printed by default.
 
-Printers receive the full statistics object, allowing context-aware formatting. Combined with hiding statistics, this allows you to create derived metrics that compute percentages, ratios, or other summaries based on multiple underlying statistics:
+Printers receive the full statistics object, allowing context-aware formatting.
+Combined with hiding statistics, this allows you to create derived metrics that
+compute percentages, ratios, or other summaries based on multiple underlying
+statistics:
 
 {@ocaml[
-# let () = Stats.register_int_printer "total_checks"
-    ~name:"Checks"
-    (fun stats ft total ->
-        if total > 0 then
-            let successes = Stats.get_int stats "successful_checks" in
-            Fmt.pf ft "%d successes of %d (%a)" successes total
-                Soteria.Logs.Printers.pp_percenti (total, successes)
-        else
-            Fmt.pf ft "%d" total
-    )
-  in
-  let () = Stats.disable_printer "successful_checks" in
+  # let () = Stats.register_int_printer "total_checks"
+      ~name:"Checks"
+      (fun stats ft total ->
+          if total > 0 then
+              let successes = Stats.get_int stats "successful_checks" in
+              Fmt.pf ft "%d successes of %d (%a)" successes total
+                  Soteria.Logs.Printers.pp_percenti (total, successes)
+          else
+              Fmt.pf ft "%d" total
+      )
+    in
+    let () = Stats.disable_printer "successful_checks" in
 
-  let demo_checks () =
-    Stats.As_ctx.add_int "total_checks" 100;
-    Stats.As_ctx.add_int "successful_checks" 85
-  in
+    let demo_checks () =
+      Stats.As_ctx.add_int "total_checks" 100;
+      Stats.As_ctx.add_int "successful_checks" 85
+    in
 
-  let _, stats = Stats.As_ctx.with_ () demo_checks in
-  Fmt.pr "%a" Stats.pp stats;;
-Statistics:
-• Checks: 85 successes of 100 (85%)
+    let _, stats = Stats.As_ctx.with_ () demo_checks in
+    Fmt.pr "%a" Stats.pp stats;;
+  Statistics:
+  • Checks: 85 successes of 100 (85%)
 
-- : unit = ()
+  - : unit = ()
 ]}
 
 {2:integration Integration with Symbolic Execution}
 
-The statistics system is designed to work seamlessly with Soteria's symbolic execution engine. Furthermore, the {{!Soteria.Symex}[Symex]} module internally uses statistics to track important metrics during symbolic execution, such as:
+The statistics system is designed to work seamlessly with Soteria's symbolic
+execution engine. Furthermore, the {{!Soteria.Symex}[Symex]} module internally
+uses statistics to track important metrics during symbolic execution, such as:
 - Execution time
 - SAT solving time
 - Number of SAT checks
@@ -210,41 +238,57 @@ The statistics system is designed to work seamlessly with Soteria's symbolic exe
 
 See {{!Soteria.Symex.StatKeys}[Symex.StatKeys]} for all available entries.
 
-The {{!Soteria.Symex.S.run}[Symex.S.run]} function receives an optional [stats] parameter that allows deciding how statistics should be tracked during symbolic execution:
-- {{!Soteria.Symex.effect_handling.Ignore}[~stats:Ignore]}: Don't track any statistics (default)
-- {{!Soteria.Symex.effect_handling.Dump}[~stats:(Dump ())]}: Track statistics and print them after execution according to the current {{!Soteria.Stats.Config}configuration} (see below)
-- {{!Soteria.Symex.effect_handling.Caller}[~stats:Caller]}: Statistics are already tracked, and the effects they raise don't need to be handled here (using {{!Soteria.Stats.As_ctx.with_}[with_]}, {{!Soteria.Stats.As_ctx.with_ignored}[with_ignored]}, or {{!Soteria.Stats.As_ctx.with_dumped}[with_dumped]})
+The {{!Soteria.Symex.S.run}[Symex.S.run]} function receives an optional [stats]
+parameter that allows deciding how statistics should be tracked during symbolic
+execution:
+- {{!Soteria.Symex.effect_handling.Ignore}[~stats:Ignore]}: Don't track any
+  statistics (default)
+- {{!Soteria.Symex.effect_handling.Dump}[~stats:(Dump ())]}: Track statistics
+  and print them after execution according to the current
+  {{!Soteria.Stats.Config}configuration} (see below)
+- {{!Soteria.Symex.effect_handling.Caller}[~stats:Caller]}: Statistics are
+  already tracked, and the effects they raise don't need to be handled here
+  (using {{!Soteria.Stats.As_ctx.with_}[with_]},
+  {{!Soteria.Stats.As_ctx.with_ignored}[with_ignored]}, or
+  {{!Soteria.Stats.As_ctx.with_dumped}[with_dumped]})
 
 {3 Configuration}
 
-The {{!Soteria.Stats.Config}[Stats.Config]} module controls where statistics are output: either to stdout, to a JSON file, or disabled entirely. You can set the configuration at the start of your program before any statistics are collected with {{!Soteria.Stats.Config.set_and_lock}[set_and_lock]}.
+The {{!Soteria.Stats.Config}[Stats.Config]} module controls where statistics are
+output: either to stdout, to a JSON file, or disabled entirely. You can set the
+configuration at the start of your program before any statistics are collected
+with {{!Soteria.Stats.Config.set_and_lock}[set_and_lock]}.
 
-A {{!Soteria.Stats.Config.cmdliner_term}Cmdliner term} is provided, exposing a [--output-stats] flag to configure this from the command line.
+A {{!Soteria.Stats.Config.cmdliner_term}Cmdliner term} is provided, exposing a
+[--output-stats] flag to configure this from the command line.
 
-You can then call {{!Soteria.Stats.output}[output]} to write statistics according to the configuration.
+You can then call {{!Soteria.Stats.output}[output]} to write statistics
+according to the configuration.
 
 {3 Best Practices}
 
-Use consistent, hierarchical names for statistics, and define a [StatKeys] module to centralize your stat key constants, document them, and register their printers — this makes the code maintainable as the number of statistics grows:
+Use consistent, hierarchical names for statistics, and define a [StatKeys]
+module to centralize your stat key constants, document them, and register their
+printers — this makes the code maintainable as the number of statistics grows:
 
 {@ocaml[
-module StatKeys = struct
-  let paths_explored = "analysis.paths_explored"
-  let total_time = "analysis.time"
-  let errors_found = "analysis.errors"
+  module StatKeys = struct
+    let paths_explored = "analysis.paths_explored"
+    let total_time = "analysis.time"
+    let errors_found = "analysis.errors"
 
-  let () =
-    let open Soteria.Stats in
-    register_int_printer paths_explored ~name:"Paths Explored"
-      (fun _ ft n -> Fmt.pf ft "%d paths" n);
-    register_float_printer total_time ~name:"Analysis Time"
-      (fun _ -> Soteria.Logs.Printers.pp_time)
-end;;
+    let () =
+      let open Soteria.Stats in
+      register_int_printer paths_explored ~name:"Paths Explored" (fun _ ft n ->
+          Fmt.pf ft "%d paths" n);
+      register_float_printer total_time ~name:"Analysis Time" (fun _ ->
+          Soteria.Logs.Printers.pp_time)
+  end
 
-let my_process () =
-  Soteria.Stats.As_ctx.incr StatKeys.paths_explored;
-  Soteria.Stats.As_ctx.add_float StatKeys.total_time 1.5;
-  ();;
+  let my_process () =
+    Soteria.Stats.As_ctx.incr StatKeys.paths_explored;
+    Soteria.Stats.As_ctx.add_float StatKeys.total_time 1.5;
+    ()
 ]}
 
 {2 That's it!}

--- a/soteria/tutorial/stats.mld
+++ b/soteria/tutorial/stats.mld
@@ -25,13 +25,18 @@ merge strategies for each statistic type.
 
 {2:basic Getting Started with Statistics}
 
-To collect statistics, you need to wrap your computation with {{!Soteria.Stats.As_ctx.with_}[with_]}.
-Note that [with_] must be called outside of any symbolic process (i.e. outside functions returning ['a Symex.t]).
-Also note that stats are {b only recorded} if the [--dump-stats] flag is used (or if the {{!Soteria.Stats.Config.output_stats}[output_stats]} configuration is programmatically set to [Some _]).
+To collect statistics, you need to wrap your computation with
+{{!Soteria.Stats.As_ctx.with_}[with_]}. Note that [with_] must be called outside
+of any symbolic process (i.e. outside functions returning ['a Symex.t]). Also
+note that stats are {b only recorded} if the [--dump-stats] flag is used (or if
+the {{!Soteria.Stats.Config.output_stats}[output_stats]} configuration is
+programmatically set to [Some _]).
 
 {@ocaml[
-  (* Manually initialising stats configuration, should be done using the Cmdliner term in practice *)
-  let () = Soteria.Stats.Config.set_and_lock { output_stats = Some "stats.json" };;
+  (* Manually initialising stats configuration, should be done using the
+     Cmdliner term in practice *)
+  let () =
+    Soteria.Stats.Config.set_and_lock { output_stats = Some "stats.json" }
 ]}
 
 {@ocaml[

--- a/soteria/tutorial/stats.mld
+++ b/soteria/tutorial/stats.mld
@@ -1,6 +1,6 @@
 {0 Soteria Statistics Tutorial}
 
-Welcome to the Soteria statistics tutorial! This tutorial will guide you through using the {{!Soteria.Stats}Stats} module for tracking, aggregating, and reporting metrics during symbolic execution and program analysis.
+Welcome to the Soteria statistics tutorial! This tutorial will guide you through using the {{!Soteria.Stats}[Stats]} module for tracking, aggregating, and reporting metrics during symbolic execution and program analysis.
 
 Today you'll be learning how to:
 - {{!basic}Track basic statistics} like counters and timers
@@ -103,11 +103,11 @@ Use {{!Soteria.Stats.As_ctx.add_time_of_to}[add_time_of_to]} to measure how long
 
 The {{!Soteria.Stats.stat_entry}[stat_entry]} type supports five kinds of statistics:
 
-- {{!Soteria.Stats.stat_entry.Int}Int}: Integer values (merged by addition)
-- {{!Soteria.Stats.stat_entry.Float}Float}: Floating-point values (merged by addition)
-- {{!Soteria.Stats.stat_entry.StrSeq}StrSeq}: Sequences of strings (merged by concatenation)
-- {{!Soteria.Stats.stat_entry.Map}Map}: Nested maps of statistics (merged recursively)
-- {{!Soteria.Stats.stat_entry.Yojson}Yojson}: Arbitrary JSON data (merged into arrays)
+- {{!Soteria.Stats.stat_entry.Int}[Int]}: Integer values (merged by addition)
+- {{!Soteria.Stats.stat_entry.Float}[Float]}: Floating-point values (merged by addition)
+- {{!Soteria.Stats.stat_entry.StrSeq}[StrSeq]}: Sequences of strings (merged by concatenation)
+- {{!Soteria.Stats.stat_entry.Map}[Map]}: Nested maps of statistics (merged recursively)
+- {{!Soteria.Stats.stat_entry.Yojson}[Yojson]}: Arbitrary JSON data (merged into arrays)
 
 {3 String Sequences}
 
@@ -201,7 +201,7 @@ Statistics:
 
 {2:integration Integration with Symbolic Execution}
 
-The statistics system is designed to work seamlessly with Soteria's symbolic execution engine. Furthermore, the {{!Soteria.Symex}Symex} module internally uses statistics to track important metrics during symbolic execution, such as:
+The statistics system is designed to work seamlessly with Soteria's symbolic execution engine. Furthermore, the {{!Soteria.Symex}[Symex]} module internally uses statistics to track important metrics during symbolic execution, such as:
 - Execution time
 - SAT solving time
 - Number of SAT checks
@@ -217,7 +217,7 @@ The {{!Soteria.Symex.S.run}[Symex.S.run]} function receives an optional [stats] 
 
 {3 Configuration}
 
-The {{!Soteria.Stats.Config}Stats.Config} module controls where statistics are output: either to stdout, to a JSON file, or disabled entirely. You can set the configuration at the start of your program before any statistics are collected with {{!Soteria.Stats.Config.set_and_lock}[set_and_lock]}.
+The {{!Soteria.Stats.Config}[Stats.Config]} module controls where statistics are output: either to stdout, to a JSON file, or disabled entirely. You can set the configuration at the start of your program before any statistics are collected with {{!Soteria.Stats.Config.set_and_lock}[set_and_lock]}.
 
 A {{!Soteria.Stats.Config.cmdliner_term}Cmdliner term} is provided, exposing a [--output-stats] flag to configure this from the command line.
 

--- a/soteria/tutorial/sym_state_ppx.mld
+++ b/soteria/tutorial/sym_state_ppx.mld
@@ -1,6 +1,8 @@
 {1 Sym state PPX tutorial}
 
-This page explains how to use the [sym_state] deriver to generate most of the boilerplate required by state modules implementing the {{!Soteria.Sym_states.Base.M.S}symbolic state base API}.
+This page explains how to use the [sym_state] deriver to generate most of the
+boilerplate required by state modules implementing the
+{{!Soteria.Sym_states.Base.M.S}symbolic state base API}.
 
 {2 What it solves}
 
@@ -12,149 +14,163 @@ This page explains how to use the [sym_state] deriver to generate most of the bo
 - [produce] and [consume] to support Soteria's logic.
 - [with_<field>] and [with_<field>_sym] helper wrappers.
 
-The [sym_state] PPX generates these from the state type declaration. More formally, this generates a product of the state models of the individual fields.
+The [sym_state] PPX generates these from the state type declaration. More
+formally, this generates a product of the state models of the individual fields.
 
 {2 Basic usage}
 
-Define a record type [t] where managed symbolic fields have type [<Module>.t option], then derive:
+Define a record type [t] where managed symbolic fields have type
+[<Module>.t option], then derive:
 
 {@ocaml[
-type t = {
-  heap : Heap.t option;
-  globs : Globs.t option;
-}
-[@@deriving sym_state { symex = My_symex }]
+  type t = { heap : Heap.t option; globs : Globs.t option }
+  [@@deriving sym_state { symex = My_symex }]
 ]}
 
-The [symex] argument is required and indicates which symbolic monad family the generated [SM] module should use.
+The [symex] argument is required and indicates which symbolic monad family the
+generated [SM] module should use.
 
 {2 What gets generated}
 
 At a high level, the deriver emits:
 
 {@ocaml skip[
-module SM :
-  Soteria.Sym_states.State_monad.S
-    with module Symex = My_symex
-     and type st = t option
+  module SM :
+    Soteria.Sym_states.State_monad.S
+      with module Symex = My_symex
+       and type st = t option
 
-type syn =
-  | Ser_heap of Heap.syn
-  | Ser_globs of Globs.syn
+  type syn =
+    | Ser_heap of Heap.syn
+    | Ser_globs of Globs.syn
 
-val pp : Format.formatter -> t -> unit
-val show : t -> string
-val pp_syn : Format.formatter -> syn -> unit
-val show_syn : syn -> string
+  val pp : Format.formatter -> t -> unit
+  val show : t -> string
+  val pp_syn : Format.formatter -> syn -> unit
+  val show_syn : syn -> string
 
-val of_opt : t option -> t
-val to_opt : t -> t option
-val empty : t option
+  val of_opt : t option -> t
+  val to_opt : t -> t option
+  val empty : t option
 
-val to_syn : t -> syn list
-val ins_outs : syn -> My_symex.Value.Expr.(t list * t list)
+  val to_syn : t -> syn list
+  val ins_outs : syn -> My_symex.Value.Expr.(t list * t list)
 
-val produce : syn -> t option -> t option My_symex.Producer.t
-val consume : syn -> t option -> (t option, syn list) My_symex.Consumer.t
+  val produce : syn -> t option -> t option My_symex.Producer.t
+  val consume : syn -> t option -> (t option, syn list) My_symex.Consumer.t
 
-val with_heap :
-  ('a, 'e, Heap.syn list) Heap.SM.Result.t ->
-  ('a, 'e, syn list) SM.Result.t
+  val with_heap :
+    ('a, 'e, Heap.syn list) Heap.SM.Result.t ->
+    ('a, 'e, syn list) SM.Result.t
 
-val with_heap_sym : 'a Heap.SM.t -> 'a SM.t
+  val with_heap_sym : 'a Heap.SM.t -> 'a SM.t
 ]}
 
-[with_heap_sym] is a wrapper that calls a symbolic computation of type [Heap.SM.t] with the heap part of the state and updates it with the result. On the other hand, [with_heap] is a more powerful wrapper that also lifts missing outcomes into the right [syn] variant.
+[with_heap_sym] is a wrapper that calls a symbolic computation of type
+[Heap.SM.t] with the heap part of the state and updates it with the result. On
+the other hand, [with_heap] is a more powerful wrapper that also lifts missing
+outcomes into the right [syn] variant.
 
 {2 Ignored fields}
 
-You can keep non-compositional auxiliary fields in [t] and still derive everything. Mark them with [@sym_state.ignore], providing their empty value:
+You can keep non-compositional auxiliary fields in [t] and still derive
+everything. Mark them with [@sym_state.ignore], providing their empty value:
 
 {@ocaml[
-type t = {
-  heap : Heap.t option;
-  globs : Globs.t option;
-  functions : FunBiMap.t [@sym_state.ignore { empty = FunBiMap.empty }];
-}
-[@@deriving sym_state { symex = My_symex }]
+  type t = {
+    heap : Heap.t option;
+    globs : Globs.t option;
+    functions : FunBiMap.t; [@sym_state.ignore { empty = FunBiMap.empty }]
+  }
+  [@@deriving sym_state { symex = My_symex }]
 ]}
 
-Ignored fields are not serialized in [to_syn]. They are still considered in [to_opt] emptiness checks using [( = )] against the provided [empty] expression, and they still get a [with_field_sym] wrapper that operates over the underlying monad (e.g. [My_symex]).
+Ignored fields are not serialized in [to_syn]. They are still considered in
+[to_opt] emptiness checks using [( = )] against the provided [empty] expression,
+and they still get a [with_field_sym] wrapper that operates over the underlying
+monad (e.g. [My_symex]).
 
 {@ocaml skip[
-val with_functions_sym :
+  val with_functions_sym :
     (FunBiMap.t -> ('a * FunBiMap.t, 'e, 'f) My_symex.Result.t) ->
     ('a, 'e, 'f) SM.Result.t
 ]}
 
-If physical equality is not appropriate for the field, you can also provide a custom equality function with [is_empty]. A custom printer can also be provided, with [pp] (by default the field is printed as "<ignored>").
+If physical equality is not appropriate for the field, you can also provide a
+custom equality function with [is_empty]. A custom printer can also be provided,
+with [pp] (by default the field is printed as "<ignored>").
 
 {@ocaml[
-type t = {
-  functions : FunBiMap.t;
-    [@sym_state.ignore {
-      empty = FunBiMap.empty;
-      is_empty = FunBiMap.is_empty;
-      pp = FunBiMap.pp;
-    }]
-}
-[@@deriving sym_state { symex = My_symex }]
+  type t = {
+    functions : FunBiMap.t;
+        [@sym_state.ignore
+          {
+            empty = FunBiMap.empty;
+            is_empty = FunBiMap.is_empty;
+            pp = FunBiMap.pp;
+          }]
+  }
+  [@@deriving sym_state { symex = My_symex }]
 ]}
 
 {2 Using other fields as context}
 
-For managed (i.e. not ignored) fields, [with_<field>] and [with_<field>_sym] can run through another field's state monad with [@sym_state.context]. This can be useful if this field's state model uses a state monad who's state type is that of another field.
+For managed (i.e. not ignored) fields, [with_<field>] and [with_<field>_sym] can
+run through another field's state monad with [@sym_state.context]. This can be
+useful if this field's state model uses a state monad who's state type is that
+of another field.
 
-[@sym_state.context] takes a record with a [field] field, which specifies which field of the state is used. That field must also be a symbolic state (i.e. not be ignored), as it's monad is what is used.
+[@sym_state.context] takes a record with a [field] field, which specifies which
+field of the state is used. That field must also be a symbolic state (i.e. not
+be ignored), as it's monad is what is used.
 
-This enables complex state shapes; for example, here [FancyHeap] is built on top of the [DecayedPointers.SM] state monad:
+This enables complex state shapes; for example, here [FancyHeap] is built on top
+of the [DecayedPointers.SM] state monad:
 
 {@ocaml[
-type t = {
-  pointers : DecayedPointers.t option;
-  heap : FancyHeap.t option;
-    [@sym_state.context { field = pointers }]
-  globs : Globs.t option;
-}
-[@@deriving sym_state { symex = My_symex }]
+  type t = {
+    pointers : DecayedPointers.t option;
+    heap : FancyHeap.t option; [@sym_state.context { field = pointers }]
+    globs : Globs.t option;
+  }
+  [@@deriving sym_state { symex = My_symex }]
 ]}
 
 This makes the generated [with_heap] and [with_heap_sym] behave like this:
 
 {@ocaml[
-let with_heap_sym f =
-  let open SM.Syntax in
-  let* st_opt = SM.get_state () in
-  let st = of_opt st_opt in
-  let { heap; pointers; _ } = st in
-  let*^ (res, heap), pointers =
-    DecayedPointers.SM.run_with_state ~state:pointers (f heap)
-  in
-  let+ () = SM.set_state (to_opt { st with heap; pointers }) in
-  res
+  let with_heap_sym f =
+    let open SM.Syntax in
+    let* st_opt = SM.get_state () in
+    let st = of_opt st_opt in
+    let { heap; pointers; _ } = st in
+    let*^ (res, heap), pointers =
+      DecayedPointers.SM.run_with_state ~state:pointers (f heap)
+    in
+    let+ () = SM.set_state (to_opt { st with heap; pointers }) in
+    res
 ]}
 
 Which can then easily be used:
 
 {@ocaml[
-let load addr ty =
-  with_heap_sym (FancyHeap.load addr ty)
+  let load addr ty = with_heap_sym (FancyHeap.load addr ty)
 ]}
 
 {2 [syn] type equality}
 
-Some applications may want to expose a stable [syn] type through an interface, without revealing the actual state type. While this PPX does not support customising the generated [syn], it does allow asserting [syn] is equal to a user-defined one, using the [syn] option:
+Some applications may want to expose a stable [syn] type through an interface,
+without revealing the actual state type. While this PPX does not support
+customising the generated [syn], it does allow asserting [syn] is equal to a
+user-defined one, using the [syn] option:
 
 {@ocaml[
-type my_syn =
-  | Ser_heap of Heap.syn
-  | Ser_globs of Globs.syn
+  type my_syn = Ser_heap of Heap.syn | Ser_globs of Globs.syn
 
-type t = {
-  heap : Heap.t option;
-  globs : Globs.t option;
-}
-[@@deriving sym_state { symex = My_symex; syn = my_syn }]
+  type t = { heap : Heap.t option; globs : Globs.t option }
+  [@@deriving sym_state { symex = My_symex; syn = my_syn }]
 ]}
 
-{b Note} this only asserts the generated [syn] type is equal to [my_syn], it does not actually change any of the generated code to use [my_syn]. If [my_syn] does not match [syn], this will cause a compile error.
+{b Note} this only asserts the generated [syn] type is equal to [my_syn], it
+does not actually change any of the generated code to use [my_syn]. If [my_syn]
+does not match [syn], this will cause a compile error.


### PR DESCRIPTION
- Add missing code highlighting in links
- Fix some broken links ([god the output of `odoc` is unusable](https://github.com/ocaml/odoc/issues/1120))
- Use `ocamlformat` to ensure `.mld` files have a max column length of 80, which makes diffs a lotttt easier to read through 
- Add a CI step to ensure mld files are formatted, and a makefile command to format them 

i'm not entirely sure why ocamlformat doesn't "just work" for `.mld` files and must be called explicitly, might be an IDE issue or something but i dont really care enough to figure that out ^^