### PR TITLE
Fix Unsoundness in Interval Analysis

### DIFF
--- a/soteria-rust/test/cram/simple.t/bool_or.rs
+++ b/soteria-rust/test/cram/simple.t/bool_or.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let x: bool = soteria::nondet_bytes();
+    let y: bool = soteria::nondet_bytes();
+    let output: bool = x | y;
+    assert!(output);
+}

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -600,3 +600,22 @@ Ensure we implement the caller_location intrinsic correctly; this used to cause 
         (0b000 == extract[0-2](V|1|))
   
   [1]
+
+Boolean BitOr must not be assumed true; both operands can be false (issue #376).
+  $ soteria-rust exec bool_or.rs
+  Compiling... done in <time>
+  => Running bool_or::main...
+  error: bool_or::main: found issues in <time>, errors in 1 branch (out of 2)
+  error: Panic: assertion failed: output in bool_or::main
+      --> $TESTCASE_ROOT/bool_or.rs:5:5
+    1 |  fn main() {
+      |  --------- 1: Entry point
+      .  
+    5 |      assert!(output);
+      |      ^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      2: Call trace
+  PC 1: (0x00 == V|1|) /\ (0x00 == V|2|) /\ (0x00 == V|1|) /\ (0x00 == V|2|)
+  
+  [1]

--- a/soteria/lib/bv_values/analyses.ml
+++ b/soteria/lib/bv_values/analyses.ml
@@ -241,9 +241,6 @@ module Interval : S = struct
   let get n v st =
     match Var.Map.find_opt v st with Some r -> r | None -> Data.mk n
 
-  let st_equal = Var.Map.reflexive_equal Data.equal
-  let merge_states = Var.Map.idempotent_inter (fun _ -> Data.union)
-
   let pp ft st =
     Fmt.(iter_bindings Var.Map.iter (pair ~sep:(any " -> ") Var.pp Data.pp))
       ft st
@@ -439,20 +436,19 @@ module Interval : S = struct
   let rec simplify (v : Svalue.t) st =
     match (v.node.kind, lazy (as_range v)) with
     | Binop (Or, v1, v2), _ ->
-        let v1', _learnt1, vars1, st1 = add_constraint v1 st in
-        let v2', _learnt2, vars2, st2 = add_constraint v2 st in
-        let st' = merge_states st1 st2 in
-        let vars = Var.Set.union vars1 vars2 in
+        (* [v1 || v2] is valid under [st] iff [¬v1 && ¬v2] is infeasible there.
+           Unlike the join of ranges (which over-approximates a union and would
+           let us wrongly conclude e.g. [x != 0 || y != 0] is always true),
+           intersecting ranges is exact, so [add_constraint] only reports
+           infeasibility (a [false] learnt fact) when it genuinely holds. *)
+        let _, learnt1, _, st1 = add_constraint (Svalue.Bool.not v1) st in
+        let _, learnt2, _, _ = add_constraint (Svalue.Bool.not v2) st1 in
         log (fun m ->
-            m "checking %a / %a / %a /@.1. %a@.2. %a"
-              Fmt.(list Var.pp)
-              (Var.Set.to_list vars) Svalue.pp v1 Svalue.pp v2 pp st pp st');
-        (* If the state is unchanged, then the conjunction covers all possible
-           states and this is always true. (I think.) *)
+            m "checking %a || %a:@.¬1. %a@.¬2. %a" Svalue.pp v1 Svalue.pp v2
+              Svalue.pp learnt1 Svalue.pp learnt2);
         if
-          Svalue.equal v1' Svalue.Bool.v_true
-          && Svalue.equal v2' Svalue.Bool.v_true
-          && st_equal st st'
+          Svalue.equal learnt1 Svalue.Bool.v_false
+          || Svalue.equal learnt2 Svalue.Bool.v_false
         then Svalue.Bool.v_true
         else v
     | ( Binop


### PR DESCRIPTION
### Problem
`x | y` over two symbolic booleans was reported as always `true`, so `assert!(x | y)` passed when it should fail (only 1 branch explored instead of 2).

### Root cause
The bug was in the **interval analysis** simplifier (`soteria/lib/bv_values/analyses.ml`).

The branch guard correctly simplifies to `(x != 0) || (y != 0)`. The `Binop (Or, _, _)` proved this is a tautology by adding each operand to the state and **joining** the results. The per-variable range join *over-approximates* the union, so the disjunction was wrongly deemed always true and the failing branch was dropped.

(`&` and `^` were unaffected, since their guards don't split into a disjunction.)

### Fix
Prove validity via the dual instead: `v1 || v2` is valid iff `¬v1 && ¬v2` is infeasible. Intersecting ranges is *exact* in this domain (unlike the join), so we now only conclude "always true" for genuine tautologies (e.g. `x < 5 || x >= 5`) and branch correctly otherwise. Removed the now-unused `st_equal`/`merge_states` helpers.

Fixes #376 