### PR TITLE
Implement the `caller_location` intrinsic

### DIFF
--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -209,4 +209,26 @@ module M (StateM : State.StateM.S) = struct
           let unquoted = String.sub str 1 (String.length str - 2) in
           try Scanf.unescaped unquoted with _ -> unquoted
         else str)
+
+  let string_to_ptr str =
+    let* ptr_res = State.load_str_global str in
+    match ptr_res with
+    | Some ptr -> ok ptr
+    | None ->
+        let len = String.length str in
+        let chars =
+          String.to_bytes str
+          |> Bytes.fold_left (fun l c -> Int (BV.u8i (Char.code c)) :: l) []
+          |> List.rev
+        in
+        let char_arr = Tuple chars in
+        let str_ty : Types.ty =
+          Common.Charon_util.mk_array_ty (TLiteral (TUInt U8)) (Z.of_int len)
+        in
+        let@ () = with_alloc_kind ~kind:StaticString in
+        let* ptr, _ = State.alloc_ty str_ty in
+        let ptr = (ptr, Len (BV.usizei len)) in
+        let* () = State.store ptr str_ty char_arr in
+        let+ () = State.store_str_global str ptr in
+        ptr
 end

--- a/soteria-rust/lib/builtins/extern/std.ml
+++ b/soteria-rust/lib/builtins/extern/std.ml
@@ -1,8 +1,9 @@
 open Rust_val
 
-type fn = PanicCleanup
+type fn = PanicCleanup | PanicImpl
 
-let fn_pats = [ ("__rust_panic_cleanup", PanicCleanup) ]
+let fn_pats =
+  [ ("__rust_panic_cleanup", PanicCleanup); ("panic_impl", PanicImpl) ]
 
 module M (StateM : State.StateM.S) = struct
   open StateM
@@ -11,5 +12,11 @@ module M (StateM : State.StateM.S) = struct
       caller does not crash before we handle the panic. *)
   let panic_cleanup _ = ok (Ptr (Sptr.null (), VTable (Sptr.null ())))
 
-  let[@inline] fn_to_stub = function PanicCleanup -> panic_cleanup
+  (** This shoyld be a call that gets resolved to the `#[panic_handler]`
+      function. For now, we just panic. *)
+  let panic_impl _ = error (`Panic None)
+
+  let[@inline] fn_to_stub = function
+    | PanicCleanup -> panic_cleanup
+    | PanicImpl -> panic_impl
 end

--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -177,8 +177,50 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     ok (Int (aux bytes))
 
   let caller_location () : full_ptr ret =
-    (* TODO: we should really do something better here *)
-    ok (Sptr.null (), Thin)
+    (*
+     * #[lang = "panic_location"]
+     * pub struct Location<'a> {
+     *     filename: NonNull<str>,
+     *     line: u32,
+     *     col: u32,
+     *     _filename: PhantomData<&'a str>,
+     * }
+     *)
+    let location_adt = Crate.get_adt_lang_item "panic_location" in
+    let generics : Types.generic_args =
+      TypesUtils.generic_args_of_params () location_adt.generics
+    in
+    let tref : Types.type_decl_ref =
+      { id = TAdtId location_adt.def_id; generics }
+    in
+    let location_ty : Types.ty = TAdt tref in
+    let* trace = get_trace () in
+    let filename, col, line =
+      match trace.loc with
+      | None -> ("unknown", 0, 0)
+      | Some { file = { name = Local file; _ }; beg_loc; _ } ->
+          (Error.file_to_user_string file, beg_loc.col, beg_loc.line)
+      | Some { file = { name = Virtual _ | NotReal _; _ }; beg_loc; _ } ->
+          ("virtual", beg_loc.col, beg_loc.line)
+    in
+    let* ptr = Core.string_to_ptr filename in
+    let location =
+      mk_struct ~ty:tref
+        [
+          (* filename: *)
+          Tuple [ Ptr ptr ];
+          (* line: *)
+          Int (BV.u32i line);
+          (* col: *)
+          Int (BV.u32i col);
+          (* _filename: *)
+          Tuple [];
+        ]
+    in
+    let@ () = with_alloc_kind ~kind:AnonConst in
+    let* ptr = State.alloc_ty location_ty in
+    let+ () = State.store ptr location_ty location in
+    ptr
 
   let carrying_mul_add ~t ~u ~multiplier ~multiplicand ~addend ~carry =
     let t = TypesUtils.ty_as_literal t in
@@ -862,26 +904,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
 
   let type_name ~t =
     let str = Fmt.to_to_string pp_ty t in
-    let* ptr_res = State.load_str_global str in
-    match ptr_res with
-    | Some ptr -> ok ptr
-    | None ->
-        let len = String.length str in
-        let chars =
-          String.to_bytes str
-          |> Bytes.fold_left (fun l c -> Int (BV.u8i (Char.code c)) :: l) []
-          |> List.rev
-        in
-        let char_arr = Tuple chars in
-        let str_ty : Types.ty =
-          mk_array_ty (TLiteral (TUInt U8)) (Z.of_int len)
-        in
-        let@ () = with_alloc_kind ~kind:StaticString in
-        let* ptr, _ = State.alloc_ty str_ty in
-        let ptr = (ptr, Len (BV.usizei len)) in
-        let* () = State.store ptr str_ty char_arr in
-        let+ () = State.store_str_global str ptr in
-        ptr
+    Core.string_to_ptr str
 
   let unchecked_op op ~t ~x ~y : rust_val ret =
     let t = TypesUtils.ty_as_literal t in

--- a/soteria-rust/lib/crate.ml
+++ b/soteria-rust/lib/crate.ml
@@ -132,6 +132,17 @@ let get_adt (adt_ref : Types.type_decl_ref) =
       Fmt.failwith "get_adt: unexpected non-ADT type decl id: %a"
         Types.pp_type_id adt_ref.id
 
+let get_adt_lang_item lang_item =
+  let exception Found of Types.type_decl in
+  let crate = get_crate () in
+  try
+    crate.type_decls
+    |> Types.TypeDeclId.Map.iter (fun id (adt : Types.type_decl) ->
+        if Option.equal String.equal adt.item_meta.lang_item (Some lang_item)
+        then raise (Found adt));
+    raise (MissingDecl ("Missing ADT with lang item: " ^ lang_item))
+  with Found adt -> adt
+
 let get_fun id =
   let crate = get_crate () in
   match UllbcAst.FunDeclId.Map.find_opt id crate.fun_decls with

--- a/soteria-rust/lib/error.ml
+++ b/soteria-rust/lib/error.ml
@@ -181,39 +181,45 @@ let decorate (where : Trace.t) (e : t) : with_trace =
       (e, List.rev @@ (elem :: where.stack))
   | None -> (e, List.rev where.stack)
 
+let replace_subpath_opt sub_str replacement path =
+  match String.index_of ~sub_str path with
+  | Some idx ->
+      let idx = idx + String.length sub_str in
+      let rel_path = String.sub path idx (String.length path - idx) in
+      Some (replacement ^ rel_path)
+  | None -> None
+
+(** Converts a file path to a user-friendly string by replacing known internal
+    subpaths. Returns [None] if no substitution is needed. *)
+let file_to_user_string_opt (file : string) =
+  let ( / ) = Filename.concat in
+  match replace_subpath_opt "rustc" "$RUSTLIB" file with
+  | Some f -> Some f
+  | None ->
+      replace_subpath_opt ("soteria-rust" / "plugins") "$SOTERIA-RUST" file
+
+(** Same as {!file_to_user_string_opt}, but returns the original file if no
+    substitution is needed. *)
+let file_to_user_string (file : string) =
+  Option.value ~default:file (file_to_user_string_opt file)
+
+let file_to_path (file : string) =
+  let ( / ) = Filename.concat in
+  if String.starts_with ~prefix:"/rustc/" file then
+    let toolchain = Lazy.force Frontend_runtime.Cmd.toolchain_path in
+    let prefix_len = String.length "/rustc/" in
+    let file = String.sub file prefix_len (String.length file - prefix_len) in
+    toolchain / "lib" / "rustlib" / "src" / "rust" / file
+  else file
+
 module Diagnostic = struct
   let to_loc (pos : Charon.Meta.loc) = (pos.line - 1, pos.col - 1)
-
-  let replace_subpath_opt sub_str replacement path =
-    match String.index_of ~sub_str path with
-    | Some idx ->
-        let idx = idx + String.length sub_str in
-        let rel_path = String.sub path idx (String.length path - idx) in
-        Some (replacement ^ rel_path)
-    | None -> None
 
   let as_ranges (span : Charon.Meta.span_data) =
     match span.file.name with
     | Local file ->
-        let ( / ) = Filename.concat in
-        let filename =
-          match replace_subpath_opt "rustc" "$RUSTLIB" file with
-          | Some f -> Some f
-          | None ->
-              replace_subpath_opt
-                ("soteria-rust" / "plugins")
-                "$SOTERIA-RUST" file
-        in
-        let file =
-          if String.starts_with ~prefix:"/rustc/" file then
-            let toolchain = Lazy.force Frontend_runtime.Cmd.toolchain_path in
-            let prefix_len = String.length "/rustc/" in
-            let file =
-              String.sub file prefix_len (String.length file - prefix_len)
-            in
-            toolchain / "lib" / "rustlib" / "src" / "rust" / file
-          else file
-        in
+        let filename = file_to_user_string_opt file in
+        let file = file_to_path file in
         [
           Soteria.Terminal.Diagnostic.mk_range_file ?filename
             ?content:span.file.contents file (to_loc span.beg_loc)

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -200,29 +200,9 @@ module Make (StateImpl : State.S) = struct
     | CLiteral (VChar c) -> ok (Int (BV.u32i (Uchar.to_int c)))
     | CLiteral (VFloat { float_value; float_ty }) ->
         ok (Float (Typed.Float.mk float_ty float_value))
-    | CLiteral (VStr str) -> (
-        let* ptr_opt = State.load_str_global str in
-        match ptr_opt with
-        | Some v -> ok (Ptr v)
-        | None ->
-            (* We "cheat" and model strings as an array of chars, with &str a
-               slice *)
-            let len = String.length str in
-            let chars =
-              String.to_bytes str
-              |> Bytes.fold_left (fun l c -> Int (BV.u8i (Char.code c)) :: l) []
-              |> List.rev
-            in
-            let char_arr = Tuple chars in
-            let str_ty : Types.ty =
-              mk_array_ty (TLiteral (TUInt U8)) (Z.of_int len)
-            in
-            let@ () = with_alloc_kind ~kind:StaticString in
-            let* ptr, _ = State.alloc_ty str_ty in
-            let ptr = (ptr, Len (BV.usizei len)) in
-            let* () = State.store ptr str_ty char_arr in
-            let+ () = State.store_str_global str ptr in
-            Ptr ptr)
+    | CLiteral (VStr str) ->
+        let+ ptr = Core.string_to_ptr str in
+        Ptr ptr
     | CFnDef _ -> ok (Tuple [])
     | CPtrNoProvenance v -> ok (Ptr (Sptr.of_address (BV.usize v), Thin))
     | CArray cs ->

--- a/soteria-rust/lib/rust_val.ml
+++ b/soteria-rust/lib/rust_val.ml
@@ -241,3 +241,8 @@ let mk_enum ~ty variant fields =
   assert (List.compare_lengths variant.fields fields = 0);
   let discr = BV.of_literal variant.discriminant in
   Enum (discr, fields)
+
+let mk_struct ~ty fields =
+  let struct_fields = Crate.as_struct ty in
+  assert (List.compare_lengths fields struct_fields = 0);
+  Tuple fields

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -575,3 +575,28 @@ Test that it's UB to write to a const (regardless of aliasing checks), and that 
   PC 1: empty
   
   [1]
+
+Ensure we implement the caller_location intrinsic correctly; this used to cause a null pointer deref, rather than a proper panic from the handler.
+  $ soteria-rust exec unreachable.rs
+  Compiling... done in <time>
+  => Running unreachable::main...
+  error: unreachable::main: found issues in <time>, errors in 1 branch (out of 1)
+  error: Panic in unreachable::main
+      --> $RUSTLIB/library/core/src/panicking.rs:80:14
+   80 |      unsafe { panic_impl(&pi) }
+      |               ^^^^^^^^^^^^^^^
+      |               |
+      |               Triggering operation
+      |               4: Call trace
+      .  
+  240 |      panic_fmt(format_args!("internal error: entered unreachable code: {}", *x));
+      |      --------------------------------------------------------------------------- 3: Call trace
+      --> $TESTCASE_ROOT/unreachable.rs:2:5
+    1 |  fn main() {
+      |  --------- 1: Entry point
+    2 |      unreachable!("This should not be a null pointer deref!");
+      |      -------------------------------------------------------- 2: Call trace
+  PC 1: (0x0000000000000008 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+        (0b000 == extract[0-2](V|1|))
+  
+  [1]

--- a/soteria-rust/test/cram/simple.t/unreachable.rs
+++ b/soteria-rust/test/cram/simple.t/unreachable.rs
@@ -1,0 +1,3 @@
+fn main() {
+    unreachable!("This should not be a null pointer deref!");
+}


### PR DESCRIPTION
Implement `caller_location` -- we used to have it as a stub that returned the null pointer, leading to null dereferences that were unintended.

Also implement `panic_impl`, which is an external function used by Rust's runtime; really it should resolve to the `#[panic_handler]` function but we don't translate attributes sufficiently in Charon/Obol for this (yet!!)