### PR TITLE
Minor helpers

### DIFF
--- a/soteria-rust/lib/analyses/wpst.ml
+++ b/soteria-rust/lib/analyses/wpst.ml
@@ -71,7 +71,7 @@ let exec_crate (crate : Charon.UllbcAst.crate)
   if List.is_empty entry_points then fatal "No entry points found";
 
   (* prepare executing the entry points *)
-  let exec_fun = Interp.exec_fun ~state:State.empty in
+  let exec_fun = Interp.exec_fun_as_whole_prog ~state:State.empty in
 
   let@ { fuel; fun_decl; expect_error } : Frontend.entry_point =
     (Fun.flip List.map) entry_points

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -1184,9 +1184,7 @@ module Make (StateImpl : State.S) = struct
         let fn = Crate.get_fun fundef.id in
         exec_real_fun fn fundef.generics args
 
-  (* re-define this for the export, nowhere else: *)
   let exec_fun ~args ~state (fundef : UllbcAst.fun_decl) =
-    let@ () = run ~env:() ~state in
     (* HACK: we protect this function with a bind to make sure no effects are
        raised before the handlers are correctly setup. For a way of fixing this,
        see
@@ -1198,7 +1196,15 @@ module Make (StateImpl : State.S) = struct
     in
     let@ () = StateM.with_frame "Entry point" in
     let generics = TypesUtils.generic_args_of_params () fundef.generics in
-    let* value = exec_real_fun fundef generics args in
+    exec_real_fun fundef generics args
+
+  let exec_fun_compo ~args ~state (fundef : UllbcAst.fun_decl) =
+    let@ () = run ~env:() ~state in
+    exec_fun ~args ~state fundef
+
+  let exec_fun_as_whole_prog ~args ~state (fundef : UllbcAst.fun_decl) =
+    let@ () = run ~env:() ~state in
+    let* value = exec_fun ~args ~state fundef in
     let* () = State.run_thread_exits () in
     if (Config.get ()).ignore_leaks then ok value
     else

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -298,6 +298,14 @@ module Make (Borrows : Tree_borrows.T) = struct
     include
       Soteria.Sym_states.With_info.Make (DecayMap.SM) (Meta) (Freeable_block)
 
+    let is_freed : syn -> bool = function
+      | { node = Freed; _ } -> true
+      | _ -> false
+
+    let trace_syn : syn -> Trace.t option = function
+      | { info = Some { trace; _ }; _ } -> Some trace
+      | _ -> None
+
     let make ?(kind = Alloc_kind.Heap) ?span ?zeroed ~size ~align () :
         (t * Borrows.Tag.t option) DecayMap.SM.t =
       let open DecayMap.SM.Syntax in

--- a/soteria-rust/lib/trace.ml
+++ b/soteria-rust/lib/trace.ml
@@ -50,3 +50,6 @@ let empty =
 let rename ?rev idx msg trace =
   let stack = Soteria.Terminal.Call_trace.rename ?rev idx msg trace.stack in
   { trace with stack }
+
+let toplevel ?loc ?name ?op () =
+  { loc; name; op; stack = Soteria.Terminal.Call_trace.empty }


### PR DESCRIPTION
- Add a few helper functions in `Tree_state.Freeable_block_with_meta`
- Add a helper in `Trace`
- split `exec_fun` in `exec_fun ~cleanup`, `exec_fun_compo` and `exec_fun_as_whole_prog`