### PR TITLE
Automatic action pinning

### DIFF
--- a/.github/actions/post-pr-status-comment/action.yml
+++ b/.github/actions/post-pr-status-comment/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Replace previous status comment
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #[actionpin: v9]
       env:
         INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
         INPUT_MARKER: ${{ inputs.marker }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -58,7 +58,7 @@ jobs:
         run: git config --global --add safe.directory '*'
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -66,7 +66,7 @@ jobs:
       # the benchmarked input is identical to the version tested there
       # (which contains a known bug → analysis exits non-zero, tolerated).
       - name: Checkout Collections-C (benchmark target)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           repository: srdja/Collections-C
           ref: 67a094035b3f7159cf3f9af82c55ae63fcb86a34
@@ -82,19 +82,19 @@ jobs:
       # otherwise from the current run (push-to-main case).
       - name: Download soteria-c package (current run)
         if: inputs.artifact-run-id == ''
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: linux-x86_64-soteria-c-package
           path: soteria-c-package
       - name: Download soteria-rust package (current run)
         if: inputs.artifact-run-id == ''
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: linux-x86_64-soteria-rust-package
           path: soteria-rust-package
       - name: Download soteria-c package (run ${{ inputs.artifact-run-id }})
         if: inputs.artifact-run-id != ''
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: linux-x86_64-soteria-c-package
           path: soteria-c-package
@@ -102,7 +102,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download soteria-rust package (run ${{ inputs.artifact-run-id }})
         if: inputs.artifact-run-id != ''
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: linux-x86_64-soteria-rust-package
           path: soteria-rust-package
@@ -142,7 +142,7 @@ jobs:
       # to main without touching the published history.
       - name: Store benchmark result
         if: inputs.pr-number == ''
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba #[actionpin: v1]
         with:
           name: Soteria benchmarks
           tool: customSmallerIsBetter
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload comparison artifact (PR only)
         if: inputs.pr-number != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #[actionpin: v7]
         with:
           name: benchmark-comparison
           path: benchmark-comparison.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,20 +26,20 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       # Setup steps: checkout, z3,  ocaml and opam
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
       - name: Check versions.json sync
         run: python3 scripts/versionsync.py check
       - name: Setup Z3
-        uses: cda-tum/setup-z3@v1
+        uses: cda-tum/setup-z3@7bfe87519f27304460db44284cb8cc59f50f5fc9 #[actionpin: v1]
         id: z3
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
+        uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 #[actionpin: v3]
         with:
           ocaml-compiler: ${{ env.OCAML_VERSION }}
           dune-cache: true
           opam-pin: false
       - name: Restore opam cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #[actionpin: v5]
         with:
           path: _opam
           key: ${{ runner.os }}-${{ runner.arch }}-opam-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}
@@ -60,19 +60,19 @@ jobs:
       - name: Get Rust toolchain
         run: curl https://raw.githubusercontent.com/$OBOL_REPO/$OBOL_COMMIT_HASH/rust-toolchain.toml > rust-toolchain
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #[actionpin: v1]
         with:
           target: x86_64-unknown-linux-gnu,aarch64-apple-darwin
       # Restore caches for Obol and Charon
       - name: Restore Obol cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #[actionpin: v5]
         id: restore-obol-cache
         with:
           path: obol-bin
           key: ${{ runner.os }}-${{ runner.arch }}-obol-${{ env.OBOL_COMMIT_HASH }}
       # Install Charon
       - name: Restore Charon cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #[actionpin: v5]
         id: restore-charon-cache
         with:
           path: charon-bin
@@ -141,7 +141,7 @@ jobs:
       - name: Create soteria-c package
         run: make package-soteria-c
       - name: Upload soteria-c package
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #[actionpin: v7]
         with:
           name: ${{ steps.platform.outputs.name }}-soteria-c-package
           path: packages/soteria-c
@@ -150,7 +150,7 @@ jobs:
       - name: Create soteria-rust package
         run: make package-soteria-rust
       - name: Upload soteria-rust package
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #[actionpin: v7]
         with:
           name: ${{ steps.platform.outputs.name }}-soteria-rust-package
           path: packages/soteria-rust
@@ -160,7 +160,7 @@ jobs:
         run: make doc
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #[actionpin: v7]
         with:
           name: odoc
           path: _build/default/_doc/_html
@@ -174,7 +174,7 @@ jobs:
         if: runner.os == 'linux'
 
       - name: Upload JSON documentation artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #[actionpin: v7]
         with:
           name: odoc-json
           path: _build/default/_doc/_html

--- a/.github/workflows/bv-fuzzer.yml
+++ b/.github/workflows/bv-fuzzer.yml
@@ -20,23 +20,23 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           ref: ${{ inputs.ref || 'main' }}
 
       - name: Setup Z3
-        uses: cda-tum/setup-z3@v1
+        uses: cda-tum/setup-z3@7bfe87519f27304460db44284cb8cc59f50f5fc9 #[actionpin: v1]
         id: z3
 
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
+        uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 #[actionpin: v3]
         with:
           ocaml-compiler: ${{ env.OCAML_VERSION }}
           dune-cache: true
           opam-pin: false
 
       - name: Restore opam cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae #[actionpin: v5]
         with:
           path: _opam
           key: ${{ runner.os }}-${{ runner.arch }}-opam-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Retrieve documentation artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: odoc
           path: site
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 #[actionpin: v4]
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
@@ -63,13 +63,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Download JSON documentation artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: odoc-json
           path: odoc-json
 
       - name: Push to docs-json branch
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 #[actionpin: v4]
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./odoc-json

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           ref: gh-pages
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Checkout status-comment action
         if: steps.cleanup.outputs.removed != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: source-repo

--- a/.github/workflows/doc-pr.yml
+++ b/.github/workflows/doc-pr.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     steps:
       - name: Download documentation artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: odoc
           path: site
@@ -30,7 +30,7 @@ jobs:
           run-id: ${{ inputs.run-id }}
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 #[actionpin: v4]
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -19,7 +19,7 @@ jobs:
   check-license:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
       - name: install reuse
         run: pip install reuse
       - name: check licenses

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -90,30 +90,30 @@ jobs:
     needs: [check-new-commits, test-packages]
     if: needs.check-new-commits.outputs.should_run == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           fetch-depth: 0
 
       - name: Download soteria-c macOS package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: macos-arm64-soteria-c-package
           path: release-artifacts/soteria-c-macos-arm64
 
       - name: Download soteria-c Linux package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: linux-x86_64-soteria-c-package
           path: release-artifacts/soteria-c-linux-x86_64
 
       - name: Download soteria-rust macOS package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: macos-arm64-soteria-rust-package
           path: release-artifacts/soteria-rust-macos-arm64
 
       - name: Download soteria-rust Linux package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: linux-x86_64-soteria-rust-package
           path: release-artifacts/soteria-rust-linux-x86_64

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -41,7 +41,7 @@ jobs:
       needs_ci: ${{ steps.parse.outputs.needs_ci }}
     steps:
       - id: parse
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #[actionpin: v9]
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         with:
@@ -70,7 +70,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Add eyes reaction
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #[actionpin: v9]
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -174,7 +174,7 @@ jobs:
       # benchmarks command, or benchmarks failed before upload).
       - name: Download benchmark comparison
         if: needs.parse.outputs.run_benchmarks == 'true' && needs.benchmarks.result == 'success'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: benchmark-comparison
           path: comparison
@@ -182,7 +182,7 @@ jobs:
 
       - name: Build status comment and react
         id: status
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #[actionpin: v9]
         env:
           DISPATCH_RESULT: ${{ needs.dispatch.result }}
           RUN_BENCHMARKS: ${{ needs.parse.outputs.run_benchmarks }}
@@ -241,7 +241,7 @@ jobs:
             });
 
       - name: Checkout status-comment action
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: source-repo

--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout soteria
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           path: soteria
 
@@ -56,7 +56,7 @@ jobs:
           EOF
 
       - name: Setup dune
-        uses: ocaml-dune/setup-dune@v2
+        uses: ocaml-dune/setup-dune@2201fa80f49561672943e7960e5f918c887ab0dc #[actionpin: v2]
         with:
           directory: tmp
           display: short

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -26,12 +26,12 @@ jobs:
             echo "name=linux-x86_64" >> $GITHUB_OUTPUT
           fi
       - name: Checkout Collections-C, version where we find a bug
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           repository: srdja/Collections-C
           ref: 67a094035b3f7159cf3f9af82c55ae63fcb86a34
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: ${{ steps.platform.outputs.name }}-soteria-c-package
           path: soteria-c-package
@@ -73,7 +73,7 @@ jobs:
           fi
           echo "✓ Collections-C test passed (found expected bug, exit code 13)"
       - name: Checkout Soteria repository for test files
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
         with:
           path: soteria-repo
       - name: Test symbolic execution with sym.c (nondet test)
@@ -101,11 +101,11 @@ jobs:
       - name: Get Rust toolchain
         run: curl https://raw.githubusercontent.com/$OBOL_REPO/$OBOL_COMMIT_HASH/rust-toolchain.toml > rust-toolchain
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #[actionpin: v1]
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
       - name: Download package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
         with:
           name: ${{ steps.platform.outputs.name }}-soteria-rust-package
           path: soteria-rust-package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,6 +235,21 @@ soteria-rust/scripts/test.py miri
 
 If you want to upgrade a version, say of OCaml, see `./scripts/versionsync.py list` to see current versions and `./scripts/versionsync.py set OCAML_VERSION X.Y.Z` to update it accross all its references in the repo.
 
+### Pinning GitHub Actions
+
+For supply-chain safety, every external GitHub Action in `.github/` is pinned to an immutable commit SHA rather than a mutable tag. The tracked major version is recorded in a trailing annotation on the `uses:` line:
+
+```yaml
+uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
+```
+
+Use `./scripts/actionpin.py` (requires the [`gh` CLI](https://cli.github.com/), authenticated) to manage these pins:
+
+- `./scripts/actionpin.py renew-pins` — repin each action to the latest release **within its current major** (e.g. picks up `v6.0.2` → `v6.0.3`).
+- `./scripts/actionpin.py upgrade-versions` — bump an action to a **newer major** when one exists (e.g. `v6` → `v7`), then pin to its latest release. Review the changelog of any action this bumps, as a new major may change inputs/behaviour.
+
+Both commands accept `--dry-run` to preview changes without writing. A bare `uses: org/repo@vN` line (no annotation) is pinned and annotated automatically on the next `renew-pins`.
+
 ## Submitting Changes
 
 ### Before Submitting

--- a/scripts/actionpin.py
+++ b/scripts/actionpin.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+GitHub Actions pinning script for the codebase.
+
+This script pins every external GitHub Action to an immutable commit SHA, while
+recording the tracked major version as a trailing annotation comment on the
+`uses:` line:
+
+    uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
+
+The annotation grammar is `#[actionpin: vMAJOR]`. The action path and pinned SHA
+are read from the `uses:` line itself.
+
+Commands:
+- renew-pins     Repin each action to the latest release within its current major.
+                 Self-bootstrapping: an un-annotated `uses: org/repo@vN` line is
+                 pinned and annotated on first run. Supports --dry-run.
+- upgrade-versions Bump each action's major version if a newer major release
+                 exists, then pin to the latest release in that new major.
+                 Supports --dry-run.
+
+Remote lookups use the `gh` CLI (authenticated), so both commands require `gh`
+to be installed and logged in.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Directory scanned (recursively) for workflow / action YAML files
+SCAN_DIR = ".github"
+
+# Regex to match the trailing annotation on a `uses:` line: #[actionpin: vMAJOR]
+TAG_PATTERN = re.compile(r"#\s*\[actionpin:\s*(v\d+)\s*\]")
+
+# Regex to match a `uses:` line; captures (indent, path, ref). Handles both
+# "uses: x@ref" and "- uses: x@ref". The ref capture stops at whitespace, so a
+# trailing annotation comment is excluded.
+USES_PATTERN = re.compile(r"^(\s*)(?:-\s*)?uses:\s*([^@\s]+)@(\S+)")
+
+# Regex to recognise a clean version tag (vX, vX.Y, vX.Y.Z), no pre-release suffix
+VERSION_TAG_PATTERN = re.compile(r"^v(\d+)(?:\.(\d+))?(?:\.(\d+))?$")
+
+
+# ANSI color codes for pretty output
+class Colors:
+    RED = "\033[91m"
+    GREEN = "\033[92m"
+    BLUE = "\033[94m"
+    YELLOW = "\033[93m"
+    BOLD = "\033[1m"
+    RESET = "\033[0m"
+
+
+# The progress bar currently being rendered, if any. Messages printed while a bar
+# is active are interleaved above it (the bar line is cleared and redrawn).
+_active_progress: "Progress | None" = None
+
+
+def color_print(message: str, color: str = "") -> None:
+    """Print a message with optional color, cooperating with an active progress bar."""
+    text = f"{color}{message}{Colors.RESET}"
+    if _active_progress is not None:
+        _active_progress.log(text)
+    else:
+        print(text)
+
+
+def info(message: str) -> None:
+    """Print an info message in blue."""
+    color_print(f"ℹ {message}", Colors.BLUE)
+
+
+def success(message: str) -> None:
+    """Print a success message in green."""
+    color_print(f"✓ {message}", Colors.GREEN)
+
+
+def warn(message: str) -> None:
+    """Print a warning message in yellow."""
+    color_print(f"⚠ {message}", Colors.YELLOW)
+
+
+def error(message: str) -> None:
+    """Print an error message in red."""
+    color_print(f"✗ {message}", Colors.RED)
+
+
+def step(message: str) -> None:
+    """Print a step message in bold."""
+    color_print(f"▶ {message}", Colors.BOLD)
+
+
+class Progress:
+    """A minimal terminal progress bar. No-op when stdout is not a TTY."""
+
+    BAR_WIDTH = 30
+
+    def __init__(self, label: str, total: int) -> None:
+        self.label = label
+        self.total = total
+        self.n = 0
+        self.enabled = sys.stdout.isatty() and total > 0
+
+    def _render(self) -> None:
+        if not self.enabled:
+            return
+        filled = int(self.BAR_WIDTH * self.n / self.total)
+        bar = "█" * filled + "░" * (self.BAR_WIDTH - filled)
+        pct = int(100 * self.n / self.total)
+        print(
+            f"\r{Colors.BOLD}{self.label}{Colors.RESET} "
+            f"[{bar}] {self.n}/{self.total} ({pct}%)",
+            end="",
+            flush=True,
+        )
+
+    def advance(self, n: int = 1) -> None:
+        """Advance the bar by n steps and redraw it."""
+        self.n += n
+        self._render()
+
+    def log(self, message: str) -> None:
+        """Print a message above the bar, then redraw the bar."""
+        if self.enabled:
+            print("\r\033[K", end="")  # clear the current bar line
+        print(message)
+        self._render()
+
+    def finish(self) -> None:
+        """Complete the bar and move to a fresh line."""
+        if self.enabled:
+            self.n = self.total
+            self._render()
+            print()
+
+
+def run_command(cmd: list[str]) -> str:
+    """Run a command and return its stdout. Exits the program on failure."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            error(f"Command failed: {' '.join(cmd)}")
+            error(f"Error output: {result.stderr.strip()}")
+            sys.exit(1)
+        return result.stdout.strip()
+    except FileNotFoundError:
+        error(f"Command not found: {cmd[0]}")
+        if cmd[0] == "gh":
+            info("Install the GitHub CLI (https://cli.github.com/) and run `gh auth login`.")
+        sys.exit(1)
+
+
+def is_external(path: str) -> bool:
+    """A `uses:` path is external if it is not a local (./) action reference."""
+    return not path.startswith("./")
+
+
+def repo_of(path: str) -> str:
+    """Return the org/repo of an action path, stripping any subdir.
+
+    e.g. actions/cache/restore -> actions/cache
+    """
+    return "/".join(path.split("/")[:2])
+
+
+def parse_version(tag: str) -> tuple[int, int, int] | None:
+    """Parse a clean version tag into a (major, minor, patch) tuple, or None."""
+    match = VERSION_TAG_PATTERN.match(tag)
+    if not match:
+        return None
+    major = int(match.group(1))
+    minor = int(match.group(2)) if match.group(2) else 0
+    patch = int(match.group(3)) if match.group(3) else 0
+    return major, minor, patch
+
+
+# Per-run cache of repo -> list of (version_tuple, tag_name)
+_tags_cache: dict[str, list[tuple[tuple[int, int, int], str]]] = {}
+# Per-run cache of (repo, tag) -> commit SHA
+_sha_cache: dict[tuple[str, str], str] = {}
+
+
+def get_version_tags(repo: str) -> list[tuple[tuple[int, int, int], str]]:
+    """Return all clean version tags of a repo as (version_tuple, tag_name)."""
+    if repo not in _tags_cache:
+        out = run_command(
+            ["gh", "api", "--paginate", f"repos/{repo}/tags", "--jq", ".[].name"]
+        )
+        tags = []
+        for name in out.splitlines():
+            name = name.strip()
+            version = parse_version(name)
+            if version is not None:
+                tags.append((version, name))
+        _tags_cache[repo] = tags
+    return _tags_cache[repo]
+
+
+def latest_in_major(repo: str, major: int) -> tuple[tuple[int, int, int], str] | None:
+    """Return the (version_tuple, tag_name) of the latest release in a major."""
+    candidates = [t for t in get_version_tags(repo) if t[0][0] == major]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda t: t[0])
+
+
+def max_major(repo: str) -> int | None:
+    """Return the highest major version available for a repo."""
+    tags = get_version_tags(repo)
+    if not tags:
+        return None
+    return max(t[0][0] for t in tags)
+
+
+def resolve_sha(repo: str, tag: str) -> str:
+    """Resolve a tag to its underlying commit SHA (dereferences annotated tags)."""
+    key = (repo, tag)
+    if key not in _sha_cache:
+        _sha_cache[key] = run_command(
+            ["gh", "api", f"repos/{repo}/commits/{tag}", "--jq", ".sha"]
+        )
+    return _sha_cache[key]
+
+
+def find_yaml_files(root: Path) -> list[Path]:
+    """Return all YAML files under the scan directory, sorted."""
+    scan_root = root / SCAN_DIR
+    files = sorted(scan_root.rglob("*.yml")) + sorted(scan_root.rglob("*.yaml"))
+    return sorted(set(files))
+
+
+def process_file(
+    file_path: Path,
+    file_rel: Path,
+    upgrade: bool,
+    dry_run: bool,
+    progress: Progress,
+) -> bool:
+    """Renew (or upgrade) pins in a single file.
+
+    Returns True if the file was modified (or would be, in dry-run mode).
+    """
+    lines = file_path.read_text().splitlines(keepends=True)
+    changed = False
+
+    for i, line in enumerate(lines):
+        uses_match = USES_PATTERN.match(line)
+        if not uses_match:
+            continue
+        _, path, ref = uses_match.groups()
+        if not is_external(path):
+            continue
+
+        progress.advance()
+        repo = repo_of(path)
+
+        # Determine the current major being tracked.
+        tag_match = TAG_PATTERN.search(line)
+        if tag_match is not None:
+            current_major = int(tag_match.group(1)[1:])
+            current_sha = ref
+        else:
+            # No annotation yet: derive the major from the `@vN` ref (bootstrap).
+            version = parse_version(ref)
+            if version is None:
+                warn(
+                    f"{file_rel}:{i + 1} - {path}@{ref} is not annotated and its ref "
+                    f"is not a version tag; skipping (pin it manually first)."
+                )
+                continue
+            current_major = version[0]
+            current_sha = ref
+
+        # Pick the target major.
+        if upgrade:
+            top = max_major(repo)
+            if top is None:
+                warn(f"{file_rel}:{i + 1} - no version tags found for {repo}; skipping.")
+                continue
+            target_major = top
+        else:
+            target_major = current_major
+
+        latest = latest_in_major(repo, target_major)
+        if latest is None:
+            warn(
+                f"{file_rel}:{i + 1} - no v{target_major}.x release found for {repo}; "
+                f"skipping."
+            )
+            continue
+        (_, latest_tag) = latest
+        new_sha = resolve_sha(repo, latest_tag)
+
+        major_changed = target_major != current_major
+        sha_changed = new_sha != current_sha
+
+        if not major_changed and not sha_changed:
+            continue
+
+        action_kind = "UPGRADE" if major_changed else "RENEW"
+        detail = (
+            f"{path}: v{current_major} ({current_sha[:8]}) -> "
+            f"v{target_major} {latest_tag} ({new_sha[:8]})"
+        )
+
+        if dry_run:
+            info(f"{action_kind} {file_rel}:{i + 1} - {detail}")
+            changed = True
+            continue
+
+        # Apply: rewrite the ref to the new SHA and (re)set the trailing annotation.
+        base = TAG_PATTERN.sub("", line).rstrip()
+        base = base.replace(f"@{ref}", f"@{new_sha}", 1)
+        lines[i] = f"{base} #[actionpin: v{target_major}]\n"
+
+        info(f"{action_kind} {file_rel}:{i + 1} - {detail}")
+        changed = True
+
+    if changed and not dry_run:
+        file_path.write_text("".join(lines))
+
+    return changed
+
+
+def count_external_uses(files: list[Path]) -> int:
+    """Count external `uses:` lines across the given files (progress bar total)."""
+    total = 0
+    for file_path in files:
+        for line in file_path.read_text().splitlines():
+            match = USES_PATTERN.match(line)
+            if match and is_external(match.group(2)):
+                total += 1
+    return total
+
+
+def cmd_pins(root: Path, upgrade: bool, dry_run: bool) -> int:
+    """Renew or upgrade pins across all scanned files."""
+    global _active_progress
+    files = find_yaml_files(root)
+    label = "Upgrading versions" if upgrade else "Renewing pins"
+    progress = Progress(label, count_external_uses(files))
+    _active_progress = progress
+
+    any_change = False
+    try:
+        for file_path in files:
+            file_rel = file_path.relative_to(root)
+            if process_file(file_path, file_rel, upgrade, dry_run, progress):
+                any_change = True
+    finally:
+        progress.finish()
+        _active_progress = None
+
+    if not any_change:
+        success("All pins are already up to date.")
+    elif dry_run:
+        info("Dry run: no files were modified.")
+    else:
+        success("Pins updated.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="GitHub Actions SHA-pinning script for Soteria",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s renew-pins              Repin to the latest release within each major
+  %(prog)s renew-pins --dry-run    Show what renewing would change
+  %(prog)s upgrade-versions        Bump majors where a newer major exists
+  %(prog)s upgrade-versions --dry-run  Show available major upgrades
+
+Annotation format (trailing comment on the `uses:` line):
+  uses: actions/checkout@<sha> #[actionpin: v6]
+""",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    renew_parser = subparsers.add_parser(
+        "renew-pins", help="Repin to the latest release within each current major"
+    )
+    renew_parser.add_argument(
+        "--dry-run", action="store_true", help="Show changes without writing files"
+    )
+
+    upgrade_parser = subparsers.add_parser(
+        "upgrade-versions", help="Bump majors when a newer major release exists"
+    )
+    upgrade_parser.add_argument(
+        "--dry-run", action="store_true", help="Show changes without writing files"
+    )
+
+    args = parser.parse_args()
+
+    root = Path(__file__).parent.parent
+
+    if args.command == "renew-pins":
+        return cmd_pins(root, upgrade=False, dry_run=args.dry_run)
+    elif args.command == "upgrade-versions":
+        return cmd_pins(root, upgrade=True, dry_run=args.dry_run)
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Claude finished cooking, here's the description of the PR. I'm honestly in favour of merging this, it's cheap and it's cute.
If in ~a month we're still happy with this, I'll actually publish it on pip because I think it's valuable 🤷‍♂️

  # Pin GitHub Actions to commit SHAs (supply-chain hardening)

  ## Summary

  Every external GitHub Action in `.github/` was referenced by a **mutable major tag** (e.g.
  `actions/checkout@v6`). A mutable tag can be force-moved by the action owner — or a
  compromised account — to point at malicious code. This PR pins all of them to **immutable 
  commit SHAs**, and adds a small script to keep those pins maintainable.

  ## Changes

  - **Bumped two stale actions to their latest major** before pinning: `actions/checkout` v4 →
  v6, `actions/github-script` v7 → v9. (All other actions were already at their latest
  major.) Arguments were checked to remain valid across these bumps.
  - **SHA-pinned all 51 `uses:` references** across 12 files, each to the commit of the latest
  release within its major. The tracked major is recorded in a trailing annotation:

    ```yaml
    uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
    ```

  - **New script `scripts/actionpin.py`** (inspired by `scripts/versionsync.py`) to manage the
  pins, using the `gh` CLI for lookups:
    - `renew-pins` — repin each action to the latest release **within its current major**.
    - `upgrade-versions` — bump an action to a **newer major** when one exists, then pin to
  its latest release.
    - Both support `--dry-run` and show a progress bar. A bare `@vN` line is pinned +
  annotated automatically.
  - **Documented** the workflow in `CONTRIBUTING.md` under "Upgrading versions".

  ### Actions pinned

  | Action | Major | Release |
  |---|---|---|
  | actions/checkout | v6 | v6.0.3 |
  | actions/download-artifact | v8 | v8.0.1 |
  | actions/upload-artifact | v7 | v7.0.1 |
  | actions/cache (+ `/restore`) | v5 | v5.0.5 |
  | actions/github-script | v9 | v9.0.0 |
  | ocaml/setup-ocaml | v3 | v3.6.1 |
  | ocaml-dune/setup-dune | v2 | v2.1.0 |
  | actions-rust-lang/setup-rust-toolchain | v1 | v1.16.1 |
  | cda-tum/setup-z3 | v1 | v1.7.2 |
  | peaceiris/actions-gh-pages | v4 | v4.1.0 |
  | benchmark-action/github-action-benchmark | v1 | v1.22.1 |

  ## Behaviour impact

  None expected. Each SHA is the exact commit its major tag currently resolves to, so CI runs
  the same action code — now immutable. The `v4→v6` (checkout) and `v7→v9` (github-script)
  bumps were verified to keep using only inputs/APIs that remain valid in the new majors.

  ## Verification

  - `scripts/actionpin.py renew-pins --dry-run` and `upgrade-versions --dry-run` → no pending
  changes (pins are current).
  - Every external `uses:` line is annotated; all `.github/**/*.yml` still parse.
  - Spot-checked pinned SHAs against `gh api repos/<action>/commits/<tag>`.

  ## Notes for reviewers

  - Pins are tag-based annotations + SHAs; renewing/upgrading requires the authenticated `gh`

  - Pins are tag-based annotations + SHAs; renewing/upgrading requires the authenticated `gh`
  CLI.
  - Pins are tag-based annotations + SHAs; renewing/upgrading requires the authenticated `gh`
  CLI.
  CLI.
  A couple of things worth flagging before you open it:

  commit the staged work first. I haven't committed or pushed anything, per the repo's "never
  push on their own" rule.
  - I wrote the table's "Release" column from the values resolved during this work; if any
  action cut a new release since, a renew-pins --dry-run will surface it.


  - `scripts/actionpin.py renew-pins --dry-run` and `upgrade-versions --dry-run` → no pending
  changes (pins are current).
  - Every external `uses:` line is annotated; all `.github/**/*.yml` still parse.
  - Spot-checked pinned SHAs against `gh api repos/<action>/commits/<tag>`.

  ## Notes for reviewers

  - Pins are tag-based annotations + SHAs; renewing/upgrading requires the authenticated `gh`
  CLI.
  - There is intentionally **no CI "is everything pinned" guard** in this PR — happy to add
  one as a follow-up if wanted.