### PR TITLE
Cleaner transmutes

### DIFF
--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -181,25 +181,6 @@ module M (StateM : State.StateM.S) = struct
           "Unexpected operation or value in eval_ptr_binop: %a, %a, %a"
           Expressions.pp_binop op pp_rust_val l pp_rust_val r
 
-  let transmute ~from_ty ~to_ty v =
-    (* Some fun details:
-     *  - we need to use [get_state] and re-use the current state, rather than
-     *    using an empty state, because if the [load] does any reference
-     *    validity checks we need the current state to have these addresses!
-     *  - we need to take the max of either types for the alignment, to ensure
-     *    that transmuting e.g. from [u16; 2] to (u32) works. *)
-    [%l.debug
-      "Transmuting %a: %a -> %a" pp_rust_val v Common.Charon_util.pp_ty from_ty
-        Common.Charon_util.pp_ty to_ty];
-    let* { size; align; _ } = Layout.layout_of from_ty in
-    let* { align = align_2; _ } = Layout.layout_of to_ty in
-    let align = BV.max ~signed:false align align_2 in
-    let* ptr = State.alloc_untyped ~zeroed:false ~size ~align () in
-    let* () = State.store ptr from_ty v in
-    let* v = State.load ptr to_ty in
-    let+ () = State.free ptr in
-    v
-
   let zero_valid ~ty =
     let+^ res =
       let@ () = run ~env:() ~state:State.empty in

--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -852,7 +852,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let+ _, align = State.size_and_align_of_val t meta in
     (align :> T.sint Typed.t)
 
-  let transmute ~t_src ~dst ~src = Core.transmute ~from_ty:t_src ~to_ty:dst src
+  let transmute ~t_src ~dst ~src = State.transmute ~from:t_src ~to_:dst src
 
   let type_id ~t =
     (* lazy but works *)

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -639,8 +639,7 @@ module Make (StateImpl : State.S) = struct
             | _ ->
                 Fmt.kstr not_impl "Invalid types for CastRawPtr: %a -> %a" pp_ty
                   from_ty pp_ty to_ty)
-        | Cast (CastTransmute (from_ty, to_ty)) ->
-            Core.transmute ~from_ty ~to_ty v
+        | Cast (CastTransmute (from, to_)) -> State.transmute ~from ~to_ v
         | Cast (CastScalar (from_ty, to_ty)) ->
             let+ v =
               match v with
@@ -1008,10 +1007,10 @@ module Make (StateImpl : State.S) = struct
            with function pointers or dyn calls, so we transmute here. *)
         let* args =
           map_list (List.combine3 args in_tys exp_tys)
-            ~f:(fun (arg, from_ty, to_ty) ->
+            ~f:(fun (arg, from, to_) ->
               let* arg = eval_operand arg in
-              if Types.equal_ty from_ty to_ty then ok arg
-              else Core.transmute ~from_ty ~to_ty arg)
+              if Types.equal_ty from to_ then ok arg
+              else State.transmute ~from ~to_ arg)
         in
         [%l.info
           "Executing function with arguments [%a]"

--- a/soteria-rust/lib/state/rust_state_m.ml
+++ b/soteria-rust/lib/state/rust_state_m.ml
@@ -207,6 +207,9 @@ module type S = sig
       size:Typed.T.sint Typed.t ->
       (unit, 'env) t
 
+    val transmute :
+      from:Types.ty -> to_:Types.ty -> rust_val -> (rust_val, 'env) t
+
     val uninit : full_ptr -> Types.ty -> (unit, 'env) t
     val free : full_ptr -> (unit, 'env) t
     val borrow : ?protect:bool -> full_ptr -> Types.ty -> (full_ptr, 'env) t
@@ -491,6 +494,7 @@ module Make (State : State_intf.S) :
     let[@inline] copy_nonoverlapping ~src ~dst ~size =
       ESM.lift (copy_nonoverlapping ~src ~dst ~size)
 
+    let[@inline] transmute ~from ~to_ v = ESM.lift (transmute ~from ~to_ v)
     let[@inline] uninit ptr ty = ESM.lift (uninit ptr ty)
     let[@inline] free ptr = ESM.lift (free ptr)
     let[@inline] borrow ?protect ptr ty = ESM.lift (borrow ?protect ptr ty)

--- a/soteria-rust/lib/state/state_intf.ml
+++ b/soteria-rust/lib/state/state_intf.ml
@@ -81,6 +81,7 @@ module type S = sig
   val copy_nonoverlapping :
     src:full_ptr -> dst:full_ptr -> size:sint Typed.t -> unit ret
 
+  val transmute : from:Types.ty -> to_:Types.ty -> rust_val -> rust_val ret
   val uninit : full_ptr -> Types.ty -> unit ret
   val zeros : full_ptr -> sint Typed.t -> unit ret
   val with_pointers_sym : 'a DecayMap.SM.t -> 'a SM.t

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -652,11 +652,10 @@ module Make (Borrows : Tree_borrows.T) = struct
         type fix = Tree_block.syn list
       end)
 
-  let transmute ~from ~to_ v =
+  let transmute_full ~from ~to_ v =
     (* a transmute is just a write of one type with a read of another type; we
        provide a function to do it that avoids allocating, checking alignment
        etc. *)
-    let@ () = with_loc_err ~trace:"Transmute" () in
     let**^ size = Layout.size_of to_ in
     let** value =
       with_pointers
@@ -691,6 +690,22 @@ module Make (Borrows : Tree_borrows.T) = struct
     in
     let++ () = check_validity ~check_refs:true to_ value in
     value
+
+  let transmute ~from ~to_ v =
+    let@ () = with_loc_err ~trace:"Transmute" () in
+    (* Fast path: thin-pointer <-> thin-pointer transmutes share the same
+       symbolic representation: [Ptr ptr]. Skip encode-decode through the tree
+       block and just validate the target type's constraints (e.g. NotNull). *)
+    let rec is_thin_ptr : Types.ty -> bool = function
+      | TRawPtr (ty, _) | TRef (_, ty, _) -> not (Layout.is_dst ty)
+      | TFnPtr _ -> true
+      | TPattern (inner, _) -> is_thin_ptr inner
+      | _ -> false
+    in
+    if is_thin_ptr from && is_thin_ptr to_ then
+      let++ () = check_validity ~check_refs:true to_ v in
+      v
+    else transmute_full ~from ~to_ v
 
   module Sptr = struct
     include Sptr_base

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -532,12 +532,7 @@ module Make (Borrows : Tree_borrows.T) = struct
     let** size, _ = size_and_align_of_val ty meta in
     check_non_dangling_untyped ptr size
 
-  and load ?ignore_borrow ?(check_refs = true) ((ptr, meta) as fptr) ty :
-      (Sptr_base.t rust_val, Error.t, syn list) Result.t =
-    let** () = check_ptr_align fptr ty in
-    let parser ~offset = Heap.Decoder.decode ~meta ~offset ty in
-    let** value = apply_parser ?ignore_borrow ptr parser in
-    [%l.debug "Finished reading rust value %a" (Rust_val.pp Sptr_base.pp) value];
+  and check_validity ~check_refs ty value =
     let check_ref =
       if (Config.get ()).recursive_validity <> Allow && check_refs then
         fun ptr ty ->
@@ -549,7 +544,15 @@ module Make (Borrows : Tree_borrows.T) = struct
         let** () = check_ptr_align ptr ty in
         check_non_dangling ptr ty
     in
-    let++ () = Encoder.check_validity ~check_ref ty value in
+    Encoder.check_validity ~check_ref ty value
+
+  and load ?ignore_borrow ?(check_refs = true) ((ptr, meta) as fptr) ty :
+      (Sptr_base.t rust_val, Error.t, syn list) Result.t =
+    let** () = check_ptr_align fptr ty in
+    let parser ~offset = Heap.Decoder.decode ~meta ~offset ty in
+    let** value = apply_parser ?ignore_borrow ptr parser in
+    [%l.debug "Finished reading rust value %a" (Rust_val.pp Sptr_base.pp) value];
+    let++ () = check_validity ~check_refs ty value in
     value
 
   and load_discriminant ((ptr, _) as fptr) ty =

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -640,6 +640,58 @@ module Make (Borrows : Tree_borrows.T) = struct
           Result.iter_iter parts ~f:(fun (value, offset) ->
               Tree_block.store (offset +!!@ ofs) value ptr.tag tb))
 
+  (** We can't use {!Heap.Decoder} for [transmute], since the transmute happens
+      regardless of the heap's state, so we need to re-instantiate it for tree
+      block instead *)
+  module Tree_block_decoder =
+    Value_codec.Decoder
+      (Sptr_base)
+      (struct
+        module SM = Tree_block.SM
+
+        type fix = Tree_block.syn list
+      end)
+
+  let transmute ~from ~to_ v =
+    (* a transmute is just a write of one type with a read of another type; we
+       provide a function to do it that avoids allocating, checking alignment
+       etc. *)
+    let@ () = with_loc_err ~trace:"Transmute" () in
+    let**^ size = Layout.size_of to_ in
+    let** value =
+      with_pointers
+        (let open DecayMap.SM in
+         let open Syntax in
+         let* block = Tree_block.alloc size in
+         Tree_block.SM.Result.run_with_state ~state:(Some block)
+           (let open Tree_block.SM in
+            let open Syntax in
+            let open Tree_block_decoder in
+            (* first, we write *)
+            let**^ parts =
+              DecayMap.SM.lift @@ Encoder.encode ~offset:Usize.(0s) v from
+            in
+            let** () =
+              Result.iter_iter parts ~f:(fun (value, offset) ->
+                  Tree_block.store offset value None None)
+            in
+            (* next, we read *)
+            let handler (ty, ofs) =
+              Tree_block.load ~ignore_borrow:true ofs ty None None
+            in
+            let get_all (size, ofs) = Tree_block.get_init_leaves ofs size in
+            ParserMonad.parse ~handler ~get_all
+            @@ decode ~meta:Thin ~offset:Usize.(0s) to_)
+         |> map (function
+           | Ok (value, _block) -> Ok value
+           | Error (e, _block) -> Error e
+           (* HACK: we add this because we can't lift misses for a part of state
+              that doesn't exist (and misses can't happen here anyways) *)
+           | Missing _ -> failwith "impossible : miss"))
+    in
+    let++ () = check_validity ~check_refs:true to_ value in
+    value
+
   module Sptr = struct
     include Sptr_base
 

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -652,10 +652,11 @@ module Make (Borrows : Tree_borrows.T) = struct
         type fix = Tree_block.syn list
       end)
 
-  let transmute_full ~from ~to_ v =
+  let transmute ~from ~to_ v =
     (* a transmute is just a write of one type with a read of another type; we
        provide a function to do it that avoids allocating, checking alignment
        etc. *)
+    let@ () = with_loc_err ~trace:"Transmute" () in
     let**^ size = Layout.size_of to_ in
     let** value =
       with_pointers
@@ -690,22 +691,6 @@ module Make (Borrows : Tree_borrows.T) = struct
     in
     let++ () = check_validity ~check_refs:true to_ value in
     value
-
-  let transmute ~from ~to_ v =
-    let@ () = with_loc_err ~trace:"Transmute" () in
-    (* Fast path: thin-pointer <-> thin-pointer transmutes share the same
-       symbolic representation: [Ptr ptr]. Skip encode-decode through the tree
-       block and just validate the target type's constraints (e.g. NotNull). *)
-    let rec is_thin_ptr : Types.ty -> bool = function
-      | TRawPtr (ty, _) | TRef (_, ty, _) -> not (Layout.is_dst ty)
-      | TFnPtr _ -> true
-      | TPattern (inner, _) -> is_thin_ptr inner
-      | _ -> false
-    in
-    if is_thin_ptr from && is_thin_ptr to_ then
-      let++ () = check_validity ~check_refs:true to_ v in
-      v
-    else transmute_full ~from ~to_ v
 
   module Sptr = struct
     include Sptr_base

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -6,6 +6,7 @@ module T = Typed.T
 open Rustsymex
 open Charon
 open Common
+open Charon_util
 open Sptr
 
 module Make (Borrows : Tree_borrows.T) = struct
@@ -251,7 +252,7 @@ module Make (Borrows : Tree_borrows.T) = struct
         being reborrowed. *)
     let borrow ?(protect = false) ((ptr : Sptr_base.t), meta) tag
         (ty : Types.ty) ofs =
-      let pointee = Charon_util.get_pointee ty in
+      let pointee = get_pointee ty in
       (* FIXME: this logic is tree borrows related and should be handled there.
          https://github.com/soteria-tools/soteria/issues/301 *)
       let state : Tree_borrows.state =
@@ -265,7 +266,7 @@ module Make (Borrows : Tree_borrows.T) = struct
         match (protect, ty) with
         | false, _ -> None
         | true, TRef _ -> Some Strong
-        | true, TAdt adt when Charon_util.adt_is_box adt -> Some Weak
+        | true, TAdt adt when adt_is_box adt -> Some Weak
         | true, _ -> failwith "Non-ref or box in borrow?"
       in
       let** tag = with_borrow (Borrows.Tree.borrow ~state ?protector tag) in
@@ -491,7 +492,7 @@ module Make (Borrows : Tree_borrows.T) = struct
     let** _, exp_align = size_and_align_of_val ty meta in
     [%l.debug
       "Checking pointer alignment of %a: expect %a for %a" Sptr_base.pp ptr
-        Typed.ppa exp_align Common.Charon_util.pp_ty ty];
+        Typed.ppa exp_align pp_ty ty];
     let loc, ofs = Typed.Ptr.decompose ptr.ptr in
     (* A pointer with no provenance is aligned to it's offset *)
     let align = Typed.(ite (Ptr.is_null_loc loc) exp_align (cast ptr.align)) in
@@ -581,8 +582,8 @@ module Make (Borrows : Tree_borrows.T) = struct
     if skip_check then Result.ok ()
     else (
       [%l.debug
-        "Checking validity of %a for %a" (pp_full_ptr Sptr_base.pp) fptr
-          Charon_util.pp_ty ty];
+        "Checking validity of %a for %a" (pp_full_ptr Sptr_base.pp) fptr pp_ty
+          ty];
       let*- err =
         let++ _ = load ~ignore_borrow:true ~check_refs:false fptr ty in
         ()

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -657,8 +657,14 @@ module Make (Borrows : Tree_borrows.T) = struct
     (* a transmute is just a write of one type with a read of another type; we
        provide a function to do it that avoids allocating, checking alignment
        etc. *)
+    [%l.debug
+      "Transmuting %a: %a -> %a" (pp_rust_val Sptr_base.pp) v pp_ty from pp_ty
+        to_];
     let@ () = with_loc_err ~trace:"Transmute" () in
-    let**^ size = Layout.size_of to_ in
+    (* We pick [from] rather than [to_], because we can transmute to a smaller
+       type, but not to a larger one, so it's guaranteed that [size(from) >=
+       size(to_)] *)
+    let**^ size = Layout.size_of from in
     let** value =
       with_pointers
         (let open DecayMap.SM in

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -523,7 +523,7 @@ Check we handle pattern types correctly
   bug: UB: Transmute: Value violates pattern type constraint in pattern_types::nonnull
       --> $RUSTLIB/library/core/src/ptr/non_null.rs:238:13
   238 |              transmute(ptr)
-      |              ^^^^^^^^^^^^^^ Memory load
+      |              ^^^^^^^^^^^^^^ Transmute
       --> $TESTCASE_ROOT/pattern_types.rs:12:25
    10 |  fn nonnull() {
       |  ------------ 1: Entry point
@@ -544,7 +544,7 @@ Check we handle pattern types correctly
       |  ------------------ 1: Entry point
       .  
    25 |      let _nz = unsafe { std::mem::transmute::<isize, NonZero<isize>>(x) };
-      |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Memory load
+      |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transmute
   PC 1: (0x0000000000000000 == V|1|) /\ (0x0000000000000000 == V|1|)
   
   [1]


### PR DESCRIPTION
Implement a proper transmutation in `State`, that doesn't require allocating a block, reading from it and then freeing it. This is much better for performance, as it avoids a bunch of extra checks we don't care about (e.g. alignment of the "fake" block, or checking the used pointer is correct)