### PR TITLE
Faster CI

### DIFF
--- a/.github/actions/post-pr-status-comment/action.yml
+++ b/.github/actions/post-pr-status-comment/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Replace previous status comment
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
         INPUT_MARKER: ${{ inputs.marker }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ env:
 
 jobs:
   build:
+    # If the job name or matrix values change, update the job name matched in
+    # pr-commands.yml ("build / Build and Test (ubuntu-latest)").
     name: Build and Test
     strategy:
       matrix:

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -107,9 +107,31 @@ jobs:
           echo "No CI workflow run found for commit ${{ steps.pr.outputs.sha }}"
           exit 1
 
-      - name: Wait for CI workflow to complete
+      - name: Wait for Linux build job to complete
         if: needs.parse.outputs.needs_ci == 'true'
-        run: gh run watch ${{ steps.find-run.outputs.run_id }} --repo ${{ github.repository }} --exit-status
+        run: |
+          # Only the Linux (ubuntu-latest) job produces the artifacts needed by
+          # benchmarks and doc-pr, so we wait for that job rather than the full
+          # CI run (which also includes a slower macOS job).
+          for ATTEMPT in $(seq 1 80); do
+            # Job name format: "{caller-job-id} / {job-name} ({matrix-value})".
+            # If build.yml's job name or matrix values change, update this string.
+            STATUS=$(gh api "repos/${{ github.repository }}/actions/runs/${{ steps.find-run.outputs.run_id }}/jobs" \
+              --jq '(.jobs[] | select(.name == "build / Build and Test (ubuntu-latest)") | .conclusion // .status) // empty')
+            case "$STATUS" in
+              success)
+                echo "Linux build job completed successfully"
+                exit 0 ;;
+              failure|cancelled|timed_out|action_required)
+                echo "Linux build job ended with status: $STATUS"
+                exit 1 ;;
+              *)
+                echo "Waiting for Linux build job... (attempt $ATTEMPT/90, status: ${STATUS:-pending})"
+                sleep 15 ;;
+            esac
+          done
+          echo "Timed out waiting for Linux build job"
+          exit 1
 
   benchmarks:
     needs: [parse, dispatch]

--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout soteria
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: soteria
 

--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -59,4 +59,4 @@ jobs:
         uses: ocaml-dune/setup-dune@v2
         with:
           directory: tmp
-          steps: all
+          display: short

--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -24,11 +24,8 @@ jobs:
         with:
           path: soteria
 
-      - name: Setup dune
-        uses: ocaml-dune/setup-dune@v1
-        with:
-          steps: "install-dune enable-pkg"
-
+      # Written before setup-dune so that setup-dune can cache tmp/_build and
+      # key the cache on tmp/dune-project (stable across commits).
       - name: Write minimal test project
         run: |
           SOTERIA_PATH="$GITHUB_WORKSPACE/soteria"
@@ -57,6 +54,12 @@ jobs:
           cat > tmp/main.ml << 'EOF'
           let () = ()
           EOF
+
+      - name: Setup dune
+        uses: ocaml-dune/setup-dune@v1
+        with:
+          steps: "install-dune enable-pkg"
+          directory: tmp
 
       - name: Lock dependencies and build
         working-directory: tmp

--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -58,9 +58,7 @@ jobs:
       - name: Setup dune
         uses: ocaml-dune/setup-dune@v1
         with:
-          steps: "install-dune enable-pkg"
           directory: tmp
-
-      - name: Lock dependencies and build
-        working-directory: tmp
-        run: dune pkg lock && dune build --display short
+          steps: all
+      - name: Build
+        run: dune pkg lock && dune build --display

--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -56,9 +56,7 @@ jobs:
           EOF
 
       - name: Setup dune
-        uses: ocaml-dune/setup-dune@v1
+        uses: ocaml-dune/setup-dune@v2
         with:
           directory: tmp
           steps: all
-      - name: Build
-        run: dune pkg lock && dune build --display


### PR DESCRIPTION
- Make the comment actions only way for the Ubuntu package to be uploaded, rather than the whole CI workflow
- Fix caching in test-lib to cache properly and install dune in the right directory apparently? not sure, trusting claude on this one