### PR TITLE
Detect writes to read-only memory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ env:
   OCAML_VERSION: 5.4.1
   # [versionsync: OBOL_REPO=soteria-tools/obol]
   OBOL_REPO: soteria-tools/obol
-  # [versionsync: OBOL_COMMIT_HASH=1ce4c36928b0ed946c13214c4f416d18abb4380a]
-  OBOL_COMMIT_HASH: 1ce4c36928b0ed946c13214c4f416d18abb4380a
+  # [versionsync: OBOL_COMMIT_HASH=ceb01d2890c6c15e851ecf92d91104a85a0adb0b]
+  OBOL_COMMIT_HASH: ceb01d2890c6c15e851ecf92d91104a85a0adb0b
   # [versionsync: CHARON_REPO=soteria-tools/charon]
   CHARON_REPO: soteria-tools/charon
   # [versionsync: CHARON_COMMIT_HASH=a16823aa6fce73baca964350d46cd667df6a1b29]

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -6,8 +6,8 @@ on:
 env:
   # [versionsync: OBOL_REPO=soteria-tools/obol]
   OBOL_REPO: soteria-tools/obol
-  # [versionsync: OBOL_COMMIT_HASH=1ce4c36928b0ed946c13214c4f416d18abb4380a]
-  OBOL_COMMIT_HASH: 1ce4c36928b0ed946c13214c4f416d18abb4380a
+  # [versionsync: OBOL_COMMIT_HASH=ceb01d2890c6c15e851ecf92d91104a85a0adb0b]
+  OBOL_COMMIT_HASH: ceb01d2890c6c15e851ecf92d91104a85a0adb0b
 
 jobs:
   test-soteria-c-package:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,12 +109,12 @@ To use Soteria Rust, you need a frontend to translate Rust code to an intermedia
 
 **Manual installation:**
 1. **Clone Obol at the correct commit:**
-   <!-- [versionsync: OBOL_COMMIT_HASH=1ce4c36928b0ed946c13214c4f416d18abb4380a] -->
+   <!-- [versionsync: OBOL_COMMIT_HASH=ceb01d2890c6c15e851ecf92d91104a85a0adb0b] -->
    ```sh
    cd ..
    git clone https://github.com/soteria-tools/obol.git
    cd obol
-   git checkout 1ce4c36928b0ed946c13214c4f416d18abb4380a
+   git checkout ceb01d2890c6c15e851ecf92d91104a85a0adb0b
    ```
    > **Note:** The required commit hash can always be found in [`scripts/versions.json`](scripts/versions.json) under `OBOL_COMMIT_HASH`.
 

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -3,7 +3,7 @@
   "CHARON_REPO": "soteria-tools/charon",
   "CHARON_COMMIT_HASH": "a16823aa6fce73baca964350d46cd667df6a1b29",
   "OBOL_REPO": "soteria-tools/obol",
-  "OBOL_COMMIT_HASH": "1ce4c36928b0ed946c13214c4f416d18abb4380a",
+  "OBOL_COMMIT_HASH": "ceb01d2890c6c15e851ecf92d91104a85a0adb0b",
   "OCAMLFORMAT_VERSION": "0.28.1",
   "OCAML_VERSION": "5.4.1",
   "DUNE_VERSION": "3.23.1"

--- a/soteria-rust/lib/builtins/fixme/impl.ml
+++ b/soteria-rust/lib/builtins/fixme/impl.ml
@@ -1,3 +1,4 @@
+open Syntaxes.FunctionWrap
 open Common
 open Rust_val
 open Typed.Infix
@@ -22,9 +23,9 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
   let cleanup ~payload =
     let ptr, _ = payload in
     let* usize_size = Layout.size_of (TLiteral (TUInt Usize)) in
+    let@ () = with_alloc_kind ~kind:(VTable Charon.TypesUtils.mk_unit_ty) in
     let* vtable, _ =
-      State.alloc_untyped ~kind:(VTable Charon.TypesUtils.mk_unit_ty)
-        ~zeroed:true
+      State.alloc_untyped ~zeroed:true
         ~size:Usize.(usize_size *!!@ 3s)
         ~align:(Typed.cast usize_size) ()
     in

--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -1,3 +1,4 @@
+open Syntaxes.FunctionWrap
 open Charon
 open Typed
 open Typed.Syntax
@@ -875,7 +876,8 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
         let str_ty : Types.ty =
           mk_array_ty (TLiteral (TUInt U8)) (Z.of_int len)
         in
-        let* ptr, _ = State.alloc_ty ~kind:StaticString str_ty in
+        let@ () = with_alloc_kind ~kind:StaticString in
+        let* ptr, _ = State.alloc_ty str_ty in
         let ptr = (ptr, Len (BV.usizei len)) in
         let* () = State.store ptr str_ty char_arr in
         let+ () = State.store_str_global str ptr in

--- a/soteria-rust/lib/common/alloc_kind.ml
+++ b/soteria-rust/lib/common/alloc_kind.ml
@@ -5,6 +5,7 @@ type t =
   | Function of Fun_kind.t
   | VTable of Types.ty [@printer Charon_util.pp_ty]
   | Static of Types.global_decl_ref [@printer Crate.pp_global_decl_ref]
+  | Const of Types.global_decl_ref [@printer Crate.pp_global_decl_ref]
   | StaticString
   | AnonConst
 [@@deriving show { with_path = false }]

--- a/soteria-rust/lib/crate.ml
+++ b/soteria-rust/lib/crate.ml
@@ -196,6 +196,13 @@ let is_struct (adt_ref : Types.type_decl_ref) =
       match (get_adt_raw id).kind with Struct _ -> true | _ -> false)
   | _ -> false
 
+let is_struct_or_tuple (adt_ref : Types.type_decl_ref) =
+  match adt_ref.id with
+  | TTuple -> true
+  | TAdtId id -> (
+      match (get_adt_raw id).kind with Struct _ -> true | _ -> false)
+  | _ -> false
+
 let is_union (adt_ref : Types.type_decl_ref) =
   match adt_ref.id with
   | TAdtId id -> (

--- a/soteria-rust/lib/error.ml
+++ b/soteria-rust/lib/error.ml
@@ -18,6 +18,7 @@ type t =
   | `NotAFnPointer
     (** Tried calling a function pointer, but it doesn't represent a function *)
   | `AccessedFnPointer  (** Tried accessing a function pointer's pointee *)
+  | `WriteToReadOnly  (** Tried writing to a read-only location *)
   | `InvalidFnArgCount of int * int
     (** Invalid argument count for function (function pointers only)
         [(expected, received)] *)
@@ -136,6 +137,7 @@ let rec pp ft : [> t ] -> unit = function
   | `UBTransmute msg -> Fmt.pf ft "UB: Transmute: %s" msg
   | `UnwindTerminate -> Fmt.string ft "Terminated unwind"
   | `UseAfterFree -> Fmt.string ft "Use after free"
+  | `WriteToReadOnly -> Fmt.string ft "Write to read-only location"
 
 let severity : t -> Soteria.Terminal.Diagnostic.severity = function
   | `MemoryLeak -> Warning

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -217,7 +217,8 @@ module Make (StateImpl : State.S) = struct
             let str_ty : Types.ty =
               mk_array_ty (TLiteral (TUInt U8)) (Z.of_int len)
             in
-            let* ptr, _ = State.alloc_ty ~kind:StaticString str_ty in
+            let@ () = with_alloc_kind ~kind:StaticString in
+            let* ptr, _ = State.alloc_ty str_ty in
             let ptr = (ptr, Len (BV.usizei len)) in
             let* () = State.store ptr str_ty char_arr in
             let+ () = State.store_str_global str ptr in
@@ -325,7 +326,8 @@ module Make (StateImpl : State.S) = struct
         (* HACK: ideally Charon shouldn't have ref constants, those are entirely
            separate allocations :/ *)
         let* v = resolve_constant expr in
-        let* ptr = State.alloc_ty ~kind:AnonConst expr.ty in
+        let@ () = with_alloc_kind ~kind:AnonConst in
+        let* ptr = State.alloc_ty expr.ty in
         let+ () = State.store ptr expr.ty v in
         Ptr ptr
     | CPtr _ ->
@@ -541,10 +543,8 @@ module Make (StateImpl : State.S) = struct
           "Resolved global init call to %a" Crate.pp_name fundef.item_meta.name];
         let global_fn = exec_real_fun fundef glob.generics in
         (* First we allocate the global and store it in the State *)
-        let* ptr =
-          State.alloc_ty ~kind:(Static glob) ~span:decl.item_meta.span.data
-            decl.ty
-        in
+        let@ () = with_alloc_kind ~kind:(Static glob) in
+        let* ptr = State.alloc_ty ~span:decl.item_meta.span.data decl.ty in
         let* () = State.store_global glob.id ptr in
         (* And only after we compute it; this enables recursive globals *)
         let* v = with_env ~env:() @@ global_fn [] in

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -122,8 +122,8 @@ module Make (StateImpl : State.S) = struct
     |> fold_list ~init:[] ~f:(fun acc ((local : GAst.local), value) ->
         (* Passed (nested) references must be protected and be valid. *)
         let* value, protected' =
-          Encoder.update_ref_tys_in value local.local_ty ~init:acc
-            ~f:(fun acc ptr ptr_ty ->
+          Encoder.ref_tys_in local.local_ty value ~init:acc
+            ~f:(fun acc ptr_ty ptr ->
               let+ ptr' = State.borrow ~protect:true ptr ptr_ty in
               let pointee = Charon_util.get_pointee ptr_ty in
               (ptr', (ptr', pointee) :: acc))
@@ -1042,11 +1042,11 @@ module Make (StateImpl : State.S) = struct
     | Return ->
         let* ptr, ty = get_variable_lazy_and_ty Expressions.LocalId.zero in
         let* value = load_lazy ptr ty in
-        let ptr_tys = Encoder.ref_tys_in value ty in
-        let+ () =
-          iter_list ptr_tys ~f:(fun (ptr, ty) -> State.tb_load ptr ty)
-        in
-        value
+        Encoder.ref_tys_in ty value ~init:() ~f:(fun () ptr_ty ptr ->
+            let pointee = get_pointee ptr_ty in
+            let+ () = State.tb_load ptr pointee in
+            (ptr, ()))
+        |> map fst
     | Switch (discr, switch) -> (
         let* discr = eval_operand discr in
         match switch with

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -543,7 +543,12 @@ module Make (StateImpl : State.S) = struct
           "Resolved global init call to %a" Crate.pp_name fundef.item_meta.name];
         let global_fn = exec_real_fun fundef glob.generics in
         (* First we allocate the global and store it in the State *)
-        let@ () = with_alloc_kind ~kind:(Static glob) in
+        let kind : Alloc_kind.t =
+          match decl.global_kind with
+          | Static | ThreadLocal -> Static glob
+          | NamedConst | AnonConst -> Const glob
+        in
+        let@ () = with_alloc_kind ~kind in
         let* ptr = State.alloc_ty ~span:decl.item_meta.span.data decl.ty in
         let* () = State.store_global glob.id ptr in
         (* And only after we compute it; this enables recursive globals *)

--- a/soteria-rust/lib/rust_val.ml
+++ b/soteria-rust/lib/rust_val.ml
@@ -199,6 +199,11 @@ let as_tuple = function
   | v ->
       Fmt.failwith "Unexpected rust_val kind, expected a tuple, got: %a" ppa v
 
+let as_enum = function
+  | Enum (disc, vals) -> (disc, vals)
+  | v ->
+      Fmt.failwith "Unexpected rust_val kind, expected an enum, got: %a" ppa v
+
 let flatten v =
   let rec aux acc = function
     | Tuple vs | Enum (_, vs) -> List.fold_left aux acc vs

--- a/soteria-rust/lib/rustsymex.ml
+++ b/soteria-rust/lib/rustsymex.ml
@@ -25,9 +25,22 @@ end)
 
 module MonadState = struct
   type t = {
-    trace : Trace.t;
+    trace : Trace.t;  (** The current trace of execution *)
     subst : Charon.Substitute.subst;
+        (** In polymorphic mode, the current substitution to be applied to
+            generics. See also {!Poly}. *)
     generic_layouts : Layout_common.t TypeMap.t;
+        (** The map of generic layouts, for types with generics.
+            {b This is soundness critical}, it is not "just" a cache. A cache
+            implies that we are allowed to clear it, and things are okay. It is
+            not the case here: if we lose information on a generic
+            (nondeterministic) layout, recomputing it will create new symbolic
+            variables, which may not match the layout that was previously
+            computed. *)
+    alloc_kind : Common.Alloc_kind.t;
+        (** The current allocation kind. This is needed to mark all allocations
+            done in a constant's initialiser as related to the constant, so that
+            they are not considered when checking for memory leaks. *)
   }
 
   let empty =
@@ -35,6 +48,7 @@ module MonadState = struct
       trace = Trace.empty;
       subst = Charon.Substitute.empty_subst;
       generic_layouts = TypeMap.empty;
+      alloc_kind = Heap;
     }
 end
 
@@ -139,6 +153,17 @@ let get_trace () : Trace.t t =
   let open Syntax in
   let+ { trace; _ } = get_state () in
   trace
+
+let with_alloc_kind alloc_kind (f : 'a t) : 'a t =
+ fun st ->
+  let open MonoSymex.Syntax in
+  let+ result, state = f { st with alloc_kind } in
+  (result, { state with alloc_kind = st.alloc_kind })
+
+let get_alloc_kind () : Common.Alloc_kind.t t =
+  let open Syntax in
+  let+ { alloc_kind; _ } = get_state () in
+  alloc_kind
 
 let error ?trace e : ('a, Error.with_trace, 'f) Result.t =
   let open Syntax in

--- a/soteria-rust/lib/state/rust_state_m.ml
+++ b/soteria-rust/lib/state/rust_state_m.ml
@@ -64,6 +64,10 @@ module type S = sig
   val of_opt_not_impl : string -> 'a option -> ('a, 'env) t
   val assume : Typed.T.sbool Typed.t list -> (unit, 'env) t
   val with_loc : loc:Meta.span_data -> (unit -> ('a, 'env) t) -> ('a, 'env) t
+
+  val with_alloc_kind :
+    kind:Alloc_kind.t -> (unit -> ('a, 'env) t) -> ('a, 'env) t
+
   val get_trace : unit -> (Trace.t, 'env) t
 
   val with_extra_call_trace :
@@ -161,9 +165,7 @@ module type S = sig
       rust_val
 
     val nondet_valid : Types.ty -> (rust_val, 'env) monad
-
-    val ref_tys_in :
-      ?include_ptrs:bool -> rust_val -> Types.ty -> (full_ptr * Types.ty) list
+    val ref_tys_in : Types.ty -> rust_val -> (Types.ty * full_ptr) Iter.t
 
     val update_ref_tys_in :
       f:('acc -> full_ptr -> Types.ty -> (full_ptr * 'acc, 'env) monad) ->
@@ -179,21 +181,12 @@ module type S = sig
     val load_discriminant : full_ptr -> Types.ty -> (Types.variant_id, 'env) t
     val store : full_ptr -> Types.ty -> rust_val -> (unit, 'env) t
     val zeros : full_ptr -> Typed.T.sint Typed.t -> (unit, 'env) t
-
-    val alloc_ty :
-      ?kind:Alloc_kind.t ->
-      ?span:Meta.span_data ->
-      Types.ty ->
-      (full_ptr, 'env) t
+    val alloc_ty : ?span:Meta.span_data -> Types.ty -> (full_ptr, 'env) t
 
     val alloc_tys :
-      ?kind:Alloc_kind.t ->
-      ?span:Meta.span_data ->
-      Types.ty list ->
-      (full_ptr list, 'env) t
+      ?span:Meta.span_data -> Types.ty list -> (full_ptr list, 'env) t
 
     val alloc_untyped :
-      ?kind:Alloc_kind.t ->
       ?span:Meta.span_data ->
       zeroed:bool ->
       size:Typed.T.sint Typed.t ->
@@ -375,6 +368,9 @@ module Make (State : State_intf.S) :
   let with_loc ~loc (f : unit -> ('a, 'env) t) : ('a, 'env) t =
    fun env state -> with_loc ~loc (f () env state)
 
+  let with_alloc_kind ~kind (f : unit -> ('a, 'env) t) : ('a, 'env) t =
+   fun env state -> with_alloc_kind kind (f () env state)
+
   let get_trace () : (Trace.t, 'env) t = lift_symex @@ Rustsymex.get_trace ()
 
   let with_extra_call_trace ?name ~loc ~msg (x : ('a, 'env) t) : ('a, 'env) t =
@@ -483,13 +479,11 @@ module Make (State : State_intf.S) :
     let[@inline] load_discriminant ptr ty = ESM.lift (load_discriminant ptr ty)
     let[@inline] store ptr ty v = ESM.lift (store ptr ty v)
     let[@inline] zeros ptr size = ESM.lift (zeros ptr size)
-    let[@inline] alloc_ty ?kind ?span ty = ESM.lift (alloc_ty ?kind ?span ty)
+    let[@inline] alloc_ty ?span ty = ESM.lift (alloc_ty ?span ty)
+    let[@inline] alloc_tys ?span tys = ESM.lift (alloc_tys ?span tys)
 
-    let[@inline] alloc_tys ?kind ?span tys =
-      ESM.lift (alloc_tys ?kind ?span tys)
-
-    let[@inline] alloc_untyped ?kind ?span ~zeroed ~size ~align () =
-      ESM.lift (alloc_untyped ?kind ?span ~zeroed ~size ~align)
+    let[@inline] alloc_untyped ?span ~zeroed ~size ~align () =
+      ESM.lift (alloc_untyped ?span ~zeroed ~size ~align)
 
     let[@inline] copy_nonoverlapping ~src ~dst ~size =
       ESM.lift (copy_nonoverlapping ~src ~dst ~size)

--- a/soteria-rust/lib/state/rust_state_m.ml
+++ b/soteria-rust/lib/state/rust_state_m.ml
@@ -165,13 +165,12 @@ module type S = sig
       rust_val
 
     val nondet_valid : Types.ty -> (rust_val, 'env) monad
-    val ref_tys_in : Types.ty -> rust_val -> (Types.ty * full_ptr) Iter.t
 
-    val update_ref_tys_in :
-      f:('acc -> full_ptr -> Types.ty -> (full_ptr * 'acc, 'env) monad) ->
+    val ref_tys_in :
+      f:('acc -> Types.ty -> full_ptr -> (full_ptr * 'acc, 'env) monad) ->
       init:'acc ->
-      rust_val ->
       Types.ty ->
+      rust_val ->
       (rust_val * 'acc, 'env) monad
   end
 
@@ -447,21 +446,21 @@ module Make (State : State_intf.S) :
     let[@inline] encode ~offset v ty = lift_err (encode ~offset v ty)
     let[@inline] nondet_valid ty = lift_err (nondet_valid ty)
 
-    (* We painfully lift [Layout.update_ref_tys_in] to make it nicer to use
-       without having to re-define. *)
-    let update_ref_tys_in
-        ~(f : 'acc -> full_ptr -> Types.ty -> (full_ptr * 'acc, 'env) monad)
-        ~(init : 'acc) (v : rust_val) (ty : Types.ty) :
+    (* We painfully lift [Layout.ref_tys_in] to make it nicer to use without
+       having to re-define. *)
+    let ref_tys_in
+        ~(f : 'acc -> Types.ty -> full_ptr -> (full_ptr * 'acc, 'env) monad)
+        ~(init : 'acc) (ty : Types.ty) (v : rust_val) :
         (rust_val * 'acc, 'env) monad =
      fun env state ->
       let open Rustsymex.Syntax in
       (* The inner function operates in Rustsymex.Result.t, carrying (acc, env,
          state) as accumulator *)
-      let f_inner (acc, env, state) ptr ty =
-        let+ (res, new_env), new_state = f acc ptr ty env state in
+      let f_inner (acc, env, state) ty ptr =
+        let+ (res, new_env), new_state = f acc ty ptr env state in
         Compo_res.map (fun (ptr, acc) -> (ptr, (acc, new_env, new_state))) res
       in
-      let+ res = update_ref_tys_in f_inner (init, env, state) v ty in
+      let+ res = ref_tys_in f_inner (init, env, state) ty v in
       match res with
       | Ok (v, (acc, env, state)) -> ((Ok (v, acc), env), state)
       | Error e -> ((Error e, env), state)

--- a/soteria-rust/lib/state/state_intf.ml
+++ b/soteria-rust/lib/state/state_intf.ml
@@ -55,22 +55,14 @@ module type S = sig
   val store : full_ptr -> Types.ty -> rust_val -> unit ret
 
   val alloc_untyped :
-    ?kind:Alloc_kind.t ->
     ?span:Meta.span_data ->
     zeroed:bool ->
     size:sint Typed.t ->
     align:nonzero Typed.t ->
     full_ptr ret
 
-  val alloc_ty :
-    ?kind:Alloc_kind.t -> ?span:Meta.span_data -> Types.ty -> full_ptr ret
-
-  val alloc_tys :
-    ?kind:Alloc_kind.t ->
-    ?span:Meta.span_data ->
-    Types.ty list ->
-    full_ptr list ret
-
+  val alloc_ty : ?span:Meta.span_data -> Types.ty -> full_ptr ret
+  val alloc_tys : ?span:Meta.span_data -> Types.ty list -> full_ptr list ret
   val free : full_ptr -> unit ret
 
   val size_and_align_of_val :

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -299,15 +299,15 @@ module Make (Borrows : Tree_borrows.T) = struct
     include
       Soteria.Sym_states.With_info.Make (DecayMap.SM) (Meta) (Freeable_block)
 
-    let is_freed : syn -> bool = function
+    let[@inline] is_freed : syn -> bool = function
       | { node = Freed; _ } -> true
       | _ -> false
 
-    let trace_syn : syn -> Trace.t option = function
+    let[@inline] trace_syn : syn -> Trace.t option = function
       | { info = Some { trace; _ }; _ } -> Some trace
       | _ -> None
 
-    let alloc_kind : t option -> Alloc_kind.t option = function
+    let[@inline] alloc_kind : t option -> Alloc_kind.t option = function
       | Some { info = Some { kind; _ }; _ } -> Some kind
       | _ -> None
 
@@ -331,7 +331,9 @@ module Make (Borrows : Tree_borrows.T) = struct
         (StateKey)
         (Freeable_block_with_meta)
 
-    let with_ptr (access : [ `Ghost | `Read | `Write ]) (ptr : Sptr_base.t)
+    type access = Ghost | Read | Write
+
+    let with_ptr (access : access) (ptr : Sptr_base.t)
         (f : [< T.sint ] Typed.t -> ('a, 'err, 'fix list) Block.SM.Result.t) :
         ('a, 'err, syn list) SM.Result.t =
       let open SM in
@@ -346,9 +348,9 @@ module Make (Borrows : Tree_borrows.T) = struct
            let open SM.Syntax in
            let* block = SM.get_state () in
            match (alloc_kind block, access) with
-           | Some (Function _), (`Read | `Write) ->
+           | Some (Function _), (Read | Write) ->
                SM.Result.error `AccessedFnPointer
-           | Some ((Const _ | AnonConst | StaticString) as k), `Write ->
+           | Some ((Const _ | AnonConst | StaticString) as k), Write ->
                let*^ cur_kind = DecayMap.SM.lift @@ get_alloc_kind () in
                if cur_kind <> k then SM.Result.error `WriteToReadOnly
                else Freeable_block_with_meta.wrap @@ Freeable_block.wrap (f ofs)
@@ -463,11 +465,11 @@ module Make (Borrows : Tree_borrows.T) = struct
       (a, Error.t, syn list) Result.t =
     let* () = log "load" ptr in
     let handler (ty, ofs) =
-      let@ _ofs = Heap.with_ptr `Read ptr in
+      let@ _ofs = Heap.with_ptr Read ptr in
       Block.with_block_read_tb (Tree_block.load ~ignore_borrow ofs ty ptr.tag)
     in
     let get_all (size, ofs) =
-      let@ _ofs = Heap.with_ptr `Read ptr in
+      let@ _ofs = Heap.with_ptr Read ptr in
       Block.with_block (Tree_block.get_init_leaves ofs size)
     in
     let offset = Typed.Ptr.ofs ptr.ptr in
@@ -482,7 +484,7 @@ module Make (Borrows : Tree_borrows.T) = struct
     let@ () = with_loc_err ~trace:"Uninitialising memory" () in
     let* () = log "uninit" ptr in
     let**^ size = Layout.size_of ty in
-    let@ ofs = with_ptr `Write ptr in
+    let@ ofs = with_ptr Write ptr in
     Block.with_block @@ Tree_block.uninit_range ofs size
 
   let rec size_and_align_of_val t meta =
@@ -535,7 +537,7 @@ module Make (Borrows : Tree_borrows.T) = struct
           (ptr', Typed.(cast (BV.neg size)))
       in
       let open Block.SM.Syntax in
-      let@ ofs = with_ptr `Ghost ptr in
+      let@ ofs = with_ptr Ghost ptr in
       let+- _ =
         Block.with_block (Tree_block.check_owned ofs (Typed.cast size))
       in
@@ -621,7 +623,7 @@ module Make (Borrows : Tree_borrows.T) = struct
         if%sat size ==@ Usize.(0s) then Result.ok ()
         else
           let* () = log "tb_load" ptr in
-          let@ ofs = with_ptr `Ghost ptr in
+          let@ ofs = with_ptr Ghost ptr in
           Block.with_block_read_tb (Tree_block.tb_access ofs size tag)
 
   (** Performs a load at the tree borrow level, by updating the borrow state,
@@ -643,7 +645,7 @@ module Make (Borrows : Tree_borrows.T) = struct
          Encoder.pp_rust_val Typed.ppa)) parts]; *)
       let* () = log "store" ptr in
       let**^ size = Layout.size_of ty in
-      let@ ofs = with_ptr `Write ptr in
+      let@ ofs = with_ptr Write ptr in
       Block.with_block_read_tb (fun tb ->
           let open Tree_block.SM in
           let open Tree_block.SM.Syntax in
@@ -772,13 +774,13 @@ module Make (Borrows : Tree_borrows.T) = struct
       (unit, Error.with_trace, syn list) Result.t =
     let@ () = with_loc_err ~trace:"Non-overlapping copy" () in
     let** tree_to_write =
-      let@ ofs = with_ptr `Read src in
+      let@ ofs = with_ptr Read src in
       Block.with_block (fun tree_block ->
           let open DecayMap.SM.Syntax in
           let+ res, _ = Tree_block.get_raw_tree_owned ofs size tree_block in
           (res, tree_block))
     in
-    let@ ofs = with_ptr `Write dst in
+    let@ ofs = with_ptr Write dst in
     Block.with_block
       (let open Tree_block.SM in
        let open Tree_block.SM.Syntax in
@@ -904,7 +906,7 @@ module Make (Borrows : Tree_borrows.T) = struct
   let zeros (ptr, _) size =
     let@ () = with_loc_err ~trace:"Memory store (0s)" () in
     let* () = log "zeroes" ptr in
-    let@ ofs = with_ptr `Write ptr in
+    let@ ofs = with_ptr Write ptr in
     Block.with_block (Tree_block.zero_range ofs size)
 
   let store_str_global str ptr =
@@ -932,7 +934,7 @@ module Make (Borrows : Tree_borrows.T) = struct
     match ptr.tag with
     | None -> Result.ok fptr
     | Some tag ->
-        let@ ofs = with_ptr `Ghost ptr in
+        let@ ofs = with_ptr Ghost ptr in
         Block.borrow ?protect fptr tag ty ofs
 
   let unprotect ((ptr : Sptr_base.t), _) (ty : Types.ty) =
@@ -944,7 +946,7 @@ module Make (Borrows : Tree_borrows.T) = struct
         if freed then Result.ok ()
         else
           let**^ size = Layout.size_of ty in
-          let@ ofs = with_ptr `Ghost ptr in
+          let@ ofs = with_ptr Ghost ptr in
           [%l.debug "Unprotecting pointer %a" Sptr_base.pp ptr];
           Block.unprotect ofs tag size
 

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -307,6 +307,10 @@ module Make (Borrows : Tree_borrows.T) = struct
       | { info = Some { trace; _ }; _ } -> Some trace
       | _ -> None
 
+    let alloc_kind : t option -> Alloc_kind.t option = function
+      | Some { info = Some { kind; _ }; _ } -> Some kind
+      | _ -> None
+
     let make ?span ?zeroed ~size ~align () :
         (t * Borrows.Tag.t option) DecayMap.SM.t =
       let open DecayMap.SM.Syntax in
@@ -327,7 +331,7 @@ module Make (Borrows : Tree_borrows.T) = struct
         (StateKey)
         (Freeable_block_with_meta)
 
-    let with_ptr (ptr : Sptr_base.t)
+    let with_ptr (access : [ `Ghost | `Read | `Write ]) (ptr : Sptr_base.t)
         (f : [< T.sint ] Typed.t -> ('a, 'err, 'fix list) Block.SM.Result.t) :
         ('a, 'err, syn list) SM.Result.t =
       let open SM in
@@ -341,9 +345,13 @@ module Make (Borrows : Tree_borrows.T) = struct
           (let open Freeable_block_with_meta in
            let open SM.Syntax in
            let* block = SM.get_state () in
-           match block with
-           | Some { info = Some { kind = Function _; _ }; _ } ->
+           match (alloc_kind block, access) with
+           | Some (Function _), (`Read | `Write) ->
                SM.Result.error `AccessedFnPointer
+           | Some ((Const _ | AnonConst | StaticString) as k), `Write ->
+               let*^ cur_kind = DecayMap.SM.lift @@ get_alloc_kind () in
+               if cur_kind <> k then SM.Result.error `WriteToReadOnly
+               else Freeable_block_with_meta.wrap @@ Freeable_block.wrap (f ofs)
            | _ -> Freeable_block_with_meta.wrap @@ Freeable_block.wrap (f ofs))
       in
       match res with
@@ -455,11 +463,11 @@ module Make (Borrows : Tree_borrows.T) = struct
       (a, Error.t, syn list) Result.t =
     let* () = log "load" ptr in
     let handler (ty, ofs) =
-      let@ _ofs = Heap.with_ptr ptr in
+      let@ _ofs = Heap.with_ptr `Read ptr in
       Block.with_block_read_tb (Tree_block.load ~ignore_borrow ofs ty ptr.tag)
     in
     let get_all (size, ofs) =
-      let@ _ofs = Heap.with_ptr ptr in
+      let@ _ofs = Heap.with_ptr `Read ptr in
       Block.with_block (Tree_block.get_init_leaves ofs size)
     in
     let offset = Typed.Ptr.ofs ptr.ptr in
@@ -467,14 +475,14 @@ module Make (Borrows : Tree_borrows.T) = struct
     @@ Heap.Decoder.ParserMonad.parse ~handler ~get_all
     @@ parser ~offset
 
-  let with_ptr ptr f = with_heap @@ Heap.with_ptr ptr f
+  let with_ptr access ptr f = with_heap @@ Heap.with_ptr access ptr f
 
   let uninit ((ptr, _) : Sptr_base.t * 'a) (ty : Types.ty) :
       (unit, 'err, 'fix) Result.t =
     let@ () = with_loc_err ~trace:"Uninitialising memory" () in
     let* () = log "uninit" ptr in
     let**^ size = Layout.size_of ty in
-    let@ ofs = with_ptr ptr in
+    let@ ofs = with_ptr `Write ptr in
     Block.with_block @@ Tree_block.uninit_range ofs size
 
   let rec size_and_align_of_val t meta =
@@ -527,7 +535,7 @@ module Make (Borrows : Tree_borrows.T) = struct
           (ptr', Typed.(cast (BV.neg size)))
       in
       let open Block.SM.Syntax in
-      let@ ofs = with_ptr ptr in
+      let@ ofs = with_ptr `Ghost ptr in
       let+- _ =
         Block.with_block (Tree_block.check_owned ofs (Typed.cast size))
       in
@@ -613,7 +621,7 @@ module Make (Borrows : Tree_borrows.T) = struct
         if%sat size ==@ Usize.(0s) then Result.ok ()
         else
           let* () = log "tb_load" ptr in
-          let@ ofs = with_ptr ptr in
+          let@ ofs = with_ptr `Ghost ptr in
           Block.with_block_read_tb (Tree_block.tb_access ofs size tag)
 
   (** Performs a load at the tree borrow level, by updating the borrow state,
@@ -635,7 +643,7 @@ module Make (Borrows : Tree_borrows.T) = struct
          Encoder.pp_rust_val Typed.ppa)) parts]; *)
       let* () = log "store" ptr in
       let**^ size = Layout.size_of ty in
-      let@ ofs = with_ptr ptr in
+      let@ ofs = with_ptr `Write ptr in
       Block.with_block_read_tb (fun tb ->
           let open Tree_block.SM in
           let open Tree_block.SM.Syntax in
@@ -764,13 +772,13 @@ module Make (Borrows : Tree_borrows.T) = struct
       (unit, Error.with_trace, syn list) Result.t =
     let@ () = with_loc_err ~trace:"Non-overlapping copy" () in
     let** tree_to_write =
-      let@ ofs = with_ptr src in
+      let@ ofs = with_ptr `Read src in
       Block.with_block (fun tree_block ->
           let open DecayMap.SM.Syntax in
           let+ res, _ = Tree_block.get_raw_tree_owned ofs size tree_block in
           (res, tree_block))
     in
-    let@ ofs = with_ptr dst in
+    let@ ofs = with_ptr `Write dst in
     Block.with_block
       (let open Tree_block.SM in
        let open Tree_block.SM.Syntax in
@@ -896,7 +904,7 @@ module Make (Borrows : Tree_borrows.T) = struct
   let zeros (ptr, _) size =
     let@ () = with_loc_err ~trace:"Memory store (0s)" () in
     let* () = log "zeroes" ptr in
-    let@ ofs = with_ptr ptr in
+    let@ ofs = with_ptr `Write ptr in
     Block.with_block (Tree_block.zero_range ofs size)
 
   let store_str_global str ptr =
@@ -924,7 +932,7 @@ module Make (Borrows : Tree_borrows.T) = struct
     match ptr.tag with
     | None -> Result.ok fptr
     | Some tag ->
-        let@ ofs = with_ptr ptr in
+        let@ ofs = with_ptr `Ghost ptr in
         Block.borrow ?protect fptr tag ty ofs
 
   let unprotect ((ptr : Sptr_base.t), _) (ty : Types.ty) =
@@ -936,7 +944,7 @@ module Make (Borrows : Tree_borrows.T) = struct
         if freed then Result.ok ()
         else
           let**^ size = Layout.size_of ty in
-          let@ ofs = with_ptr ptr in
+          let@ ofs = with_ptr `Ghost ptr in
           [%l.debug "Unprotecting pointer %a" Sptr_base.pp ptr];
           Block.unprotect ofs tag size
 

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -307,10 +307,11 @@ module Make (Borrows : Tree_borrows.T) = struct
       | { info = Some { trace; _ }; _ } -> Some trace
       | _ -> None
 
-    let make ?(kind = Alloc_kind.Heap) ?span ?zeroed ~size ~align () :
+    let make ?span ?zeroed ~size ~align () :
         (t * Borrows.Tag.t option) DecayMap.SM.t =
       let open DecayMap.SM.Syntax in
       let* tag, block = Block.alloc ?zeroed size in
+      let*^ kind = get_alloc_kind () in
       let+^ trace = get_trace () in
       let trace = Trace.rename 0 "Allocation" trace in
       let trace = Trace.move_to_opt span trace in
@@ -434,6 +435,9 @@ module Make (Borrows : Tree_borrows.T) = struct
         ptr
         (Fmt.Dump.option (pp_pretty ~ignore_freed:true))
         st]
+
+  let[@inline] with_alloc_kind kind (f : unit -> 'a t) : 'a t =
+   fun st -> with_alloc_kind kind (f () st)
 
   let[@inline] with_loc_err ?trace:msg ()
       (f : unit -> ('a, Error.t, 'f) SM.Result.t) :
@@ -824,12 +828,12 @@ module Make (Borrows : Tree_borrows.T) = struct
        in
        Tree_block.put_raw_tree ofs tree_to_write)
 
-  let alloc ?kind ?span ?zeroed size align =
+  let alloc ?span ?zeroed size align =
     with_heap
       (let open Heap.SM in
        let open Heap.SM.Syntax in
        let*^ block, tag =
-         Freeable_block_with_meta.make ?kind ?span ?zeroed ~align ~size ()
+         Freeable_block_with_meta.make ?span ?zeroed ~align ~size ()
        in
        let** loc = Heap.alloc ~new_codom:block in
        let ptr = Typed.Ptr.mk loc Usize.(0s) in
@@ -838,15 +842,14 @@ module Make (Borrows : Tree_borrows.T) = struct
        let+ () = assume [ Typed.(not (Ptr.is_null_loc loc)) ] in
        ok (ptr, Thin))
 
-  let alloc_untyped ?kind ?span ~zeroed ~size ~align =
-    alloc ?kind ?span ~zeroed size align
+  let alloc_untyped ?span ~zeroed ~size ~align = alloc ?span ~zeroed size align
 
-  let alloc_ty ?kind ?span ty =
+  let alloc_ty ?span ty =
     let@ () = with_loc_err ~trace:"Allocation" () in
     let**^ layout = Layout.layout_of ty in
-    alloc ?kind ?span layout.size layout.align
+    alloc ?span layout.size layout.align
 
-  let alloc_tys ?kind ?span tys : ('a, Error.with_trace, syn list) Result.t =
+  let alloc_tys ?span tys : ('a, Error.with_trace, syn list) Result.t =
     let@ () = with_loc_err ~trace:"Allocation" () in
     let**^ layouts = Rustsymex.Result.map_list tys ~f:Layout.layout_of in
     let layouts = List.rev layouts in
@@ -857,7 +860,7 @@ module Make (Borrows : Tree_borrows.T) = struct
            (* make Tree_block *)
            let { size; align; _ } : Layout.t = layout in
            let* block, tag =
-             Freeable_block_with_meta.make ?kind ?span ~align ~size ()
+             Freeable_block_with_meta.make ?span ~align ~size ()
            in
            (* create pointer *)
            let* () = assume [ Typed.(not (Ptr.is_null_loc loc)) ] in
@@ -965,56 +968,28 @@ module Make (Borrows : Tree_borrows.T) = struct
                    Result.ok (ptr, Thin)))
 
   let leak_check () : (unit, Error.with_trace, syn list) Result.t =
-    (* FIXME: this is an unnecessarily complicated function; what we should do
-       is properly track what allocations come from a const/static (with
-       Alloc_kind), and then simply iterate over all allocations and look for
-       non-const/static allocations. *)
-    let* st = SM.get_state () in
-    let st = of_opt st in
-    let* global_addresses =
-      fold_list (GlobMap.bindings st.globals) ~init:[]
-        ~f:(fun acc (g, ((ptr : Sptr_base.t), _)) ->
-          let loc = Typed.Ptr.loc ptr.ptr in
-          match g with
-          | String _ -> return (loc :: acc)
-          | Global g -> (
-              let glob = Crate.get_global g in
-              let* res = load ~ignore_borrow:true (ptr, Thin) glob.ty in
-              match res with
-              | Ok v ->
-                  let ptrs = Encoder.ref_tys_in ~include_ptrs:true v glob.ty in
-                  let ptrs =
-                    List.map
-                      (fun (((p : Sptr_base.t), _), _) -> Typed.Ptr.loc p.ptr)
-                      ptrs
-                  in
-                  return (loc :: (ptrs @ acc))
-              | _ -> return acc))
-    in
     with_heap
       (let open Heap.SM in
        let open Heap.SM.Syntax in
        let* heap = get_state () in
-       let*^ leaks =
-         Heap.fold
-           (fun leaks (k, (v : Freeable_block_with_meta.t)) ->
+       let leaks =
+         Heap.syntactic_bindings (Heap.of_opt heap)
+         |> Seq.filter_map (fun (k, (v : Freeable_block_with_meta.t)) ->
              (* FIXME: This only works because our addresses are concrete *)
              let open DecayMap.SM in
-             match v with
-             | { node = Alive _; info = Some { kind = Heap; trace; _ }; _ }
-               when not (List.mem k global_addresses) ->
-                 return ((k, trace) :: leaks)
-             | _ -> return leaks)
-           [] heap
+             match (v.node, v.info) with
+             | Alive _, Some { kind = Heap; trace; _ } -> Some (k, trace)
+             | _ -> None)
        in
-       if List.is_empty leaks then Result.ok ()
+       if Seq.is_empty leaks then Result.ok ()
        else
          let pp_leak ft (k, trace) =
            Fmt.pf ft "%a (allocated at %a)" Typed.ppa k Trace.pp trace
          in
-         [%l.info "Found leaks: %a" Fmt.(list ~sep:(any ", ") pp_leak) leaks];
-         let wheres = List.map snd leaks in
-         let* leak_trace = branches (List.map (fun t () -> return t) wheres) in
+         [%l.info "Found leaks: %a" Fmt.(seq ~sep:(any ", ") pp_leak) leaks];
+         let* leak_trace =
+           Seq.map (fun (_, t) () -> return t) leaks |> List.of_seq |> branches
+         in
          let leak_trace =
            Trace.rename ~rev:true 0 "Leaking function" leak_trace
          in
@@ -1057,9 +1032,8 @@ module Make (Borrows : Tree_borrows.T) = struct
           | Synthetic _ -> None
         in
         let** ptr, meta =
-          alloc_untyped ~kind:(Function fn_def) ?span ~zeroed:false
-            ~size:Usize.(0s)
-            ~align
+          with_alloc_kind (Function fn_def) @@ fun () ->
+          alloc_untyped ?span ~zeroed:false ~size:Usize.(0s) ~align
         in
         let ptr = { ptr with tag = None } in
         let loc = Typed.Ptr.loc ptr.ptr in

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -671,69 +671,31 @@ module Encoder (Sptr : Sptr.S) = struct
     in
     v
 
-  (** Traverses the given type and rust value, and returns all findable
-      references with their type (ignores pointers, except if [include_ptrs] is
-      true). This is needed e.g. when needing to get the pointers along with the
-      size of their pointee, in particular in nested cases. *)
-  let rec ref_tys_in ?(include_ptrs = false) (v : rust_val) (ty : Types.ty) :
-      ('a full_ptr * Types.ty) list =
-    let f = ref_tys_in ~include_ptrs in
-    match (v, ty) with
-    | Ptr ptr, (TAdt { id = TBuiltin TBox; _ } | TRef _) ->
-        [ (ptr, get_pointee ty) ]
-    | Ptr ptr, TRawPtr _ when include_ptrs -> [ (ptr, get_pointee ty) ]
-    | (Int _ | Float _), _ -> []
-    | Tuple vs, TAdt adt -> List.concat_map2 f vs (Crate.as_struct_or_tuple adt)
-    | Tuple vs, (TArray (ty, _) | TSlice ty) ->
-        List.concat_map (fun v -> f v ty) vs
-    | Enum (d, vs), TAdt adt -> (
-        match BV.to_z d with
-        | Some d -> (
-            let variants = Crate.as_enum adt in
-            let v =
-              List.find_opt
-                (fun (v : Types.variant) ->
-                  Z.equal d (z_of_literal v.discriminant))
-                variants
-            in
-            match v with
-            | Some v -> List.concat_map2 f vs (field_tys Types.(v.fields))
-            | None -> [])
-        | None -> [])
-    | Union _, TAdt { id = TAdtId _; _ } ->
-        (* FIXME: figure out if references inside unions get reborrowed. They
-           could, but I suspect they don't because there's no guarantee the
-           reference isn't some other field, e.g. in [union { a: &u8, b: &u16
-           }] *)
-        []
-    | _, TPattern (inner, _) -> f v inner
-    | _ -> []
-
   (** Folds over all the references and boxes in the given value and type,
       applying [fn] to them. This is used to update nested references when
       reborrowing. Calls [fn] with the pointer value and the pointer type (not
       the pointee). *)
-  let rec update_ref_tys_in
+  let rec ref_tys_in
       (fn :
         'acc ->
-        'a full_ptr ->
         Types.ty ->
+        'a full_ptr ->
         ('a full_ptr * 'acc, 'e, 'f) Rustsymex.Result.t) (init : 'acc)
-      (v : rust_val) (ty : Types.ty) :
+      (ty : Types.ty) (v : rust_val) :
       (rust_val * 'acc, 'e, 'f) Rustsymex.Result.t =
     let open Rustsymex in
     let open Syntax in
-    let f = update_ref_tys_in fn in
-    let fs acc vs ty =
+    let f = ref_tys_in fn in
+    let fs acc ty vs =
       let++ vs, acc =
         Result.fold_list vs ~init:([], acc) ~f:(fun (vs, acc) v ->
-            let++ v, acc = f acc v ty in
+            let++ v, acc = f acc ty v in
             (v :: vs, acc))
       in
       (List.rev vs, acc)
     in
-    let fs2 acc vs tys =
-      let vs = List.combine vs tys in
+    let fs' acc tys vs =
+      let vs = List.combine tys vs in
       let++ vs, acc =
         Result.fold_list vs ~init:([], acc) ~f:(fun (vs, acc) (v, ty) ->
             let++ v, acc = f acc v ty in
@@ -741,14 +703,14 @@ module Encoder (Sptr : Sptr.S) = struct
       in
       (List.rev vs, acc)
     in
-    match (v, ty) with
-    | Ptr ptr, TRef (_, _, _) ->
-        let++ ptr, acc = fn init ptr ty in
+    match ty with
+    | TRef (_, _, _) | TAdt { id = TBuiltin TBox; _ } ->
+        let++ ptr, acc = fn init ty (as_ptr v) in
         (Ptr ptr, acc)
-    | Tuple _, TAdt adt when adt_is_box adt ->
+    | TAdt adt when adt_is_box adt ->
         (* a box has only one non ZST, the pointer *)
         let ptr = as_ptr @@ List.hd @@ flatten v in
-        let++ ptr, acc = fn init ptr ty in
+        let++ ptr, acc = fn init ty ptr in
         (* recursively look for where the pointer is and replace it *)
         let rec subst_ptr = function
           | Tuple vs -> Tuple (List.map subst_ptr vs)
@@ -756,31 +718,19 @@ module Encoder (Sptr : Sptr.S) = struct
           | v -> v
         in
         (subst_ptr v, acc)
-    | Tuple vs, TAdt adt ->
-        let++ vs, acc = fs2 init vs (Crate.as_struct_or_tuple adt) in
+    | TAdt adt when Crate.is_struct_or_tuple adt ->
+        let++ vs, acc = fs' init (Crate.as_struct_or_tuple adt) (as_tuple v) in
         (Tuple vs, acc)
-    | Tuple vs, (TArray (ty, _) | TSlice ty) ->
-        let++ vs, acc = fs init vs ty in
+    | TArray (ty, _) | TSlice ty ->
+        let++ vs, acc = fs init ty (as_tuple v) in
         (Tuple vs, acc)
-    | Enum (d, vs), TAdt adt -> (
-        let variants = Crate.as_enum adt in
-        let* var =
-          match_on variants ~constr:(fun v ->
-              BV.of_literal v.discriminant ==@ d)
-        in
-        match var with
-        | Some var ->
-            let++ vs, acc = fs2 init vs (field_tys Types.(var.fields)) in
-            (Enum (d, vs), acc)
-        | None -> Result.ok (v, init))
-    | (Union _ as v), TAdt { id = TAdtId _; _ } ->
-        (* FIXME: figure out if references inside unions get reborrowed. They
-           could, but I suspect they don't because there's no guarantee the
-           reference isn't some other field, e.g. in [union { a: &u8, b: &u16
-           }] *)
-        Result.ok (v, init)
-    | v, TPattern (inner, _) -> f init v inner
-    | v, _ -> Result.ok (v, init)
+    | TAdt adt when Crate.is_enum adt ->
+        let d, vs = as_enum v in
+        let* var = variant_for_discr d adt in
+        let++ vs, acc = fs' init (field_tys Types.(var.fields)) vs in
+        (Enum (d, vs), acc)
+    | TPattern (inner, _) -> f init inner v
+    | _ -> Result.ok (v, init)
 
   (** Calculates the size and alignment of a type [t], according to the pointer
       metadata [meta]. Receives an arbitrary state and [load] function, to

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -552,14 +552,25 @@ Check we handle pattern types correctly
 Test that it's UB to write to a const (regardless of aliasing checks), and that we don't detect const refs as leaks
   $ soteria-rust exec write_to_const.rs  --ignore-aliasing
   Compiling... done in <time>
-  => Running write_to_const::main...
-  error: write_to_const::main: found issues in <time>, errors in 1 branch (out of 1)
-  bug: Write to read-only location in write_to_const::main
-      --> $TESTCASE_ROOT/write_to_const.rs:5:14
-    3 |  fn main() {
-      |  --------- 1: Entry point
-    4 |      let ptr = REF as *const u8 as *mut u8;
-    5 |      unsafe { *ptr = 67 };
+  => Running write_to_const::write_to_const...
+  error: write_to_const::write_to_const: found issues in <time>, errors in 1 branch (out of 1)
+  bug: Write to read-only location in write_to_const::write_to_const
+      --> $TESTCASE_ROOT/write_to_const.rs:6:14
+    4 |  fn write_to_const() {
+      |  ------------------- 1: Entry point
+    5 |      let ptr = REF as *const u8 as *mut u8;
+    6 |      unsafe { *ptr = 67 };
+      |               ^^^^^^^^^ Memory store
+  PC 1: empty
+  
+  => Running write_to_const::write_to_str...
+  error: write_to_const::write_to_str: found issues in <time>, errors in 1 branch (out of 1)
+  bug: Write to read-only location in write_to_const::write_to_str
+      --> $TESTCASE_ROOT/write_to_const.rs:12:14
+   10 |  fn write_to_str() {
+      |  ----------------- 1: Entry point
+   11 |      let ptr = "hello" as *const str as *mut u8;
+   12 |      unsafe { *ptr = 67 };
       |               ^^^^^^^^^ Memory store
   PC 1: empty
   

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -548,3 +548,11 @@ Check we handle pattern types correctly
   PC 1: (0x0000000000000000 == V|1|) /\ (0x0000000000000000 == V|1|)
   
   [1]
+
+Test that it's UB to write to a const (regardless of aliasing checks), and that we don't detect const refs as leaks
+  $ soteria-rust exec write_to_const.rs  --ignore-aliasing
+  Compiling... done in <time>
+  => Running write_to_const::main...
+  note: write_to_const::main: done in <time>, ran 1 branch
+  PC 1: empty
+  

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -553,6 +553,14 @@ Test that it's UB to write to a const (regardless of aliasing checks), and that 
   $ soteria-rust exec write_to_const.rs  --ignore-aliasing
   Compiling... done in <time>
   => Running write_to_const::main...
-  note: write_to_const::main: done in <time>, ran 1 branch
+  error: write_to_const::main: found issues in <time>, errors in 1 branch (out of 1)
+  bug: Write to read-only location in write_to_const::main
+      --> $TESTCASE_ROOT/write_to_const.rs:5:14
+    3 |  fn main() {
+      |  --------- 1: Entry point
+    4 |      let ptr = REF as *const u8 as *mut u8;
+    5 |      unsafe { *ptr = 67 };
+      |               ^^^^^^^^^ Memory store
   PC 1: empty
   
+  [1]

--- a/soteria-rust/test/cram/simple.t/write_to_const.rs
+++ b/soteria-rust/test/cram/simple.t/write_to_const.rs
@@ -1,6 +1,13 @@
 const REF: &u8 = &11;
 
-fn main() {
+#[soteria::test]
+fn write_to_const() {
     let ptr = REF as *const u8 as *mut u8;
+    unsafe { *ptr = 67 };
+}
+
+#[soteria::test]
+fn write_to_str() {
+    let ptr = "hello" as *const str as *mut u8;
     unsafe { *ptr = 67 };
 }

--- a/soteria-rust/test/cram/simple.t/write_to_const.rs
+++ b/soteria-rust/test/cram/simple.t/write_to_const.rs
@@ -1,0 +1,6 @@
+const REF: &u8 = &11;
+
+fn main() {
+    let ptr = REF as *const u8 as *mut u8;
+    unsafe { *ptr = 67 };
+}


### PR DESCRIPTION
We now properly track the source of allocations!
This means
- I could simplify leak checks significantly (and avoid false positives there)
- We now can detect and report writes to read-only memory (e.g. `const`s, or `&'static str`)

Originally I did all this because I wanted to remove both `update_ref_tys_in` and `ref_tys_in` (which play awfuly with what im doing in a future PR). Unfortunately I failed there but I managed to simplify it enough that it's not too bad anymore regardless.