### PR TITLE
Don't decay pointer for null checks in niche optims

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,4 +4,12 @@
     "switch": "${workspaceFolder:soteria}"
   },
   "makefile.configureOnOpen": false,
+  "files.associations": {
+    "*.t": "cram"
+  },
+  "[perl]": {
+    "editor.formatOnSave": false,
+    "files.trimTrailingWhitespace": false,
+    "files.insertFinalNewline": false
+  }
 }

--- a/soteria-rust/lib/analyses/wpst.ml
+++ b/soteria-rust/lib/analyses/wpst.ml
@@ -73,6 +73,8 @@ let exec_crate (crate : Charon.UllbcAst.crate)
   (* prepare executing the entry points *)
   let exec_fun = Interp.exec_fun_as_whole_prog ~state:State.empty in
 
+  (* Aggregate statistics over all entry points, then dump them once. *)
+  let@ () = Stats.As_ctx.with_dumped () in
   let@ { fuel; fun_decl; expect_error } : Frontend.entry_point =
     (Fun.flip List.map) entry_points
   in
@@ -92,7 +94,7 @@ let exec_crate (crate : Charon.UllbcAst.crate)
     let@@ () =
       Rustsymex.Result.run_with_stats
         ~flamegraph:(Dump (flamegraph_name entry_name))
-        ~stats:(Dump ()) ~mode:OX ~fuel ~fail_fast:(Config.get ()).fail_fast
+        ~stats:Caller ~mode:OX ~fuel ~fail_fast:(Config.get ()).fail_fast
     in
     exec_fun fun_decl ~args
   in

--- a/soteria-rust/lib/rustsymex.ml
+++ b/soteria-rust/lib/rustsymex.ml
@@ -3,6 +3,7 @@ module StatKeys = struct
   let loads_from_store = "soteria-rust.loads_from_store"
   let function_calls = "soteria-rust.function_calls"
   let allocs = "soteria-rust.allocs"
+  let decayed_pointers = "soteria-rust.decayed_pointers"
 
   let () =
     let open Soteria.Stats in

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -112,6 +112,7 @@ module DecayMap = struct
              Result.ok address
          | Some { address; exposed = _ } -> Result.ok address
          | None ->
+             Soteria.Stats.As_ctx.incr Rustsymex.StatKeys.decayed_pointers;
              let* address = nondet (Typed.t_usize ()) in
              let isize_max = Layout.max_value_z (TInt Isize) in
              (* Distinct allocations live at distinct addresses. We

--- a/soteria-rust/lib/typed.ml
+++ b/soteria-rust/lib/typed.ml
@@ -114,9 +114,7 @@ module BitVec = struct
 
   let max ~signed l r = ite (gt ~signed l r) l r
   let min ~signed l r = ite (lt ~signed l r) l r
-
-  let sure_is_zero v =
-    match to_z v with Some z -> Z.equal z Z.zero | None -> false
+  let sure_is_zero v = Option.is_some_and Z.(equal zero) (to_z v)
 end
 
 module BV = BitVec

--- a/soteria-rust/lib/typed.ml
+++ b/soteria-rust/lib/typed.ml
@@ -114,6 +114,9 @@ module BitVec = struct
 
   let max ~signed l r = ite (gt ~signed l r) l r
   let min ~signed l r = ite (lt ~signed l r) l r
+
+  let sure_is_zero v =
+    match to_z v with Some z -> Z.equal z Z.zero | None -> false
 end
 
 module BV = BitVec

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -200,20 +200,47 @@ struct
         Fields_shape.discriminator -> Types.variant_id ParserMonad.t = function
       | Known v -> ok v
       | Branch { offset = tag_ofs; tag_ty; children; fallback } ->
-          let* tag = query (TLiteral tag_ty, offset +!!@ tag_ofs) in
-          let tag = as_base tag_ty tag in
+          (* You know what's cheaper than Pointer->Integer cast?
+             Integer->Pointer cast. If the tag is pointer-sized, we read it as a
+             pointer anyway, and special case null-checking. Allows for
+             optimising away decays happening for e.g. Option<NonNull<T>>. *)
+          let* tag =
+            if size_of_literal_ty tag_ty = Crate.pointer_size () then
+              let+ v = query (unit_ptr, offset +!!@ tag_ofs) in
+              `Ptr (fst (as_ptr v))
+            else
+              let+ v = query (TLiteral tag_ty, offset +!!@ tag_ofs) in
+              `Int (as_base tag_ty v)
+          in
+          let pp_tag ft = function
+            | `Int v -> Typed.ppa ft v
+            | `Ptr p -> Sptr.pp ft p
+          in
           let pp_info ft () =
-            Fmt.pf ft ", read %a: %s at offset %a" Typed.ppa tag
+            Fmt.pf ft ", read %a: %s at offset %a" pp_tag tag
               (Print.literal_type_to_string tag_ty)
               Typed.ppa offset
           in
+          let cond_for from_ to_ =
+            let int_cond tag =
+              if Typed.equal from_ to_ then tag ==@ from_
+              else from_ <=@ tag &&@ (tag <=@ to_)
+            in
+            match tag with
+            | `Int tag -> ok (int_cond tag)
+            | `Ptr ptr ->
+                if Typed.equal from_ to_ && Typed.BV.sure_is_zero from_ then
+                  (* fast path *)
+                  ok (Sptr.is_null ptr)
+                else
+                  let+ tag = lift (Sptr.decay ptr) in
+                  int_cond tag
+          in
           let rec aux = function
             | [] -> exec fallback
-            | (from_, to_, discr) :: rest when Typed.equal from_ to_ ->
-                if%sat tag ==@ from_ then exec ~pp_info discr else aux rest
             | (from_, to_, discr) :: rest ->
-                if%sat from_ <=@ tag &&@ (tag <=@ to_) then exec ~pp_info discr
-                else aux rest
+                let* cond = cond_for from_ to_ in
+                if%sat cond then exec ~pp_info discr else aux rest
           in
           aux children
       | Invalid ->

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -205,7 +205,8 @@ struct
              pointer anyway, and special case null-checking. Allows for
              optimising away decays happening for e.g. Option<NonNull<T>>. *)
           let* tag =
-            if size_of_literal_ty tag_ty = Crate.pointer_size () then
+            if match tag_ty with TInt Isize | TUInt Usize -> true | _ -> false
+            then
               let+ v = query (unit_ptr, offset +!!@ tag_ofs) in
               `Ptr (fst (as_ptr v))
             else
@@ -222,19 +223,16 @@ struct
               Typed.ppa offset
           in
           let cond_for from_ to_ =
+            let is_single = Typed.equal from_ to_ in
             let int_cond tag =
-              if Typed.equal from_ to_ then tag ==@ from_
+              if is_single then tag ==@ from_
               else from_ <=@ tag &&@ (tag <=@ to_)
             in
             match tag with
             | `Int tag -> ok (int_cond tag)
-            | `Ptr ptr ->
-                if Typed.equal from_ to_ && Typed.BV.sure_is_zero from_ then
-                  (* fast path *)
-                  ok (Sptr.is_null ptr)
-                else
-                  let+ tag = lift (Sptr.decay ptr) in
-                  int_cond tag
+            | `Ptr ptr when is_single && Typed.BV.sure_is_zero from_ ->
+                ok (Sptr.is_null ptr)
+            | `Ptr ptr -> map int_cond @@ lift (Sptr.decay ptr)
           in
           let rec aux = function
             | [] -> exec fallback

--- a/soteria-rust/test/cram/common.sh
+++ b/soteria-rust/test/cram/common.sh
@@ -12,3 +12,17 @@ check_allocs() {
 		return 1
 	fi
 }
+check_decays() {
+	local input_file="$1"
+	local expected="$2"
+
+	soteria-rust exec "$input_file" --stats stats.json
+
+	local decays
+	decays="$(jq '."soteria-rust.decayed_pointers" // 0' stats.json)"
+
+	if [ "$decays" != "$expected" ]; then
+		echo "check_decays: expected '$expected', got '$decays'" >&2
+		return 1
+	fi
+}

--- a/soteria-rust/test/cram/common.sh
+++ b/soteria-rust/test/cram/common.sh
@@ -1,28 +1,13 @@
-check_allocs() {
-	local input_file="$1"
-	local expected="$2"
+check_stat() {
+	local stats_file="$1"
+	local stat="$2"
+	local expected="$3"
 
-	soteria-rust exec "$input_file" --stats stats.json
+	local value
+	value="$(jq ".\"soteria-rust.$stat\" // 0" "$stats_file")"
 
-	local allocs
-	allocs="$(jq '."soteria-rust.allocs" // 0' stats.json)"
-
-	if [ "$allocs" != "$expected" ]; then
-		echo "check_allocs: expected '$expected', got '$allocs'" >&2
-		return 1
-	fi
-}
-check_decays() {
-	local input_file="$1"
-	local expected="$2"
-
-	soteria-rust exec "$input_file" --stats stats.json
-
-	local decays
-	decays="$(jq '."soteria-rust.decayed_pointers" // 0' stats.json)"
-
-	if [ "$decays" != "$expected" ]; then
-		echo "check_decays: expected '$expected', got '$decays'" >&2
+	if [ "$value" != "$expected" ]; then
+		echo "check_stat: expected '$expected', got '$value' for $stat" >&2
 		return 1
 	fi
 }

--- a/soteria-rust/test/cram/simple.t/nonnull.rs
+++ b/soteria-rust/test/cram/simple.t/nonnull.rs
@@ -13,7 +13,8 @@ fn make_nonnull_res() -> RN {
     Ok(NonNull::new(Box::into_raw(b)).unwrap())
 }
 
-fn main() {
+#[soteria::test]
+fn match_niched_enums() {
     match make_nonnull_opt() {
         Some(ptr) => unsafe {
             let b = Box::from_raw(ptr.as_ptr());

--- a/soteria-rust/test/cram/simple.t/nonnull.rs
+++ b/soteria-rust/test/cram/simple.t/nonnull.rs
@@ -1,0 +1,71 @@
+use std::ptr::NonNull;
+
+type ON = Option<NonNull<usize>>;
+type RN = Result<NonNull<usize>, usize>;
+
+fn make_nonnull_opt() -> ON {
+    let b = Box::new(67);
+    Some(NonNull::new(Box::into_raw(b)).unwrap())
+}
+
+fn make_nonnull_res() -> RN {
+    let b = Box::new(42);
+    Ok(NonNull::new(Box::into_raw(b)).unwrap())
+}
+
+fn main() {
+    match make_nonnull_opt() {
+        Some(ptr) => unsafe {
+            let b = Box::from_raw(ptr.as_ptr());
+            assert!(*b == 67)
+        },
+        None => {
+            unreachable!()
+        }
+    }
+    match make_nonnull_res() {
+        Ok(ptr) => unsafe {
+            let b = Box::from_raw(ptr.as_ptr());
+            assert!(*b == 42)
+        },
+        Err(_) => {
+            unreachable!()
+        }
+    }
+}
+
+#[soteria::test]
+fn null_is_none() {
+    assert!(NonNull::<usize>::new(std::ptr::null_mut()).is_none());
+}
+
+#[soteria::test]
+fn niche_ok() {
+    let b = Box::new(91);
+    let res: Result<NonNull<usize>, ()> = Ok(NonNull::new(Box::into_raw(b)).unwrap());
+    match res {
+        Ok(ptr) => unsafe {
+            let b = Box::from_raw(ptr.as_ptr());
+            assert!(*b == 91)
+        },
+        Err(()) => {
+            unreachable!()
+        }
+    }
+}
+
+#[soteria::test]
+fn niche_err() {
+    let res: Result<NonNull<usize>, ()> = Err(());
+    assert!(res.is_err());
+}
+
+#[soteria::test]
+fn transmuted_discriminant() {
+    let addr: usize = soteria::nondet_bytes();
+    let opt: ON = unsafe { std::mem::transmute(addr) };
+    match opt {
+        Some(_) => assert!(addr != 0),
+        None => assert!(addr == 0),
+    }
+}

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -626,32 +626,32 @@ Boolean BitOr must not be assumed true; both operands can be false (issue #376).
 
 Test that allocating a box only requires two heap allocation (thanks to the store optimisation): one for the contents of the box, and one for the box that we pass to the drop glue.
 FIXME: now that named consts are globals, there is in fact a third allocation: the one for <i32 as SizedTypeProperties>::LAYOUT. We should extend the store optimisation to handle globals; in particular we have a guarantee they can't be written to, so it's likely the optimisation will perform really well.
-  $ check_allocs box.rs 2
+  $ soteria-rust exec box.rs --stats stats.json && check_stat stats.json allocs 2
   Compiling... done in <time>
   => Running box::main...
   note: box::main: done in <time>, ran 1 branch
   PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
         (0b00 == extract[0-1](V|1|))
   
-  check_allocs: expected '2', got '3'
+  check_stat: expected '2', got '3' for allocs
   [1]
 
 Test that taking a reference to a ZST doesn't allocate it on the heap; the reference is a dangling pointer, so the value stays in the store.
-  $ check_allocs zst_ref.rs 0
+  $ soteria-rust exec zst_ref.rs --stats stats.json && check_stat stats.json allocs 0
   Compiling... done in <time>
   => Running zst_ref::main...
   note: zst_ref::main: done in <time>, ran 1 branch
   PC 1: empty
   
 Test that indexing arrays with a constant index does not allocate; the value is updated in place in the store.
-  $ check_allocs store_struct.rs 0
+  $ soteria-rust exec store_struct.rs --stats stats.json && check_stat stats.json allocs 0
   Compiling... done in <time>
   => Running store_struct::main...
   note: store_struct::main: done in <time>, ran 1 branch
   PC 1: empty
   
 Test that reading the metadata of a store-hosted pointer does not allocate; the pointer stays in the store.
-  $ check_allocs ptr_metadata.rs 0
+  $ soteria-rust exec ptr_metadata.rs --stats stats.json && check_stat stats.json allocs 0
   Compiling... done in <time>
   => Running ptr_metadata::main...
   note: ptr_metadata::main: done in <time>, ran 1 branch
@@ -665,10 +665,11 @@ Test we can use ptr::metadata to get the metadata of a trait object; this used t
   PC 1: empty
   
 
-  $ check_decays nonnull.rs 0
+FIXME: the last 3 decayed pointers shall be removed in #386
+  $ soteria-rust exec nonnull.rs --stats stats.json && check_stat stats.json decayed_pointers 3
   Compiling... done in <time>
-  => Running nonnull::main...
-  note: nonnull::main: done in <time>, ran 1 branch
+  => Running nonnull::match_niched_enums...
+  note: nonnull::match_niched_enums: done in <time>, ran 1 branch
   PC 1: Distinct(V|1-2|) /\ (0x0000000000000008 <=u V|1|) /\
         (V|1| <=u 0x7ffffffffffffff6) /\ (0x0000000000000008 <=u V|2|) /\
         (V|2| <=u 0x7ffffffffffffff6) /\ (0b000 == extract[0-2](V|1|)) /\

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -86,12 +86,7 @@ Test that we properly handle the niche optimisation
   Compiling... done in <time>
   => Running niche_optim::main...
   note: niche_optim::main: done in <time>, ran 1 branch
-  PC 1: Distinct(V|1-2|) /\ Distinct(V|1-3|) /\
-        (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
-        (0x0000000000000004 <=u V|2|) /\ (V|2| <=u 0x7ffffffffffffff6) /\
-        (0x0000000000000004 <=u V|3|) /\ (V|3| <=u 0x7ffffffffffffffa) /\
-        (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|2|)) /\
-        (0b00 == extract[0-1](V|3|))
+  PC 1: empty
   
 Test function calls on function pointers
   $ soteria-rust exec fn_ptr.rs
@@ -462,8 +457,7 @@ Print the callgraph
   Compiling... done in <time>
   => Running callgraph::main...
   note: callgraph::main: done in <time>, ran 1 branch
-  PC 1: (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffa) /\
-        (0b00 == extract[0-1](V|1|))
+  PC 1: empty
   
   digraph callgraph {
     node [shape=box fontname="monospace"];
@@ -607,8 +601,7 @@ Ensure we implement the caller_location intrinsic correctly; this used to cause 
       |  --------- 1: Entry point
     2 |      unreachable!("This should not be a null pointer deref!");
       |      -------------------------------------------------------- 2: Call trace
-  PC 1: (0x0000000000000008 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-        (0b000 == extract[0-2](V|1|))
+  PC 1: empty
   
   [1]
 

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -664,3 +664,31 @@ Test we can use ptr::metadata to get the metadata of a trait object; this used t
   note: ptr_dyn_metadata::main: done in <time>, ran 1 branch
   PC 1: empty
   
+
+  $ check_decays nonnull.rs 0
+  Compiling... done in <time>
+  => Running nonnull::main...
+  note: nonnull::main: done in <time>, ran 1 branch
+  PC 1: Distinct(V|1-2|) /\ (0x0000000000000008 <=u V|1|) /\
+        (V|1| <=u 0x7ffffffffffffff6) /\ (0x0000000000000008 <=u V|2|) /\
+        (V|2| <=u 0x7ffffffffffffff6) /\ (0b000 == extract[0-2](V|1|)) /\
+        (0b000 == extract[0-2](V|2|))
+  
+  => Running nonnull::null_is_none...
+  note: nonnull::null_is_none: done in <time>, ran 1 branch
+  PC 1: empty
+  
+  => Running nonnull::niche_ok...
+  note: nonnull::niche_ok: done in <time>, ran 1 branch
+  PC 1: (0x0000000000000008 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffff6) /\
+        (0b000 == extract[0-2](V|1|))
+  
+  => Running nonnull::niche_err...
+  note: nonnull::niche_err: done in <time>, ran 1 branch
+  PC 1: empty
+  
+  => Running nonnull::transmuted_discriminant...
+  note: nonnull::transmuted_discriminant: done in <time>, ran 2 branches
+  PC 1: (0x0000000000000000 == V|1|) /\ (0x0000000000000000 == V|1|)
+  PC 2: (0x0000000000000001 <=u V|1|)
+  


### PR DESCRIPTION
An issue is to do with, e.g. `Option<NonNull<_>>`. When reading the discriminant of the option, the interpreter performs a pointer decay because it must read the discriminant of the Option, which spans the entire NonNull. That's a bit dumb, because that's effectively just a null check, which should be extremely cheap. Talk about zero-cost abstraction.

Here's a fun insight though: it's cheaper to cast an integer to a pointer than the other way around. So, when the niche is the size of a pointer, instead of reading an integer, we read a pointer. And then if we just want to check whether it's == 0, it's a null check. Otherwise, we decay

Note that the win isn't that substantial because without the charon transformation coming in other PRs, pointer decay still happens in another place for the same pointers we're dealing with here, in calls to __rust_alloc. Combined with the charon change, this amounts to ~1/2 of all decays
