### PR TITLE
Don't decay on `check_overlap` for pointers with != provenance

### DIFF
--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -475,16 +475,22 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
 
   (** [check_overlap name l r size] ensures the pointers [l] and [r] do not
       overlap for a range of size [size]; otherwise errors, with
-      [`StdErr (name ^ " overlapped")]. *)
+      [`StdErr (name ^ " overlapped")].
+
+      We optimise the path where pointers don't have the same provenance to
+      avoid spuriously decaying pointers. *)
   let check_overlap name l r size =
-    let* l_end = Sptr.offset ~signed:false size l in
-    let* r_end = Sptr.offset ~signed:false size r in
-    let* dist1 = Sptr.distance l r_end in
-    let* dist2 = Sptr.distance r l_end in
-    let zero = Usize.(0s) in
-    assert_not
-      (Sptr.have_same_provenance l r &&@ (dist1 <$@ zero &&@ (dist2 <$@ zero)))
-      (`StdErr (name ^ " overlapped"))
+    let same_provenance = Sptr.have_same_provenance l r in
+    if%sure not same_provenance then ok ()
+    else
+      let* l_end = Sptr.offset ~signed:false size l in
+      let* r_end = Sptr.offset ~signed:false size r in
+      let* dist1 = Sptr.distance l r_end in
+      let* dist2 = Sptr.distance r l_end in
+      let zero = Usize.(0s) in
+      assert_not
+        (same_provenance &&@ (dist1 <$@ zero &&@ (dist2 <$@ zero)))
+        (`StdErr (name ^ " overlapped"))
 
   let copy_ nonoverlapping ~t ~src:((src, _) as fsrc : full_ptr)
       ~dst:((dst, _) as fdst : full_ptr) ~count : unit ret =

--- a/soteria-rust/test/cram/perf.t/run.t
+++ b/soteria-rust/test/cram/perf.t/run.t
@@ -8,927 +8,668 @@
   Compiling... done in <time>
   => Running btreeset_sort::test_treeset_is_ordered...
   note: btreeset_sort::test_treeset_is_ordered: done in <time>, ran 75 branches
-  PC 1: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-        (V|4| <u V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-        (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-        Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-       V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|,
-       V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-        (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-        (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-        (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-        (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-        (V|10| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|11|) /\
-        (V|11| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-        (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-        (0b00 == extract[0-1](V|8|)) /\ (0b000 == extract[0-2](V|9|)) /\
-        (0b00 == extract[0-1](V|10|)) /\ (0b00 == extract[0-1](V|11|))
-  PC 2: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-        (V|4| <u V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-        (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|,
-       V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ (V|4| != V|5|) /\
-        Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|,
-       V|7|, V|8|, V|9|, V|10|, V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-        (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-        (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-        (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-        (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-        (V|10| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|11|) /\
-        (V|11| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-        (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-        (0b00 == extract[0-1](V|8|)) /\ (0b000 == extract[0-2](V|9|)) /\
-        (0b00 == extract[0-1](V|10|)) /\ (0b00 == extract[0-1](V|11|))
-  PC 3: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-        (V|4| <u V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-        (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|,
-       V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|,
-       V|7|, V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|,
-       V|10|, V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-        (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-        (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-        (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-        (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-        (V|10| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|11|) /\
-        (V|11| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-        (V|4| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-        (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-        (0b000 == extract[0-2](V|9|)) /\ (0b00 == extract[0-1](V|10|)) /\
-        (0b00 == extract[0-1](V|11|))
-  PC 4: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-        (V|4| <u V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-        (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-       V|6|, V|7|, V|8|, V|9|) /\ (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|,
-       V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|,
-       V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-        (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-        (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-        (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-        (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-        (V|10| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|11|) /\
-        (V|11| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-        (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-        (0b00 == extract[0-1](V|8|)) /\ (0b000 == extract[0-2](V|9|)) /\
-        (0b00 == extract[0-1](V|10|)) /\ (0b00 == extract[0-1](V|11|))
-  PC 5: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-        (V|4| <u V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-        (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-       V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|,
-       V|10|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|, V|11|) /\
+  PC 1: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|4| <u V|3|) /\ (V|5| <u V|2|) /\
+        (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ Distinct(V|1|, V|6|) /\
+        Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-        (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-        (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-        (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffffa) /\
-        (0x0000000000000008 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffc6) /\
-        (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff2) /\
-        (0x0000000000000004 <=u V|11|) /\ (V|11| <=u 0x7ffffffffffffff2) /\
+        (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+        (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffee) /\
+        (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffee) /\
+        (0b00 == extract[0-1](V|1|)) /\ (0b000 == extract[0-2](V|6|)) /\
+        (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 2: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|4| <u V|3|) /\ (V|5| <u V|2|) /\
+        (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+        (V|4| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+       V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+        (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+        (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+        (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+        (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+        (0b00 == extract[0-1](V|8|))
+  PC 3: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|4| <u V|3|) /\ (V|5| <u V|2|) /\
+        (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+        Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+        (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+        (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+        (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+        (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
+        (0b00 == extract[0-1](V|1|)) /\ (V|4| == V|5|) /\
+        (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+        (0b00 == extract[0-1](V|8|))
+  PC 4: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|4| <u V|3|) /\ (V|5| <u V|2|) /\
+        (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|3| != V|5|) /\
+        Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+        (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+        (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+        (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffee) /\
+        (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffee) /\
+        (0b00 == extract[0-1](V|1|)) /\ (0b000 == extract[0-2](V|6|)) /\
+        (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 5: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|4| <u V|3|) /\ (V|5| <u V|2|) /\
+        (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
+       V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+        (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+        (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+        (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+        (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|5|) /\
-        (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-        (0b00 == extract[0-1](V|8|)) /\ (0b000 == extract[0-2](V|9|)) /\
-        (0b00 == extract[0-1](V|10|)) /\ (0b00 == extract[0-1](V|11|))
-  PC 6: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-        (V|4| <u V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|2| <=u V|5|) /\
-        Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| != V|5|) /\ Distinct(V|1|,
-       V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|,
-       V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-        (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-        (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-        (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-        (V|9| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|10|) /\
-        (V|10| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-        (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-        (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-        (0b00 == extract[0-1](V|9|))
-  PC 7: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-        (V|4| <u V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|2| <=u V|5|) /\
-        Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-       V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
+        (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+        (0b00 == extract[0-1](V|8|))
+  PC 6: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|4| <u V|3|) /\
+        (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|5|) /\
+        Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-        (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-        (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-        (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-        (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-        (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff2) /\
+        (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+        (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffee) /\
+        (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffee) /\
+        (0b00 == extract[0-1](V|1|)) /\ (0b000 == extract[0-2](V|6|)) /\
+        (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 7: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|4| <u V|3|) /\
+        (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
+       V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+        (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+        (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+        (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+        (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|5|) /\
-        (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-        (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-        (0b00 == extract[0-1](V|9|))
-  PC 8: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-        (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-        (V|5| <u V|4|) /\ (V|5| <u V|3|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-        Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ (V|3| != V|4|) /\
-        Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|,
-       V|7|, V|8|, V|9|, V|10|, V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-        (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-        (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-        (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-        (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-        (V|10| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|11|) /\
-        (V|11| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-        (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-        (0b00 == extract[0-1](V|8|)) /\ (0b000 == extract[0-2](V|9|)) /\
-        (0b00 == extract[0-1](V|10|)) /\ (0b00 == extract[0-1](V|11|))
-  PC 9: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-        (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-        (V|5| <u V|4|) /\ (V|5| <u V|3|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-        Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-       V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|,
-       V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-        (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-        (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-        (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-        (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-        (V|10| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|11|) /\
-        (V|11| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-        (V|3| == V|4|) /\ (0b00 == extract[0-1](V|6|)) /\
-        (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-        (0b000 == extract[0-2](V|9|)) /\ (0b00 == extract[0-1](V|10|)) /\
-        (0b00 == extract[0-1](V|11|))
-  PC 10: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-         (V|5| <u V|4|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ (V|3| != V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|, V|9|, V|10|, V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|11|) /\
-         (V|11| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b000 == extract[0-2](V|9|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b00 == extract[0-1](V|11|))
-  PC 11: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-         (V|5| <u V|4|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|,
-        V|10|, V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|11|) /\
-         (V|11| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|3| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|9|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b00 == extract[0-1](V|11|))
-  PC 12: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-         (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ (V|3| != V|4|) /\ (V|4| != V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|, V|9|, V|10|, V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|11|) /\
-         (V|11| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b000 == extract[0-2](V|9|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b00 == extract[0-1](V|11|))
-  PC 13: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-         (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ (V|3| != V|4|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|,
-        V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|11|) /\
-         (V|11| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|4| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|9|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b00 == extract[0-1](V|11|))
-  PC 14: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-         (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|,
-        V|11|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|11|) /\
-         (V|11| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|3| == V|4|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|9|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b00 == extract[0-1](V|11|))
-  PC 15: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|5| <u V|2|) /\
-         (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|,
-        V|10|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|, V|11|) /\
+        (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+        (0b00 == extract[0-1](V|8|))
+  PC 8: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+        (V|5| <u V|2|) /\ (V|5| <u V|4|) /\ (V|5| <u V|3|) /\ Distinct(V|1|,
+       V|6|) /\ (V|3| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
+       V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+        (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+        (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+        (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+        (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+        (0b00 == extract[0-1](V|8|))
+  PC 9: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+        (V|5| <u V|2|) /\ (V|5| <u V|4|) /\ (V|5| <u V|3|) /\ Distinct(V|1|,
+       V|6|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|,
+       V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+        (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+        (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+        (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+        (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+        (V|3| == V|4|) /\ (0b000 == extract[0-2](V|6|)) /\
+        (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 10: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|5| <u V|2|) /\ (V|5| <u V|4|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
+        V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 11: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|5| <u V|2|) /\ (V|5| <u V|4|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|,
+        V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|3| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 12: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|3| != V|4|) /\ (V|4| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
+         Distinct(V|1|, V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 13: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|3| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|4| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 14: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|3| == V|4|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 15: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff6) /\
-         (0x0000000000000004 <=u V|11|) /\ (V|11| <=u 0x7ffffffffffffff6) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\ (V|3| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b000 == extract[0-2](V|9|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b00 == extract[0-1](V|11|))
-  PC 16: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|2| <=u V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|3| != V|4|) /\
-         (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 17: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|2| <=u V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|3| != V|4|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|,
-        V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 18: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|2| <=u V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| != V|5|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|,
-        V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|3| == V|4|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 19: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|4| <u V|2|) /\
-         (V|3| <=u V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|2| <=u V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-        V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff6) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff6) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\ (V|2| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 20: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|5| <u V|4|) /\ (V|5| <u V|2|) /\ (V|5| <u V|3|) /\ Distinct(V|1|,
-        V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| != V|4|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 21: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|5| <u V|4|) /\ (V|5| <u V|2|) /\ (V|5| <u V|3|) /\ Distinct(V|1|,
-        V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff2) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|4|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 22: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|5| <u V|4|) /\ (V|5| <u V|2|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|,
-        V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|3| != V|5|) /\
-         (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 23: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|5| <u V|4|) /\ (V|5| <u V|2|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|,
-        V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|3| != V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|4|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 24: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|5| <u V|4|) /\ (V|5| <u V|2|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|,
-        V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| != V|4|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|3| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 25: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|5| <u V|4|) /\ (V|5| <u V|2|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|,
-        V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff6) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff6) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|4|) /\ (V|3| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 26: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|5| <u V|4|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| != V|5|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|,
-        V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 27: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|5| <u V|4|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-        V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff2) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 28: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|2| != V|4|) /\
-         (V|4| != V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
-  PC 29: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|2| != V|4|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-        V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|4| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
-  PC 30: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ (V|2| != V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-        V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|4|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
-  PC 31: (V|3| <u V|2|) /\ Distinct(V|1|, V|6|) /\ (V|2| <=u V|4|) /\
-         (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff6) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|4|) /\ (V|2| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
-  PC 32: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|5| <u V|4|) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\ (V|3| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 16: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|3| != V|4|) /\
+         (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 17: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|3| != V|4|) /\
          Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         (V|2| != V|3|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 33: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|5| <u V|4|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|3|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 34: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         (V|4| != V|5|) /\ (V|2| != V|3|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-        V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 35: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         (V|4| != V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff2) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 36: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         (V|2| != V|3|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff2) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|4| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 37: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff6) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff6) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|3|) /\ (V|4| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 38: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| != V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 39: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 40: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         (V|2| != V|3|) /\ (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 18: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|5|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 19: (V|3| <u V|2|) /\ (V|4| <u V|2|) /\ (V|3| <=u V|4|) /\
+         (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
+        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\ (V|2| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 20: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|5| <u V|4|) /\
+         (V|5| <u V|2|) /\ (V|5| <u V|3|) /\ Distinct(V|1|, V|6|) /\
+         (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 21: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|5| <u V|4|) /\
+         (V|5| <u V|2|) /\ (V|5| <u V|3|) /\ Distinct(V|1|, V|6|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|4|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 22: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|5| <u V|4|) /\
+         (V|5| <u V|2|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|3| != V|5|) /\ (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\
+         Distinct(V|1|, V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 23: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|5| <u V|4|) /\
+         (V|5| <u V|2|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|4|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 24: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|5| <u V|4|) /\
+         (V|5| <u V|2|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|3| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 25: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|5| <u V|4|) /\
+         (V|5| <u V|2|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|4|) /\ (V|3| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 26: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|5| <u V|4|) /\
+         (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|5|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffee) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
-  PC 41: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         (V|2| != V|3|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|3| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
-  PC 42: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|3|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
-  PC 43: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\ Distinct(V|1|,
-        V|6|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-        V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffff6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff6) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|3|) /\ (V|2| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
-  PC 44: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ (V|5| <u V|2|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
+         (0b00 == extract[0-1](V|1|)) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 27: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|5| <u V|4|) /\
+         (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
+        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 45: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ (V|5| <u V|2|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|4|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 46: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ (V|2| <=u V|5|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 28: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ (V|2| != V|4|) /\ (V|4| != V|5|) /\ Distinct(V|1|, V|6|,
+        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 47: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ (V|2| <=u V|5|) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffee) /\
+         (0b00 == extract[0-1](V|1|)) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 29: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
+        V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|4| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 30: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
+        V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|4|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 31: (V|3| <u V|2|) /\ (V|2| <=u V|4|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|,
+        V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff6) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff6) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|4|) /\ (V|2| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 32: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|5| <u V|4|) /\ Distinct(V|1|,
+        V|6|) /\ (V|2| != V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
+        V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 33: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|5| <u V|4|) /\ Distinct(V|1|,
+        V|6|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|,
+        V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|3|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 34: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ (V|4| != V|5|) /\ (V|2| != V|3|) /\ Distinct(V|1|, V|6|,
+        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffee) /\
+         (0b00 == extract[0-1](V|1|)) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 35: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ (V|4| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
+        V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|3|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 36: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ (V|2| != V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
+        V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|4| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 37: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|,
+        V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff6) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff6) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|3|) /\ (V|4| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 38: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|5| <u V|3|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 39: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|5| <u V|3|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
          Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 48: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| != V|4|) /\
-         (V|4| != V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 49: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| != V|4|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|4| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 50: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| != V|5|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|, V|10|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|7|) /\
-         (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|10|) /\
-         (V|10| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|4|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|10|)) /\
-         (0b000 == extract[0-2](V|8|)) /\ (0b00 == extract[0-1](V|9|))
-  PC 51: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|, V|10|) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 40: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|3|) /\
+         (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 41: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|3|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff6) /\
-         (0x0000000000000004 <=u V|10|) /\ (V|10| <=u 0x7ffffffffffffff6) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 42: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|5|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 43: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|4| <u V|2|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
+        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\ (V|2| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 44: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ (V|5| <u V|2|) /\ Distinct(V|1|,
+        V|6|) /\ (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
+        V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 45: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ (V|5| <u V|2|) /\ Distinct(V|1|,
+        V|6|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|,
+        V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|4|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 46: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
+        V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 47: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|5| <u V|3|) /\ (V|5| <u V|4|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|,
+        V|6|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|,
+        V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 48: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|2| != V|4|) /\ (V|4| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
+         Distinct(V|1|, V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 49: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|4| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 50: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|4|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
+  PC 51: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|5| <u V|3|) /\ (V|4| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|4|) /\ (V|2| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
-         (0b00 == extract[0-1](V|10|)) /\ (0b000 == extract[0-2](V|8|)) /\
-         (0b00 == extract[0-1](V|9|))
-  PC 52: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         (V|2| != V|4|) /\ (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 52: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|4|) /\
+         (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 53: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|4|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
-  PC 53: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|3| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
-  PC 54: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|,
-        V|6|, V|7|, V|8|, V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|4|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
-  PC 55: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\ Distinct(V|1|,
-        V|6|) /\ (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-        V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffff6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff6) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|4|) /\ (V|3| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 54: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|3| != V|5|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|4|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
+  PC 55: (V|2| <=u V|3|) /\ (V|4| <u V|3|) /\ (V|2| <=u V|4|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
+        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|4|) /\ (V|3| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 56: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
          (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ Distinct(V|1|, V|6|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ (V|2| != V|3|) /\ (V|3| != V|4|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-        V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (V|2| != V|3|) /\ (V|3| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\
+         Distinct(V|1|, V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 57: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
          (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ Distinct(V|1|, V|6|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ (V|2| != V|3|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (V|2| != V|3|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|3| == V|4|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
   PC 58: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
          (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ Distinct(V|1|, V|6|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ (V|2| != V|4|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (V|2| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|3|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
   PC 59: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
          (V|5| <u V|3|) /\ (V|5| <u V|2|) /\ Distinct(V|1|, V|6|) /\
          Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff6) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\ (V|2| == V|4|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 60: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
          (V|5| <u V|3|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ (V|2| != V|5|) /\ (V|3| != V|4|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|,
-        V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (V|2| != V|5|) /\ (V|3| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\
+         Distinct(V|1|, V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 61: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
          (V|5| <u V|3|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ (V|2| != V|5|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|3| == V|4|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
   PC 62: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
          (V|5| <u V|3|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
-         Distinct(V|1|, V|6|, V|7|) /\ (V|3| != V|4|) /\ Distinct(V|1|, V|6|,
-        V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
-         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (V|3| != V|4|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7ffffffffffffff2) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7ffffffffffffff2) /\ (0b00 == extract[0-1](V|1|)) /\
+         (V|2| == V|5|) /\ (0b000 == extract[0-2](V|6|)) /\
+         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|))
   PC 63: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
          (V|5| <u V|3|) /\ (V|2| <=u V|5|) /\ Distinct(V|1|, V|6|) /\
          Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff6) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\ (V|2| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 64: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
-         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ (V|2| != V|3|) /\ (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|) /\ Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
-         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
-         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7fffffffffffffee) /\
-         (0b00 == extract[0-1](V|1|)) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|3|) /\
+         (V|3| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
+        V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
+         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000008 <=u V|6|) /\
+         (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
+         (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
+         (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 65: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
-         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ (V|2| != V|3|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|3|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|5|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 66: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
-         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ (V|2| != V|5|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
-         Distinct(V|1|, V|6|, V|7|, V|8|, V|9|) /\
+         (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ (V|2| != V|5|) /\
+         Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
          (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
-         (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
-         (0x0000000000000008 <=u V|7|) /\ (V|7| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
-         (0x0000000000000004 <=u V|9|) /\ (V|9| <=u 0x7ffffffffffffff2) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\
-         (0b00 == extract[0-1](V|6|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b00 == extract[0-1](V|9|)) /\ (0b000 == extract[0-2](V|7|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 67: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|5| <u V|4|) /\
          (V|3| <=u V|5|) /\ Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|,
-        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ Distinct(V|1|, V|6|, V|7|,
-        V|8|, V|9|) /\ (0x0000000000000004 <=u V|1|) /\
-         (V|1| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|6|) /\
-         (V|6| <=u 0x7ffffffffffffffa) /\ (0x0000000000000008 <=u V|7|) /\
-         (V|7| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|8|) /\
-         (V|8| <=u 0x7ffffffffffffff6) /\ (0x0000000000000004 <=u V|9|) /\
-         (V|9| <=u 0x7ffffffffffffff6) /\ (0b00 == extract[0-1](V|1|)) /\
-         (V|2| == V|3|) /\ (V|2| == V|5|) /\ (0b00 == extract[0-1](V|6|)) /\
-         (0b00 == extract[0-1](V|8|)) /\ (0b00 == extract[0-1](V|9|)) /\
-         (0b000 == extract[0-2](V|7|))
+        V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
+         (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7fffffffffffffee) /\
+         (0x0000000000000008 <=u V|6|) /\ (V|6| <=u 0x7fffffffffffffc6) /\
+         (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
+         (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
+         (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\ (V|2| == V|5|) /\
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 68: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|4| <=u V|5|) /\
          Distinct(V|1|, V|6|) /\ (V|2| != V|3|) /\ (V|3| != V|4|) /\
          (V|4| != V|5|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|,
@@ -937,8 +678,8 @@
          (V|6| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|7|) /\
          (V|7| <=u 0x7fffffffffffffee) /\ (0x0000000000000004 <=u V|8|) /\
          (V|8| <=u 0x7fffffffffffffee) /\ (0b00 == extract[0-1](V|1|)) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|6|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 69: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|4| <=u V|5|) /\
          Distinct(V|1|, V|6|) /\ (V|2| != V|3|) /\ (V|3| != V|4|) /\
          Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
@@ -947,8 +688,8 @@
          (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|4| == V|5|) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|6|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 70: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|4| <=u V|5|) /\
          Distinct(V|1|, V|6|) /\ (V|2| != V|3|) /\ (V|3| != V|5|) /\
          Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
@@ -957,8 +698,8 @@
          (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|6|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 71: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|4| <=u V|5|) /\
          Distinct(V|1|, V|6|) /\ (V|2| != V|3|) /\ Distinct(V|1|, V|6|,
         V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
@@ -967,8 +708,8 @@
          (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|3| == V|4|) /\ (V|3| == V|5|) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|6|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 72: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|4| <=u V|5|) /\
          Distinct(V|1|, V|6|) /\ (V|2| != V|4|) /\ (V|4| != V|5|) /\
          Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
@@ -977,8 +718,8 @@
          (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff2) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff2) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|6|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 73: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|4| <=u V|5|) /\
          Distinct(V|1|, V|6|) /\ (V|2| != V|4|) /\ Distinct(V|1|, V|6|,
         V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\ (V|2| <=u V|4|) /\
@@ -987,8 +728,8 @@
          (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\ (V|4| == V|5|) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|6|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 74: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|4| <=u V|5|) /\
          Distinct(V|1|, V|6|) /\ (V|2| != V|5|) /\ Distinct(V|1|, V|6|,
         V|7|) /\ Distinct(V|1|, V|6|, V|7|, V|8|) /\
@@ -997,8 +738,8 @@
          (0x0000000000000004 <=u V|7|) /\ (V|7| <=u 0x7ffffffffffffff6) /\
          (0x0000000000000004 <=u V|8|) /\ (V|8| <=u 0x7ffffffffffffff6) /\
          (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\ (V|2| == V|4|) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|6|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   PC 75: (V|2| <=u V|3|) /\ (V|3| <=u V|4|) /\ (V|4| <=u V|5|) /\
          Distinct(V|1|, V|6|) /\ Distinct(V|1|, V|6|, V|7|) /\ Distinct(V|1|,
         V|6|, V|7|, V|8|) /\ (0x0000000000000004 <=u V|1|) /\
@@ -1007,6 +748,6 @@
          (V|7| <=u 0x7ffffffffffffffa) /\ (0x0000000000000004 <=u V|8|) /\
          (V|8| <=u 0x7ffffffffffffffa) /\ (0b00 == extract[0-1](V|1|)) /\
          (V|2| == V|3|) /\ (V|2| == V|4|) /\ (V|2| == V|5|) /\
-         (0b00 == extract[0-1](V|7|)) /\ (0b00 == extract[0-1](V|8|)) /\
-         (0b000 == extract[0-2](V|6|))
+         (0b000 == extract[0-2](V|6|)) /\ (0b00 == extract[0-1](V|7|)) /\
+         (0b00 == extract[0-1](V|8|))
   

--- a/soteria-rust/test/cram/simple.t/btreeset_small.rs
+++ b/soteria-rust/test/cram/simple.t/btreeset_small.rs
@@ -1,0 +1,21 @@
+use std::collections::BTreeSet;
+
+const SIZE: usize = 2;
+
+fn nondet_treeset() -> BTreeSet<u32> {
+    (0..SIZE).map(|_| soteria::nondet_bytes()).collect()
+}
+
+#[soteria::test]
+fn test_treeset_is_ordered() {
+    let set = nondet_treeset();
+
+    let values: Vec<u32> = set.iter().copied().collect();
+    let mut sorted = values.clone();
+    sorted.sort();
+
+    assert_eq!(
+        values, sorted,
+        "BTreeSet values should be in ascending order"
+    );
+}

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -693,3 +693,37 @@ FIXME: the last 3 decayed pointers shall be removed in #386
   PC 1: (0x0000000000000000 == V|1|) /\ (0x0000000000000000 == V|1|)
   PC 2: (0x0000000000000001 <=u V|1|)
   
+
+  $ soteria-rust exec btreeset_small.rs --stats stats.json && check_stat stats.json decayed_pointers 0
+  Compiling... done in <time>
+  => Running btreeset_small::test_treeset_is_ordered...
+  note: btreeset_small::test_treeset_is_ordered: done in <time>, ran 3 branches
+  PC 1: (V|3| <u V|2|) /\ Distinct(V|1|, V|4|) /\ Distinct(V|1|, V|4|, V|5|) /\
+        Distinct(V|1|, V|4|, V|5|, V|6|) /\ (0x0000000000000004 <=u V|1|) /\
+        (V|1| <=u 0x7ffffffffffffff6) /\ (0x0000000000000008 <=u V|4|) /\
+        (V|4| <=u 0x7fffffffffffffc6) /\ (0x0000000000000004 <=u V|5|) /\
+        (V|5| <=u 0x7ffffffffffffff6) /\ (0x0000000000000004 <=u V|6|) /\
+        (V|6| <=u 0x7ffffffffffffff6) /\ (0b00 == extract[0-1](V|1|)) /\
+        (0b000 == extract[0-2](V|4|)) /\ (0b00 == extract[0-1](V|5|)) /\
+        (0b00 == extract[0-1](V|6|))
+  PC 2: (V|2| <=u V|3|) /\ Distinct(V|1|, V|4|) /\ (V|2| != V|3|) /\
+        Distinct(V|1|, V|4|, V|5|) /\ Distinct(V|1|, V|4|, V|5|, V|6|) /\
+        (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffff6) /\
+        (0x0000000000000008 <=u V|4|) /\ (V|4| <=u 0x7fffffffffffffc6) /\
+        (0x0000000000000004 <=u V|5|) /\ (V|5| <=u 0x7ffffffffffffff6) /\
+        (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffff6) /\
+        (0b00 == extract[0-1](V|1|)) /\ (0b000 == extract[0-2](V|4|)) /\
+        (0b00 == extract[0-1](V|5|)) /\ (0b00 == extract[0-1](V|6|))
+  PC 3: (V|2| <=u V|3|) /\ Distinct(V|1|, V|4|) /\ Distinct(V|1|, V|4|,
+       V|5|) /\ Distinct(V|1|, V|4|, V|5|, V|6|) /\
+        (0x0000000000000004 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffff6) /\
+        (0x0000000000000008 <=u V|4|) /\ (V|4| <=u 0x7fffffffffffffc6) /\
+        (0x0000000000000004 <=u V|5|) /\ (V|5| <=u 0x7ffffffffffffffa) /\
+        (0x0000000000000004 <=u V|6|) /\ (V|6| <=u 0x7ffffffffffffffa) /\
+        (0b00 == extract[0-1](V|1|)) /\ (V|2| == V|3|) /\
+        (0b000 == extract[0-2](V|4|)) /\ (0b00 == extract[0-1](V|5|)) /\
+        (0b00 == extract[0-1](V|6|))
+  
+  check_stat: expected '0', got '9' for decayed_pointers
+  [1]
+


### PR DESCRIPTION
Another fast path that avoid decays.

CI won't path because we need to merge a bunch of other stuff before we truly have no decay in btreeset