### PR TITLE
Don't decay on pointer equality if it can be avoided

### DIFF
--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -140,12 +140,24 @@ module M (StateM : State.StateM.S) = struct
         let+ res = eval_ptr_binop Eq l r in
         BV.not_bool (cast res)
     | Eq, Ptr (l, meta_l), Ptr (r, meta_r) ->
-        let* meta_eq = eval_meta_eq meta_l meta_r in
         (* Pointer comparison just uses the address! See
            https://doc.rust-lang.org/std/ptr/index.html#provenance *)
-        let+ distance = Sptr.distance l r in
-        let ptr_eq = distance ==@ Usize.(0s) in
-        BV.of_bool (meta_eq &&@ ptr_eq)
+        (* We optimise when the pointers surely have (or surely don't have) the
+           same provenance, to avoid spuriously decaying them. *)
+        let same_provenance = Sptr.have_same_provenance l r in
+        if%sure same_provenance then
+          (* Same allocation: comparing the offsets is enough. *)
+          let+ meta_eq = eval_meta_eq meta_l meta_r in
+          BV.of_bool (meta_eq &&@ (Sptr.ofs l ==@ Sptr.ofs r))
+        else if%sure not same_provenance then
+          (* Distinct allocations live at distinct addresses, so the pointers
+             cannot be equal. *)
+          ok (BV.of_bool v_false)
+        else
+          let* meta_eq = eval_meta_eq meta_l meta_r in
+          let+ distance = Sptr.distance l r in
+          let ptr_eq = distance ==@ Usize.(0s) in
+          BV.of_bool (meta_eq &&@ ptr_eq)
     | Eq, Ptr (p, _), Int v | Eq, Int v, Ptr (p, _) ->
         let v = cast_i Usize v in
         if%sat v ==@ Usize.(0s) then ok (BV.of_bool (Sptr.is_null p))

--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -135,6 +135,7 @@ module M (StateM : State.StateM.S) = struct
     | _, _ -> v_false
 
   let rec eval_ptr_binop (bop : Expressions.binop) l r =
+    let null_or_in_bound p = Sptr.is_null p ||@ Sptr.in_bound p in
     match (bop, l, r) with
     | Ne, _, _ ->
         let+ res = eval_ptr_binop Eq l r in
@@ -149,14 +150,19 @@ module M (StateM : State.StateM.S) = struct
           let+ meta_eq = eval_meta_eq meta_l meta_r in
           BV.of_bool (meta_eq &&@ (Sptr.ofs l ==@ Sptr.ofs r))
         else if%sure
-          (not same_provenance) &&@ Sptr.in_bound l &&@ Sptr.in_bound r
+          (not same_provenance) &&@ null_or_in_bound l &&@ null_or_in_bound r
         then
-          (* Fast path: if two pointer have different provenances AND are in
-             bound of their respective allocations, they cannot be equal (since
-             allocations cannot overlap).
+          (* Fast path: case where two pointers have different provenances. If
+             they are both in bound, then they can't compare equal since two
+             distinct allocations cannot overlap. Similarly, if one of the is
+             null, and the other one has a valid provance and is in bound, then
+             they can't compare equal either because an allocation cannot be at
+             address 0.
 
              Note: pointers that have no provenance have size 0, so they are
-             always out of bound.*)
+             always out of bound, so testing equality of a pointer with valid
+             provenance and a non-0 address with no provenance will bypass this
+             path, as it should. *)
           ok (BV.of_bool v_false)
         else
           let* meta_eq = eval_meta_eq meta_l meta_r in

--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -142,16 +142,18 @@ module M (StateM : State.StateM.S) = struct
     | Eq, Ptr (l, meta_l), Ptr (r, meta_r) ->
         (* Pointer comparison just uses the address! See
            https://doc.rust-lang.org/std/ptr/index.html#provenance *)
-        (* We optimise when the pointers surely have (or surely don't have) the
-           same provenance, to avoid spuriously decaying them. *)
         let same_provenance = Sptr.have_same_provenance l r in
         if%sure same_provenance then
-          (* Same allocation: comparing the offsets is enough. *)
+          (* Fast path: if two pointer have the same provenance, it's enough to
+             compare their offsets *)
           let+ meta_eq = eval_meta_eq meta_l meta_r in
           BV.of_bool (meta_eq &&@ (Sptr.ofs l ==@ Sptr.ofs r))
-        else if%sure not same_provenance then
-          (* Distinct allocations live at distinct addresses, so the pointers
-             cannot be equal. *)
+        else if%sure
+          (not same_provenance) &&@ Sptr.in_bound l &&@ Sptr.in_bound r
+        then
+          (* Fast path: if two pointer have different provenances AND are in
+             bound of their respective allocations, they cannot be equal (since
+             allocations cannot overlap). *)
           ok (BV.of_bool v_false)
         else
           let* meta_eq = eval_meta_eq meta_l meta_r in

--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -153,7 +153,10 @@ module M (StateM : State.StateM.S) = struct
         then
           (* Fast path: if two pointer have different provenances AND are in
              bound of their respective allocations, they cannot be equal (since
-             allocations cannot overlap). *)
+             allocations cannot overlap).
+
+             Note: pointers that have no provenance have size 0, so they are
+             always out of bound.*)
           ok (BV.of_bool v_false)
         else
           let* meta_eq = eval_meta_eq meta_l meta_r in

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -190,8 +190,6 @@ module type S = sig
       to its allocation. *)
   val in_bound : t -> sbool Typed.t
 
-  (** The size of the allocation this pointer points to. *)
-
   (** Whether this pointer has provenance, i.e. points to some allocation. *)
   val has_provenance : t -> sbool Typed.t
 

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -183,6 +183,9 @@ module type S = sig
   (** Whether this is the null pointer, meaning it always decays to 0. *)
   val is_null : t -> sbool Typed.t
 
+  (** The offset of this pointer within its allocation. *)
+  val ofs : t -> [> sint ] Typed.t
+
   (** Whether this pointer has provenance, i.e. points to some allocation. *)
   val has_provenance : t -> sbool Typed.t
 

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -186,6 +186,12 @@ module type S = sig
   (** The offset of this pointer within its allocation. *)
   val ofs : t -> [> sint ] Typed.t
 
+  (** Returns a symbolic boolean characterising whether the pointer is in bound
+      to its allocation. *)
+  val in_bound : t -> sbool Typed.t
+
+  (** The size of the allocation this pointer points to. *)
+
   (** Whether this pointer has provenance, i.e. points to some allocation. *)
   val has_provenance : t -> sbool Typed.t
 

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -94,6 +94,7 @@ module Make (Borrows : Tree_borrows.T) = struct
       else Result.ok None
 
     let is_null { ptr; _ } = Typed.Ptr.is_null ptr
+    let ofs { ptr; _ } = Typed.Ptr.ofs ptr
     let has_provenance { ptr; _ } = Typed.not (Typed.Ptr.is_at_null_loc ptr)
 
     let have_same_provenance { ptr = ptr1; _ } { ptr = ptr2; _ } =

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -49,6 +49,10 @@ module Make (Borrows : Tree_borrows.T) = struct
         tag = L_option.to_syn Borrows.Tag.to_syn tag;
       }
 
+    let in_bound { ptr; size; _ } =
+      let ofs = Typed.Ptr.ofs ptr in
+      Usize.(0s) <=@ ofs &&@ (ofs <@ size)
+
     let learn_eq syn t =
       let open DecayMap.SM.Consumer in
       let open Syntax in

--- a/soteria-rust/test/cram/simple.t/ptr_diff_prov.rs
+++ b/soteria-rust/test/cram/simple.t/ptr_diff_prov.rs
@@ -1,4 +1,7 @@
-fn main() {
+use std::mem::transmute;
+
+#[soteria::test]
+fn diff_prov_same_address() {
     let x = 11u8;
     let y = 12u8;
     // provenance of x
@@ -8,4 +11,11 @@ fn main() {
     // still has provenance of y, but address of x
     let ptr2 = ptr2.wrapping_sub((ptr2 as usize).wrapping_sub(ptr1 as usize));
     assert!(ptr1 == ptr2) // diff provenance, same address.
+}
+
+#[soteria::test]
+fn one_prov_one_no_prove_same_address() {
+    let x = 11usize;
+    let no_prov = unsafe { transmute::<usize, *const usize>(transmute::<&usize, usize>(&x)) };
+    assert!(no_prov == (&x as *const usize));
 }

--- a/soteria-rust/test/cram/simple.t/ptr_diff_prov.rs
+++ b/soteria-rust/test/cram/simple.t/ptr_diff_prov.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let x = 11u8;
+    let y = 12u8;
+    // provenance of x
+    let ptr1 = &x as *const u8;
+    // provenance of y
+    let ptr2 = &y as *const u8;
+    // still has provenance of y, but address of x
+    let ptr2 = ptr2.wrapping_sub((ptr2 as usize).wrapping_sub(ptr1 as usize));
+    assert!(ptr1 == ptr2) // diff provenance, same address.
+}

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -728,9 +728,14 @@ but different provenance should be decayed, compared, and checked to be equal
 successfuly.
   $ soteria-rust exec ptr_diff_prov.rs
   Compiling... done in <time>
-  => Running ptr_diff_prov::main...
-  note: ptr_diff_prov::main: done in <time>, ran 1 branch
+  => Running ptr_diff_prov::diff_prov_same_address...
+  note: ptr_diff_prov::diff_prov_same_address: done in <time>, ran 1 branch
   PC 1: Distinct(V|1-2|) /\ (0x0000000000000001 <=u V|1|) /\
         (V|1| <=u 0x7ffffffffffffffd) /\ (0x0000000000000001 <=u V|2|) /\
         (V|2| <=u 0x7ffffffffffffffd)
+  
+  => Running ptr_diff_prov::one_prov_one_no_prove_same_address...
+  note: ptr_diff_prov::one_prov_one_no_prove_same_address: done in <time>, ran 1 branch
+  PC 1: (0x0000000000000008 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffff6) /\
+        (0b000 == extract[0-2](V|1|))
   

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -146,15 +146,11 @@ Check permissive provenance allows int to ptr casts
   PC 1: (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd)
   
 Distinct allocations get distinct base addresses, so they can never alias
-  $ soteria-rust exec distinct_allocs.rs
+  $ soteria-rust exec distinct_allocs.rs --stats stats.json && check_stat stats.json decayed_pointers 0
   Compiling... done in <time>
   => Running distinct_allocs::distinct_allocs_dont_alias...
   note: distinct_allocs::distinct_allocs_dont_alias: done in <time>, ran 1 branch
-  PC 1: Distinct(V|1-2|) /\ (0x0000000000000000 != (V|1| - V|2|)) /\
-        Distinct(V|1-3|) /\ (0x0000000000000000 != (V|2| - V|3|)) /\
-        (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd) /\
-        (0x0000000000000001 <=u V|2|) /\ (V|2| <=u 0x7ffffffffffffffd) /\
-        (0x0000000000000001 <=u V|3|) /\ (V|3| <=u 0x7ffffffffffffffd)
+  PC 1: empty
   
 Check corner cases with permissive provenance, around transmutes
   $ soteria-rust exec provenance_transmute.rs --provenance permissive

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -723,3 +723,14 @@ FIXME: the last 3 decayed pointers shall be removed in #386
   check_stat: expected '0', got '9' for decayed_pointers
   [1]
 
+Pointers are compared by their addresses. Two pointer with equal addresses
+but different provenance should be decayed, compared, and checked to be equal
+successfuly.
+  $ soteria-rust exec ptr_diff_prov.rs
+  Compiling... done in <time>
+  => Running ptr_diff_prov::main...
+  note: ptr_diff_prov::main: done in <time>, ran 1 branch
+  PC 1: Distinct(V|1-2|) /\ (0x0000000000000001 <=u V|1|) /\
+        (V|1| <=u 0x7ffffffffffffffd) /\ (0x0000000000000001 <=u V|2|) /\
+        (V|2| <=u 0x7ffffffffffffffd)
+  

--- a/soteria/lib/bv_values/svalue.ml
+++ b/soteria/lib/bv_values/svalue.ml
@@ -1009,6 +1009,7 @@ and BitVec : BitVec = struct
     | Binop (Add _, l, r), _ when equal r v2 -> l
     | Binop (Add _, l1, r1), Binop (Add _, l2, r2) when equal l1 l2 ->
         sub ~checked r1 r2
+    | _l, Binop (Sub _, l', r) when equal v1 l' -> r
     (* only propagate down ites if we know it's concrete *)
     | Ite (b, l, r), BitVec _ -> Bool.ite b (sub l v2) (sub r v2)
     | BitVec _, Ite (b, l, r) -> Bool.ite b (sub v1 l) (sub v1 r)


### PR DESCRIPTION
Again, another fast path. If we know two pointers have the same provenance, or if we know they don't, we can immediately return.

This is another use case for your "lazy &&" I think?