### PR TITLE
Fix nondet_raw for unions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ endif
 SOTERIA_C_PACKAGE=packages/soteria-c
 SOTERIA_RUST_PACKAGE=packages/soteria-rust
 
+COLOR_BLUE=\033[1;34m
+COLOR_GREEN=\033[1;32m
+COLOR_RESET=\033[0m
+
 ##### Normal ocaml stuff #####
 .PHONY: ocaml
 ocaml:
@@ -146,12 +150,12 @@ ocaml-deps:
 # We make sure that every file or folder deleted is displayed in the terminal.
 .PHONY: clean-rust-tests
 clean-rust-tests:
-	@echo "Cleaning Rust test artifacts in soteria-rust/test/cram/..."
-	find soteria-rust/test/cram/ -type f -name '*.llbc.json' -print -delete
-	@echo ""
-	find soteria-rust/test/cram/ -type f -name 'Cargo.lock' -print -delete
-	@echo ""
-	find soteria-rust/test/cram/ -type d -name 'target' -print -exec rm -rf {} +
+	@echo "$(COLOR_BLUE)==> Cleaning Rust test artifacts in soteria-rust/test/cram/$(COLOR_RESET)"
+	@find soteria-rust/test/cram/ -type f -name '*.llbc.json' -print -delete | sed 's/^/  🗑️ /'
+	@find soteria-rust/test/cram/ -type f -name '*.llbc.json.crate' -print -delete | sed 's/^/  🗑️ /'
+	@find soteria-rust/test/cram/ -type f -name 'Cargo.lock' -print -delete | sed 's/^/  🗑️ /'
+	@find soteria-rust/test/cram/ -type d -name 'target' -print -exec rm -rf {} + | sed 's/^/  🗑️ /'
+	@echo "$(COLOR_GREEN)==> Done$(COLOR_RESET)"
 	
 	
 

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -615,10 +615,8 @@ module Make (Borrows : Tree_borrows.T) = struct
     if Iter.is_empty parts then Result.ok ()
     else
       let** () = check_ptr_align fptr ty in
-      (* [%l.debug
-       *   "Parsed to parts [%a]"
-       *   Fmt.(list ~sep:comma Encoder.pp_cval_info)
-       *   parts]; *)
+      (* [%l.debug "Parsed to parts [%a]" (Iter.pp_seq ~sep:", " (Fmt.Dump.pair
+         Encoder.pp_rust_val Typed.ppa)) parts]; *)
       let* () = log "store" ptr in
       let**^ size = Layout.size_of ty in
       let@ ofs = with_ptr ptr in

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -617,7 +617,7 @@ module Encoder (Sptr : Sptr.S) = struct
               | None -> vanish ()
             in
             let+ bytes = nondet (Typed.t_int (sizei * 8)) in
-            Ok (Union [ (Int bytes, size) ])
+            Ok (Union [ (Int bytes, Usize.(0s)) ])
         | ty ->
             Fmt.kstr Rustsymex.not_impl "nondet: unsupported type %a"
               Types.pp_type_decl_kind ty)

--- a/soteria-rust/test/cram/cleanup.sh
+++ b/soteria-rust/test/cram/cleanup.sh
@@ -1,1 +1,1 @@
-rm -rf *.llbc.json target/ Cargo.lock
+rm -rf *.llbc.json *.llbc.json.crate target/ Cargo.lock

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -504,16 +504,6 @@ Check we trust addresses for pointer alignment
   PC 2: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffb) /\
         (0b1 == extract[0-0](V|1|))
   
-Check we trust addresses for pointer alignment
-  $ soteria-rust exec assumed_align.rs
-  Compiling... done in <time>
-  => Running assumed_align::main...
-  note: assumed_align::main: done in <time>, ran 2 branches
-  PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffb) /\
-        (0b0 == extract[0-0](V|1|))
-  PC 2: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffb) /\
-        (0b1 == extract[0-0](V|1|))
-  
 Check that nondet_raw for unions work
   $ soteria-rust exec union_nondet.rs
   Compiling... done in <time>

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -504,3 +504,20 @@ Check we trust addresses for pointer alignment
   PC 2: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffb) /\
         (0b1 == extract[0-0](V|1|))
   
+Check we trust addresses for pointer alignment
+  $ soteria-rust exec assumed_align.rs
+  Compiling... done in <time>
+  => Running assumed_align::main...
+  note: assumed_align::main: done in <time>, ran 2 branches
+  PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffb) /\
+        (0b0 == extract[0-0](V|1|))
+  PC 2: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffb) /\
+        (0b1 == extract[0-0](V|1|))
+  
+Check that nondet_raw for unions work
+  $ soteria-rust exec union_nondet.rs
+  Compiling... done in <time>
+  => Running union_nondet::read_d0...
+  note: union_nondet::read_d0: done in <time>, ran 1 branch
+  PC 1: empty
+  

--- a/soteria-rust/test/cram/simple.t/union_nondet.rs
+++ b/soteria-rust/test/cram/simple.t/union_nondet.rs
@@ -1,0 +1,11 @@
+#[repr(C)]
+union Vec128Storage {
+    d: [u32; 4],
+    q: [u64; 2],
+}
+
+#[soteria::test]
+fn read_d0() -> u32 {
+    let s: Vec128Storage = soteria::nondet_bytes();
+    unsafe { s.d[0] }
+}

--- a/soteria/lib/bv_values/svalue.ml
+++ b/soteria/lib/bv_values/svalue.ml
@@ -812,9 +812,9 @@ and BitVec : BitVec = struct
   (* Index [n-1] holds the cached value for bitwidth [n]; we skip [n=0] because
      [mk] asserts [n > 0]. *)
   let zero_cache : t Array.t = Array.init 256 (fun n -> mk (n + 1) Z.zero)
-  let[@inline] zero n = zero_cache.(n - 1)
+  let[@inline] zero n = if n <= 256 then zero_cache.(n - 1) else mk n Z.one
   let one_cache : t Array.t = Array.init 256 (fun n -> mk (n + 1) Z.one)
-  let[@inline] one n = one_cache.(n - 1)
+  let[@inline] one n = if n <= 256 then one_cache.(n - 1) else mk n Z.zero
 
   (** [bv_to_z signed bits z] parses a BitVector [z], for a given bitwidth
       [bits], with [signed], into an integer. *)

--- a/soteria/lib/bv_values/svalue.ml
+++ b/soteria/lib/bv_values/svalue.ml
@@ -800,8 +800,8 @@ and BitVec : BitVec = struct
 
   (* Bitwidth -> [(1 lsl n) - 1] mask. Memoized to avoid re-allocating the mask
      bignum on each [mk_masked] call (expensive in pathological cases). *)
-  let mask_cache : Z.t Array.t = Array.init 257 (fun n -> Z.(pred (one lsl n)))
-  let mask_of_bits n = mask_cache.(n)
+  let mask_cache : Z.t Array.t = Array.init 256 (fun n -> Z.(pred (one lsl n)))
+  let mask_of_bits n = if n <= 255 then mask_cache.(n) else Z.(pred (one lsl n))
 
   let mk_masked n bv =
     let mask = mask_of_bits n in


### PR DESCRIPTION
As well as drive-bys:

Improve the clean-rust-tests recipe and cram script
Make cached values work with n > 256