### PR TITLE
Conformance benchmark in CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -157,7 +157,11 @@ jobs:
           echo "MIRI_SUITE_PATH=${GITHUB_WORKSPACE}/conformance/miri/tests" >> $GITHUB_ENV
 
       - name: Run benchmarks
-        run: python3 scripts/run_benchmarks.py --output benchmark-results.json --conformance
+        run: |
+          python3 scripts/run_benchmarks.py \
+            --output benchmark-results.json \
+            --conformance \
+            --conformance-csv conformance-outcomes.csv
 
       # Main pushes publish the new data point to gh-pages so the dashboard's
       # history advances. PR runs deliberately skip the publish — the
@@ -180,9 +184,13 @@ jobs:
           alert-threshold: "150%"
           fail-on-alert: false
 
-      # github-action-benchmark only writes its default index.html when none
-      # exists, so it never overwrites ours. Copy our custom dashboard over the
-      # published one; this only produces a commit when the template changes.
+      # Publish two things to gh-pages alongside github-action-benchmark's data.js:
+      #   - our custom dashboard (the action only writes its default index.html
+      #     when none exists, so it never overwrites ours);
+      #   - the per-test conformance outcomes CSV, whose git history then records
+      #     exactly when a test's outcome changed (the file is sorted and times-
+      #     free, so it only differs on a real regression/improvement).
+      # A commit is produced only when one of these files actually changes.
       - name: Publish custom benchmark dashboard
         if: inputs.pr-number == ''
         run: |
@@ -190,14 +198,19 @@ jobs:
           git fetch origin gh-pages
           git worktree add --detach bench-dashboard origin/gh-pages
           cp scripts/bench-index.html bench-dashboard/dev/bench/index.html
+          files="dev/bench/index.html"
+          if [ -f conformance-outcomes.csv ]; then
+            cp conformance-outcomes.csv bench-dashboard/dev/bench/conformance-outcomes.csv
+            files="$files dev/bench/conformance-outcomes.csv"
+          fi
           cd bench-dashboard
-          if git diff --quiet -- dev/bench/index.html; then
-            echo "Dashboard already up to date."
+          git add $files
+          if git diff --cached --quiet; then
+            echo "Dashboard and conformance outcomes already up to date."
           else
-            git add dev/bench/index.html
             git -c user.name='github-actions[bot]' \
                 -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-                commit -m 'Update benchmark dashboard'
+                commit -m 'Update benchmark dashboard and conformance outcomes'
             git push origin HEAD:gh-pages
           fi
           cd ..

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,6 +66,22 @@ jobs:
           ref: 67a094035b3f7159cf3f9af82c55ae63fcb86a34
           path: benchmark-projects/Collections-C
 
+      # Conformance suites for the Rust conformance benchmark. Pinned to a
+      # specific upstream commit so the metric is stable over time; bump these
+      # by hand when tracking a newer toolchain.
+      - name: Checkout Kani (conformance suite)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
+        with:
+          repository: model-checking/kani
+          ref: 4c0fce8c300e1f049f2b0c6766a5111dfc9ff32e
+          path: conformance/kani
+      - name: Checkout Miri (conformance suite)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
+        with:
+          repository: rust-lang/miri
+          ref: 28b3a0aad5cc0fc7d2fbaf480f50db823f7fe31d
+          path: conformance/miri
+
       # The Obol-pinned rust-toolchain.toml drives rustup inside the container
       # so the .rs files / crates are compiled with the same toolchain CI uses.
       # The Obol repo/commit is read from the checked-out scripts/versions.json
@@ -133,9 +149,15 @@ jobs:
           # Each tool resolves z3 from its own package.
           echo "SOTERIA_Z3_PATH=${C_DIR}/bin/z3" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=${C_DIR}/lib:${RUST_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+          # Conformance benchmark: soteria-rust/scripts/test.py invokes
+          # `soteria-rust` and `obol` by name, and reads the suite locations
+          # from these env vars.
+          echo "${RUST_DIR}/bin" >> $GITHUB_PATH
+          echo "KANI_SUITE_PATH=${GITHUB_WORKSPACE}/conformance/kani/tests/kani" >> $GITHUB_ENV
+          echo "MIRI_SUITE_PATH=${GITHUB_WORKSPACE}/conformance/miri/tests" >> $GITHUB_ENV
 
       - name: Run benchmarks
-        run: python3 scripts/run_benchmarks.py --output benchmark-results.json
+        run: python3 scripts/run_benchmarks.py --output benchmark-results.json --conformance
 
       # Main pushes publish the new data point to gh-pages so the dashboard's
       # history advances. PR runs deliberately skip the publish — the
@@ -157,6 +179,29 @@ jobs:
           summary-always: true
           alert-threshold: "150%"
           fail-on-alert: false
+
+      # github-action-benchmark only writes its default index.html when none
+      # exists, so it never overwrites ours. Copy our custom dashboard over the
+      # published one; this only produces a commit when the template changes.
+      - name: Publish custom benchmark dashboard
+        if: inputs.pr-number == ''
+        run: |
+          set -euo pipefail
+          git fetch origin gh-pages
+          git worktree add --detach bench-dashboard origin/gh-pages
+          cp scripts/bench-index.html bench-dashboard/dev/bench/index.html
+          cd bench-dashboard
+          if git diff --quiet -- dev/bench/index.html; then
+            echo "Dashboard already up to date."
+          else
+            git add dev/bench/index.html
+            git -c user.name='github-actions[bot]' \
+                -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+                commit -m 'Update benchmark dashboard'
+            git push origin HEAD:gh-pages
+          fi
+          cd ..
+          git worktree remove bench-dashboard
 
       # PR-only path: pull just main's data.js, build a comparison table, and
       # surface it via the step summary + an artifact that pr-commands.yml's

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -228,9 +228,11 @@ jobs:
             git fetch --depth=1 origin gh-pages
             # `git show` exits non-zero if the file doesn't exist on gh-pages
             # (first run, dir not yet created); tolerate that and leave the
-            # file empty — the compare script then renders every row as new.
+            # file empty — the compare scripts then render no baseline.
             git --no-pager show origin/gh-pages:dev/bench/data.js \
               > main-bench/data.js 2>/dev/null || true
+            git --no-pager show origin/gh-pages:dev/bench/conformance-outcomes.csv \
+              > main-bench/conformance-outcomes.csv 2>/dev/null || true
           else
             echo "No gh-pages branch yet; comparing against an empty baseline."
           fi
@@ -242,6 +244,18 @@ jobs:
             --current benchmark-results.json \
             --main-data main-bench/data.js \
             --output benchmark-comparison.md
+          # Append the per-test conformance outcome changes (before -> after)
+          # below the timing table so reviewers can see what conformance moved.
+          if [ -f conformance-outcomes.csv ]; then
+            python3 scripts/diff_conformance.py \
+              --before main-bench/conformance-outcomes.csv \
+              --after conformance-outcomes.csv \
+              --output conformance-changes.md
+            {
+              echo
+              cat conformance-changes.md
+            } >> benchmark-comparison.md
+          fi
           {
             echo "## Soteria benchmarks vs \`main\`"
             echo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ env:
   OCAML_VERSION: 5.4.1
   # [versionsync: OBOL_REPO=soteria-tools/obol]
   OBOL_REPO: soteria-tools/obol
-  # [versionsync: OBOL_COMMIT_HASH=0fff449d6c2ca9dc4ea6bf44b999d4d1b67bf670]
-  OBOL_COMMIT_HASH: 0fff449d6c2ca9dc4ea6bf44b999d4d1b67bf670
+  # [versionsync: OBOL_COMMIT_HASH=7eef0668b9385042a379efe785b049517a304cc3]
+  OBOL_COMMIT_HASH: 7eef0668b9385042a379efe785b049517a304cc3
   # [versionsync: CHARON_REPO=soteria-tools/charon]
   CHARON_REPO: soteria-tools/charon
   # [versionsync: CHARON_COMMIT_HASH=4986f2907dbe5899b0756ab623b5ef661ed2c58c]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ env:
   OCAML_VERSION: 5.4.1
   # [versionsync: OBOL_REPO=soteria-tools/obol]
   OBOL_REPO: soteria-tools/obol
-  # [versionsync: OBOL_COMMIT_HASH=42f11d00b19ba8bda50fd6fd43d860ef4dd4946d]
-  OBOL_COMMIT_HASH: 42f11d00b19ba8bda50fd6fd43d860ef4dd4946d
+  # [versionsync: OBOL_COMMIT_HASH=7eef0668b9385042a379efe785b049517a304cc3]
+  OBOL_COMMIT_HASH: 7eef0668b9385042a379efe785b049517a304cc3
   # [versionsync: CHARON_REPO=soteria-tools/charon]
   CHARON_REPO: soteria-tools/charon
   # [versionsync: CHARON_COMMIT_HASH=4986f2907dbe5899b0756ab623b5ef661ed2c58c]

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -6,8 +6,8 @@ on:
 env:
   # [versionsync: OBOL_REPO=soteria-tools/obol]
   OBOL_REPO: soteria-tools/obol
-  # [versionsync: OBOL_COMMIT_HASH=42f11d00b19ba8bda50fd6fd43d860ef4dd4946d]
-  OBOL_COMMIT_HASH: 42f11d00b19ba8bda50fd6fd43d860ef4dd4946d
+  # [versionsync: OBOL_COMMIT_HASH=7eef0668b9385042a379efe785b049517a304cc3]
+  OBOL_COMMIT_HASH: 7eef0668b9385042a379efe785b049517a304cc3
 
 jobs:
   test-soteria-c-package:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -6,8 +6,8 @@ on:
 env:
   # [versionsync: OBOL_REPO=soteria-tools/obol]
   OBOL_REPO: soteria-tools/obol
-  # [versionsync: OBOL_COMMIT_HASH=0fff449d6c2ca9dc4ea6bf44b999d4d1b67bf670]
-  OBOL_COMMIT_HASH: 0fff449d6c2ca9dc4ea6bf44b999d4d1b67bf670
+  # [versionsync: OBOL_COMMIT_HASH=7eef0668b9385042a379efe785b049517a304cc3]
+  OBOL_COMMIT_HASH: 7eef0668b9385042a379efe785b049517a304cc3
 
 jobs:
   test-soteria-c-package:

--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ _opam/
 
 # LLBC generated files by Charon, debug file
 *.llbc.json
+*.ullbc
 *.crate
 
 ### macOS ###

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,12 +109,12 @@ To use Soteria Rust, you need a frontend to translate Rust code to an intermedia
 
 **Manual installation:**
 1. **Clone Obol at the correct commit:**
-   <!-- [versionsync: OBOL_COMMIT_HASH=42f11d00b19ba8bda50fd6fd43d860ef4dd4946d] -->
+   <!-- [versionsync: OBOL_COMMIT_HASH=7eef0668b9385042a379efe785b049517a304cc3] -->
    ```sh
    cd ..
    git clone https://github.com/soteria-tools/obol.git
    cd obol
-   git checkout 42f11d00b19ba8bda50fd6fd43d860ef4dd4946d
+   git checkout 7eef0668b9385042a379efe785b049517a304cc3
    ```
    > **Note:** The required commit hash can always be found in [`scripts/versions.json`](scripts/versions.json) under `OBOL_COMMIT_HASH`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,12 +109,12 @@ To use Soteria Rust, you need a frontend to translate Rust code to an intermedia
 
 **Manual installation:**
 1. **Clone Obol at the correct commit:**
-   <!-- [versionsync: OBOL_COMMIT_HASH=0fff449d6c2ca9dc4ea6bf44b999d4d1b67bf670] -->
+   <!-- [versionsync: OBOL_COMMIT_HASH=7eef0668b9385042a379efe785b049517a304cc3] -->
    ```sh
    cd ..
    git clone https://github.com/soteria-tools/obol.git
    cd obol
-   git checkout 0fff449d6c2ca9dc4ea6bf44b999d4d1b67bf670
+   git checkout 7eef0668b9385042a379efe785b049517a304cc3
    ```
    > **Note:** The required commit hash can always be found in [`scripts/versions.json`](scripts/versions.json) under `OBOL_COMMIT_HASH`.
 

--- a/Makefile
+++ b/Makefile
@@ -146,18 +146,18 @@ ocaml-deps:
 	$(OPAM) install . --deps-only --with-test --with-doc -y
 	$(OPAM) install sherlodoc -y
 
-# Clears all *.llbc.json, Cargo.lock and target/ subflders in soteria-rust/test/cram/
+# Clears all *.ullbc, Cargo.lock and target/ subflders in soteria-rust/test/cram/
 # We make sure that every file or folder deleted is displayed in the terminal.
 .PHONY: clean-rust-tests
 clean-rust-tests:
 	@echo "$(COLOR_BLUE)==> Cleaning Rust test artifacts in soteria-rust/test/cram/$(COLOR_RESET)"
-	@find soteria-rust/test/cram/ -type f -name '*.llbc.json' -print -delete | sed 's/^/  🗑️ /'
-	@find soteria-rust/test/cram/ -type f -name '*.llbc.json.crate' -print -delete | sed 's/^/  🗑️ /'
+	@find soteria-rust/test/cram/ -type f -name '*.ullbc' -print -delete | sed 's/^/  🗑️ /'
+	@find soteria-rust/test/cram/ -type f -name '*.crate' -print -delete | sed 's/^/  🗑️ /'
 	@find soteria-rust/test/cram/ -type f -name 'Cargo.lock' -print -delete | sed 's/^/  🗑️ /'
 	@find soteria-rust/test/cram/ -type d -name 'target' -print -exec rm -rf {} + | sed 's/^/  🗑️ /'
 	@echo "$(COLOR_GREEN)==> Done$(COLOR_RESET)"
-	
-	
+
+
 
 .PHONY: clean
 clean: clean-rust-tests

--- a/scripts/bench-index.html
+++ b/scripts/bench-index.html
@@ -1,0 +1,451 @@
+<!DOCTYPE html>
+<!--
+  Custom dashboard for benchmark-action/github-action-benchmark, derived from
+  the action's default template. Differences from the default:
+    - benches are grouped into sections (Rust performance, C performance and
+      Rust conformance) by their name prefix, with clear visual separation;
+    - charts are laid out in a two-column grid instead of one long column;
+    - the Rust conformance benches ("conformance-<suite>: <metric>") are drawn
+      as four charts: a multi-line outcomes chart and a total-time chart for
+      each of the Kani and Miri suites.
+  scripts/run_benchmarks.py produces the bench names this relies on; CI copies
+  this file over dev/bench/index.html on gh-pages (see .github/workflows/benchmarks.yml).
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
+    <style>
+      html {
+        font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+        -webkit-font-smoothing: antialiased;
+        background-color: #fff;
+        font-size: 16px;
+      }
+      body {
+        color: #4a4a4a;
+        margin: 8px;
+        font-size: 1em;
+        font-weight: 400;
+      }
+      header {
+        margin-bottom: 8px;
+        display: flex;
+        flex-direction: column;
+      }
+      main {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      a {
+        color: #3273dc;
+        cursor: pointer;
+        text-decoration: none;
+      }
+      a:hover {
+        color: #000;
+      }
+      button {
+        color: #fff;
+        background-color: #3298dc;
+        border-color: transparent;
+        cursor: pointer;
+        text-align: center;
+      }
+      button:hover {
+        background-color: #2793da;
+        flex: none;
+      }
+      .spacer {
+        flex: auto;
+      }
+      .small {
+        font-size: 0.75rem;
+      }
+      footer {
+        margin-top: 16px;
+        display: flex;
+        align-items: center;
+      }
+      .header-label {
+        margin-right: 4px;
+      }
+      /* Each top-level group (Rust / C / conformance) is a clearly separated
+         block with a coloured accent bar so the categories don't blur together. */
+      .benchmark-section {
+        margin: 28px 0;
+        padding: 8px 16px 16px;
+        border: 1px solid #e1e4e8;
+        border-radius: 8px;
+        border-top: 6px solid var(--accent, #888);
+        background-color: #fafbfc;
+      }
+      .section-title {
+        font-size: 1.9rem;
+        font-weight: 700;
+        margin: 8px 0 4px;
+        color: #24292e;
+      }
+      .section-subtitle {
+        margin: 0 0 8px;
+        color: #6a737d;
+        font-size: 0.9rem;
+      }
+      /* Two-column grid of charts. */
+      .benchmark-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 16px;
+        align-items: start;
+      }
+      @media (max-width: 800px) {
+        .benchmark-grid {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
+      .benchmark-card {
+        border: 1px solid #e1e4e8;
+        border-radius: 6px;
+        background-color: #fff;
+        padding: 8px 12px 12px;
+        min-width: 0;
+      }
+      .chart-title {
+        font-size: 1rem;
+        font-weight: 600;
+        margin: 4px 0 8px;
+        word-break: break-word;
+        text-align: center;
+      }
+      .benchmark-chart {
+        width: 100%;
+      }
+    </style>
+    <title>Soteria Benchmarks</title>
+  </head>
+
+  <body>
+    <header id="header">
+      <div class="header-item">
+        <strong class="header-label">Last Update:</strong>
+        <span id="last-update"></span>
+      </div>
+      <div class="header-item">
+        <strong class="header-label">Repository:</strong>
+        <a id="repository-link" rel="noopener"></a>
+      </div>
+    </header>
+    <main id="main"></main>
+    <footer>
+      <button id="dl-button">Download data as JSON</button>
+      <div class="spacer"></div>
+      <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
+    <script src="data.js"></script>
+    <script id="main-script">
+      'use strict';
+      (function() {
+        // The ordered list of sections. A bench is assigned to the first
+        // section whose `match` accepts its name; `conformance` is rendered
+        // specially (see renderConformanceSection).
+        const SECTIONS = [
+          {
+            id: 'rust',
+            title: 'Rust — performance',
+            subtitle: 'soteria-rust analysis time on a fixed set of programs (lower is better).',
+            accent: '#dea584',
+            match: name => name.startsWith('rust-'),
+          },
+          {
+            id: 'c',
+            title: 'C — performance',
+            subtitle: 'soteria-c analysis time on a fixed set of programs (lower is better).',
+            accent: '#6a9fb5',
+            match: name => name === 'c' || name.startsWith('c:') || name.startsWith('c-'),
+          },
+          {
+            id: 'conformance',
+            title: 'Rust — conformance',
+            subtitle: 'soteria-rust over the Kani and Miri test suites: how many tests pass/fail/are unsupported/time out, and the total time taken.',
+            accent: '#8957e5',
+            conformance: true,
+            match: name => name.startsWith('conformance-'),
+          },
+          {
+            id: 'other',
+            title: 'Other',
+            subtitle: '',
+            accent: '#888',
+            match: () => true,
+          },
+        ];
+
+        // Colours for the four conformance outcomes.
+        const OUTCOME_STYLE = {
+          passed: { label: 'passed', color: '#28a745' },
+          failed: { label: 'failed', color: '#d73a49' },
+          unsupported: { label: 'unsupported', color: '#f66a0a' },
+          'timed out': { label: 'timed out', color: '#dbab09' },
+        };
+        const OUTCOME_ORDER = ['passed', 'failed', 'unsupported', 'timed out'];
+        const CONFORMANCE_TIME = 'total time';
+        const CONFORMANCE_SUITES = ['kani', 'miri'];
+
+        function collectBenchesPerTestCase(entries) {
+          const map = new Map();
+          for (const entry of entries) {
+            const { commit, date, tool, benches } = entry;
+            for (const bench of benches) {
+              const result = { commit, date, tool, bench };
+              const arr = map.get(bench.name);
+              if (arr === undefined) {
+                map.set(bench.name, [result]);
+              } else {
+                arr.push(result);
+              }
+            }
+          }
+          return map;
+        }
+
+        function init() {
+          const data = window.BENCHMARK_DATA;
+
+          // Render header
+          document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
+          const repoLink = document.getElementById('repository-link');
+          repoLink.href = data.repoUrl;
+          repoLink.textContent = data.repoUrl;
+
+          // Render footer
+          document.getElementById('dl-button').onclick = () => {
+            const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
+            const a = document.createElement('a');
+            a.href = dataUrl;
+            a.download = 'benchmark_data.json';
+            a.click();
+          };
+
+          // Merge the runs of every top-level entry into a single bench map.
+          // In practice there is only one entry ("Soteria benchmarks").
+          const allRuns = [];
+          for (const name of Object.keys(data.entries)) {
+            for (const run of data.entries[name]) {
+              allRuns.push(run);
+            }
+          }
+          return collectBenchesPerTestCase(allRuns);
+        }
+
+        // Assign every bench name to exactly one section, preserving the order
+        // in which names first appear.
+        function groupBySection(benchMap) {
+          const groups = new Map(SECTIONS.map(s => [s.id, []]));
+          for (const name of benchMap.keys()) {
+            const section = SECTIONS.find(s => s.match(name));
+            groups.get(section.id).push(name);
+          }
+          return groups;
+        }
+
+        // Parse "conformance-<suite>: <metric>" into { suite, metric }.
+        function parseConformance(name) {
+          const m = name.match(/^conformance-([^:]+):\s*(.+)$/);
+          if (!m) return null;
+          return { suite: m[1], metric: m[2].trim() };
+        }
+
+        // Strip the "<kind>: " prefix from a performance bench name for display.
+        function displayTitle(name) {
+          const i = name.indexOf(': ');
+          return i >= 0 ? name.slice(i + 2) : name;
+        }
+
+        function commitLabels(series) {
+          return series.map(d => d.commit.id.slice(0, 7));
+        }
+
+        // Build a chart with one or more line datasets sharing the same commit
+        // axis. `ref` is the series used for x-axis labels and commit links.
+        function makeChart(parent, titleText, datasets, unit, ref) {
+          const card = document.createElement('div');
+          card.className = 'benchmark-card';
+
+          const titleElem = document.createElement('h2');
+          titleElem.className = 'chart-title';
+          titleElem.textContent = titleText;
+          card.appendChild(titleElem);
+
+          const canvas = document.createElement('canvas');
+          canvas.className = 'benchmark-chart';
+          card.appendChild(canvas);
+          parent.appendChild(card);
+
+          const options = {
+            legend: { display: datasets.length > 1 },
+            scales: {
+              xAxes: [{ scaleLabel: { display: true, labelString: 'commit' } }],
+              yAxes: [{
+                scaleLabel: { display: true, labelString: unit },
+                ticks: { beginAtZero: true },
+              }],
+            },
+            tooltips: {
+              callbacks: {
+                afterTitle: items => {
+                  const { index } = items[0];
+                  const commit = ref[index].commit;
+                  return '\n' + commit.message + '\n\n' + commit.timestamp + ' committed by @' + commit.committer.username + '\n';
+                },
+                label: item => {
+                  const ds = datasets[item.datasetIndex];
+                  let label = item.value + ' ' + unit;
+                  if (datasets.length > 1) {
+                    label = ds.label + ': ' + label;
+                  }
+                  const range = ds.ranges && ds.ranges[item.index];
+                  if (range) {
+                    label += ' (' + range + ')';
+                  }
+                  return label;
+                },
+              },
+            },
+            onClick: (_mouseEvent, activeElems) => {
+              if (activeElems.length === 0) return;
+              // XXX: Undocumented. How can we know the index?
+              const index = activeElems[0]._index;
+              const url = ref[index].commit.url;
+              window.open(url, '_blank');
+            },
+          };
+
+          new Chart(canvas, {
+            type: 'line',
+            data: { labels: commitLabels(ref), datasets },
+            options,
+          });
+        }
+
+        // One chart per performance bench, in a two-column grid.
+        function renderPerfSection(section, names, benchMap, main) {
+          const grid = sectionShell(section, main);
+          for (const name of names) {
+            const series = benchMap.get(name);
+            const color = section.accent;
+            const dataset = {
+              label: displayTitle(name),
+              data: series.map(d => d.bench.value),
+              ranges: series.map(d => d.bench.range),
+              borderColor: color,
+              backgroundColor: color + '60',
+              fill: false,
+            };
+            const unit = series.length > 0 ? series[0].bench.unit : '';
+            makeChart(grid, displayTitle(name), [dataset], unit, series);
+          }
+        }
+
+        // Four charts: an outcomes chart and a total-time chart per suite.
+        function renderConformanceSection(section, names, benchMap, main) {
+          const grid = sectionShell(section, main);
+
+          // Index this section's benches by suite + metric.
+          const bySuite = new Map();
+          for (const name of names) {
+            const parsed = parseConformance(name);
+            if (!parsed) continue;
+            if (!bySuite.has(parsed.suite)) bySuite.set(parsed.suite, new Map());
+            bySuite.get(parsed.suite).set(parsed.metric, benchMap.get(name));
+          }
+
+          // Keep the known suites first and in order, then any extras.
+          const suites = CONFORMANCE_SUITES.filter(s => bySuite.has(s))
+            .concat([...bySuite.keys()].filter(s => !CONFORMANCE_SUITES.includes(s)));
+
+          for (const suite of suites) {
+            const metrics = bySuite.get(suite);
+            const suiteName = suite.charAt(0).toUpperCase() + suite.slice(1);
+
+            // Outcomes chart: one line per outcome present.
+            const outcomeDatasets = [];
+            let ref = null;
+            for (const metric of OUTCOME_ORDER) {
+              const series = metrics.get(metric);
+              if (!series) continue;
+              if (!ref || series.length > ref.length) ref = series;
+              const style = OUTCOME_STYLE[metric];
+              outcomeDatasets.push({
+                label: style.label,
+                data: series.map(d => d.bench.value),
+                borderColor: style.color,
+                backgroundColor: style.color + '60',
+                fill: false,
+              });
+            }
+            if (outcomeDatasets.length > 0 && ref) {
+              makeChart(grid, suiteName + ' — outcomes', outcomeDatasets, 'tests', ref);
+            }
+
+            // Total-time chart.
+            const timeSeries = metrics.get(CONFORMANCE_TIME);
+            if (timeSeries) {
+              const color = section.accent;
+              makeChart(grid, suiteName + ' — total time', [{
+                label: 'total time',
+                data: timeSeries.map(d => d.bench.value),
+                borderColor: color,
+                backgroundColor: color + '60',
+                fill: false,
+              }], 's', timeSeries);
+            }
+          }
+        }
+
+        // Build the <section> + heading + grid; returns the grid element.
+        function sectionShell(section, main) {
+          const sectionElem = document.createElement('section');
+          sectionElem.className = 'benchmark-section';
+          sectionElem.style.setProperty('--accent', section.accent);
+          main.appendChild(sectionElem);
+
+          const titleElem = document.createElement('h1');
+          titleElem.className = 'section-title';
+          titleElem.textContent = section.title;
+          sectionElem.appendChild(titleElem);
+
+          if (section.subtitle) {
+            const subtitleElem = document.createElement('p');
+            subtitleElem.className = 'section-subtitle';
+            subtitleElem.textContent = section.subtitle;
+            sectionElem.appendChild(subtitleElem);
+          }
+
+          const grid = document.createElement('div');
+          grid.className = 'benchmark-grid';
+          sectionElem.appendChild(grid);
+          return grid;
+        }
+
+        function renderAllCharts(benchMap) {
+          const groups = groupBySection(benchMap);
+          const main = document.getElementById('main');
+          for (const section of SECTIONS) {
+            const names = groups.get(section.id);
+            if (!names || names.length === 0) continue;
+            if (section.conformance) {
+              renderConformanceSection(section, names, benchMap, main);
+            } else {
+              renderPerfSection(section, names, benchMap, main);
+            }
+          }
+        }
+
+        renderAllCharts(init()); // Start
+      })();
+    </script>
+  </body>
+</html>

--- a/scripts/compare_to_main.py
+++ b/scripts/compare_to_main.py
@@ -59,7 +59,10 @@ def parse_baseline(path: Path) -> dict[str, float]:
     }
 
 
-def fmt_time(v: float) -> str:
+def fmt_value(v: float, unit: str = "s") -> str:
+    if unit != "s":
+        # Non-time benches (e.g. conformance test counts) keep their own unit.
+        return f"{v:g} {unit}".rstrip()
     return f"{v * 1000:.1f} ms" if v < 1 else f"{v:.3f} s"
 
 
@@ -103,11 +106,12 @@ def main() -> None:
         name = entry["name"]
         new_val = entry["value"]
         old_val = baseline.get(name)
+        unit = entry.get("unit", "s")
         lines.append(
             "| {} | {} | {} | {} |".format(
                 name,
-                fmt_time(old_val) if old_val is not None else "—",
-                fmt_time(new_val),
+                fmt_value(old_val, unit) if old_val is not None else "—",
+                fmt_value(new_val, unit),
                 fmt_delta(old_val, new_val),
             )
         )

--- a/scripts/diff_conformance.py
+++ b/scripts/diff_conformance.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Diff two conformance-outcomes.csv files and emit a markdown list of the
+per-test outcome changes, for the PR benchmark comment.
+
+Both inputs are the sorted `suite,file,outcome` CSVs produced by
+run_benchmarks.py (--conformance-csv). The "before" is main's published copy
+(from gh-pages); the "after" is this PR's run. Each changed test is shown as
+`before -> after` with an emoji conveying whether the change is good:
+
+  🔴 regression  (was passing, now isn't)
+  🟢 fixed       (now passing, wasn't)
+  🟡 changed     (still not passing, but a different outcome)
+  🆕 added       (test only present after — e.g. a suite bump)
+  🗑️ removed     (test only present before)
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+from collections import Counter
+from pathlib import Path
+from typing import Optional
+
+# Cap the listed rows so a large change set (e.g. a suite-pin bump) can't bloat
+# the PR comment; the count line still reports the true total.
+MAX_ROWS = 50
+
+# kind -> (emoji, sort priority, summary label). Lower priority sorts first, so
+# regressions lead.
+KINDS = {
+    "regression": ("🔴", 0, "🔴 regressed"),
+    "changed": ("🟡", 1, "🟡 changed"),
+    "fixed": ("🟢", 2, "🟢 fixed"),
+    "added": ("🆕", 3, "🆕 added"),
+    "removed": ("🗑️", 4, "🗑️ removed"),
+}
+
+
+def classify(before: Optional[str], after: Optional[str]) -> Optional[str]:
+    if before == after:
+        return None
+    if before is None:
+        return "added"
+    if after is None:
+        return "removed"
+    if before == "pass":
+        return "regression"
+    if after == "pass":
+        return "fixed"
+    return "changed"
+
+
+def load(path: Optional[Path]) -> dict[tuple[str, str], str]:
+    out: dict[tuple[str, str], str] = {}
+    if not path or not path.exists() or path.stat().st_size == 0:
+        return out
+    with path.open(newline="") as f:
+        reader = csv.reader(f)
+        next(reader, None)  # header: suite,file,outcome
+        for row in reader:
+            if len(row) >= 3:
+                out[(row[0], row[1])] = row[2]
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--before", type=Path, help="main's conformance-outcomes.csv")
+    ap.add_argument("--after", type=Path, required=True, help="this run's CSV")
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+
+    before = load(args.before)
+    after = load(args.after)
+
+    lines = ["### Conformance changes", ""]
+
+    if not before:
+        lines.append("_No main baseline to compare conformance outcomes against._")
+        args.output.write_text("\n".join(lines) + "\n")
+        return
+
+    changes = []
+    for key in set(before) | set(after):
+        kind = classify(before.get(key), after.get(key))
+        if kind is not None:
+            changes.append((key[0], key[1], before.get(key), after.get(key), kind))
+
+    if not changes:
+        lines.append("✅ _No conformance test outcomes changed._")
+        args.output.write_text("\n".join(lines) + "\n")
+        return
+
+    counts = Counter(c[4] for c in changes)
+    summary = ", ".join(
+        f"{counts[kind]} {KINDS[kind][2]}" for kind in KINDS if counts.get(kind)
+    )
+    lines.append(f"{len(changes)} test(s) changed: {summary}.")
+    lines.append("")
+
+    changes.sort(key=lambda c: (KINDS[c[4]][1], c[0], c[1]))
+    for suite, file, b, a, kind in changes[:MAX_ROWS]:
+        emoji = KINDS[kind][0]
+        if kind == "added":
+            transition = f"_added_ → {a}"
+        elif kind == "removed":
+            transition = f"{b} → _removed_"
+        else:
+            transition = f"{b} → {a}"
+        lines.append(f"- {emoji} `{suite}/{file}`: {transition}")
+    if len(changes) > MAX_ROWS:
+        lines.append(f"- … and {len(changes) - MAX_ROWS} more")
+
+    args.output.write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -36,6 +36,7 @@ Per-entry fields:
 """
 
 import argparse
+import csv
 import importlib.util
 import json
 import os
@@ -239,16 +240,44 @@ def load_soteria_test():
     return module
 
 
-def bench_conformance() -> list[dict]:
+def write_conformance_outcomes(src_csv: Path, dest_csv: Path) -> None:
+    """Write a sorted `suite,file,outcome` CSV from test.py's benchmark.csv.
+
+    Dropping the per-test times and sorting the rows makes this file diff
+    cleanly: committed to gh-pages, its git history gains a commit only when a
+    test's outcome actually changes, so before/after regressions are obvious.
+    """
+    with src_csv.open(newline="") as f:
+        rows = list(csv.reader(f))
+    # benchmark.csv header: Suite,File,Soteria,(s),Kani,(s),Miri,(s)
+    # We keep the suite, file, and Soteria outcome (the only tool run here).
+    body = sorted((r[0], r[1], r[2]) for r in rows[1:] if len(r) >= 3)
+    with dest_csv.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["suite", "file", "outcome"])
+        writer.writerows(body)
+
+
+def bench_conformance(csv_dest: Optional[Path] = None) -> list[dict]:
     """Run the Kani/Miri conformance suites and return one list of benches.
 
     Requires KANI_SUITE_PATH and MIRI_SUITE_PATH to point at the cloned suites
     (test.py reads them); CI sets these up. test.py writes its CSV/logs to
-    OUTPUT_DIR, which we point at a temp dir to keep the repo clean.
+    OUTPUT_DIR, which we point at a temp dir to keep the repo clean. When
+    `csv_dest` is given, the per-test outcomes are also written there (for
+    committing as a diffable regression record).
     """
     if "OUTPUT_DIR" not in os.environ:
         os.environ["OUTPUT_DIR"] = tempfile.mkdtemp(prefix="soteria-conformance-")
     summary = load_soteria_test().soteria_conformance(CONFORMANCE_TIMEOUT_S)
+
+    if csv_dest is not None:
+        src = Path(os.environ["OUTPUT_DIR"]) / "benchmark.csv"
+        if src.exists():
+            write_conformance_outcomes(src, csv_dest)
+            log(f"wrote conformance outcomes to {csv_dest}")
+        else:
+            log(f"WARNING: no conformance CSV at {src}; skipping {csv_dest}")
 
     results: list[dict] = []
     for suite in CONFORMANCE_SUITES:
@@ -316,6 +345,15 @@ def main() -> None:
             "(requires KANI_SUITE_PATH and MIRI_SUITE_PATH; see test.py)"
         ),
     )
+    parser.add_argument(
+        "--conformance-csv",
+        type=Path,
+        default=None,
+        help=(
+            "Write a sorted suite,file,outcome CSV of the conformance run here, "
+            "for committing as a diffable record of per-test outcome changes"
+        ),
+    )
     parsed = parser.parse_args()
 
     config = json.loads(parsed.config.read_text())
@@ -344,7 +382,7 @@ def main() -> None:
     if parsed.conformance:
         log("=== conformance: Kani/Miri suites ===")
         try:
-            results.extend(bench_conformance())
+            results.extend(bench_conformance(parsed.conformance_csv))
         except Exception as exc:  # noqa: BLE001 - report and continue
             failures += 1
             log(f"FAILED (conformance): {exc}")

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -15,6 +15,12 @@ benchmarks.json (every entry accepts `args` and `no_hyperfine`, see below):
   - "c_biab":   a C project run in bi-abduction, with `mode` set to either
                     "gen-summaries" or "capture-db"
 
+With --conformance, an additional Rust *conformance* benchmark runs the Kani
+and Miri test suites through soteria-rust (via soteria-rust/scripts/test.py) and
+emits, per suite, the passed/failed/unsupported/timed-out test counts and the
+total time. It is not configured in benchmarks.json; CI must clone the suites
+and set KANI_SUITE_PATH / MIRI_SUITE_PATH first.
+
 Per-entry fields:
   - "path"          (required) file or project root, relative to the repo root
   - "name"          (optional) label used in the report; defaults to the path
@@ -30,6 +36,7 @@ Per-entry fields:
 """
 
 import argparse
+import importlib.util
 import json
 import os
 import shlex
@@ -185,6 +192,93 @@ def make_result(entry: dict, kind: str, stats: dict) -> dict:
     return result
 
 
+# --- Rust conformance benchmark ------------------------------------------
+#
+# Unlike the performance benchmarks above, this is a *conformance* benchmark:
+# it runs soteria-rust over the Kani and Miri test suites (which CI clones
+# beforehand) and tracks how many tests pass/fail/are unsupported/time out,
+# plus the total time spent. The running and aggregation live in
+# soteria-rust/scripts/test.py (`soteria_conformance`); here we only shape its
+# per-suite summary into benches. Bench names are prefixed "conformance-<suite>:"
+# so the dashboard can group them into their own section.
+
+CONFORMANCE_SUITES = ("kani", "miri")
+
+# A small tail of slow tests dominates each suite's runtime (see benchmark.csv:
+# kani's median is ~0.1s but a handful of tests run for 5-23s). Cap each test so
+# the benchmark finishes in a few minutes rather than ~10; the cost is a few
+# extra "timed out" outcomes, which is fine since timeouts are tracked anyway.
+CONFORMANCE_TIMEOUT_S = 3
+
+# soteria_conformance() summary key -> dashboard label, for the count benches.
+CONFORMANCE_OUTCOMES = {
+    "passed": "passed",
+    "failed": "failed",
+    "unsupported": "unsupported",
+    "timed_out": "timed out",
+}
+
+
+def load_soteria_test():
+    """Import soteria-rust/scripts/test.py as a module.
+
+    test.py and its siblings (cliopts, common, config, ...) import each other by
+    bare name, so their directory must be on sys.path. We load test.py under a
+    distinct module name to avoid clashing with the stdlib `test` package.
+    """
+    rust_scripts = REPO_ROOT / "soteria-rust" / "scripts"
+    if str(rust_scripts) not in sys.path:
+        sys.path.insert(0, str(rust_scripts))
+    spec = importlib.util.spec_from_file_location(
+        "soteria_rust_test", rust_scripts / "test.py"
+    )
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"could not load {rust_scripts / 'test.py'}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def bench_conformance() -> list[dict]:
+    """Run the Kani/Miri conformance suites and return one list of benches.
+
+    Requires KANI_SUITE_PATH and MIRI_SUITE_PATH to point at the cloned suites
+    (test.py reads them); CI sets these up. test.py writes its CSV/logs to
+    OUTPUT_DIR, which we point at a temp dir to keep the repo clean.
+    """
+    if "OUTPUT_DIR" not in os.environ:
+        os.environ["OUTPUT_DIR"] = tempfile.mkdtemp(prefix="soteria-conformance-")
+    summary = load_soteria_test().soteria_conformance(CONFORMANCE_TIMEOUT_S)
+
+    results: list[dict] = []
+    for suite in CONFORMANCE_SUITES:
+        suite_summary = summary.get(suite, {})
+        for key, label in CONFORMANCE_OUTCOMES.items():
+            results.append(
+                {
+                    "name": f"conformance-{suite}: {label}",
+                    "unit": "tests",
+                    "value": suite_summary.get(key, 0),
+                }
+            )
+        results.append(
+            {
+                "name": f"conformance-{suite}: total time",
+                "unit": "s",
+                "value": round(suite_summary.get("total_time", 0.0), 4),
+            }
+        )
+        log(
+            f"-> conformance-{suite}: "
+            + ", ".join(
+                f"{lbl} {suite_summary.get(k, 0)}"
+                for k, lbl in CONFORMANCE_OUTCOMES.items()
+            )
+            + f", total time {suite_summary.get('total_time', 0.0):.2f}s"
+        )
+    return results
+
+
 # Maps each benchmarks.json section to the function that runs one of its
 # entries; iteration order is the order benchmarks run in.
 SECTIONS: dict[str, Callable[[dict], dict]] = {
@@ -214,6 +308,14 @@ def main() -> None:
         action="store_true",
         help="Continue with remaining benchmarks if one fails",
     )
+    parser.add_argument(
+        "--conformance",
+        action="store_true",
+        help=(
+            "Also run the Rust conformance benchmark over the Kani/Miri suites "
+            "(requires KANI_SUITE_PATH and MIRI_SUITE_PATH; see test.py)"
+        ),
+    )
     parsed = parser.parse_args()
 
     config = json.loads(parsed.config.read_text())
@@ -225,7 +327,7 @@ def main() -> None:
         for entry in config.get(section, [])
     ]
 
-    if not plan:
+    if not plan and not parsed.conformance:
         raise SystemExit(f"no benchmarks configured in {parsed.config}")
 
     failures = 0
@@ -236,6 +338,16 @@ def main() -> None:
         except Exception as exc:  # noqa: BLE001 - we want to report and continue
             failures += 1
             log(f"FAILED ({kind} {entry.get('path')!r}): {exc}")
+            if not parsed.keep_going:
+                raise
+
+    if parsed.conformance:
+        log("=== conformance: Kani/Miri suites ===")
+        try:
+            results.extend(bench_conformance())
+        except Exception as exc:  # noqa: BLE001 - report and continue
+            failures += 1
+            log(f"FAILED (conformance): {exc}")
             if not parsed.keep_going:
                 raise
 

--- a/scripts/soteria_utils.py
+++ b/scripts/soteria_utils.py
@@ -300,11 +300,13 @@ def pptable(rows: "list[list[tuple[str, Optional[str]]]]") -> None:
 
 
 def get_env_path_or(key: str, fallback: Path) -> Path:
-    """Resolve an environment variable to a path, or fall back to `fallback`."""
+    """Resolve an environment variable to a path, or fall back to `fallback`.
+    Will create the path if it doesn't exist."""
     e = os.environ.get(key)
-    if e:
-        return Path(e).resolve()
-    return fallback.resolve()
+    path = Path(e).resolve() if e else fallback.resolve()
+    if not path.exists():
+        path.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def ask_and_remove(path: Path) -> None:

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -3,7 +3,7 @@
   "CHARON_REPO": "soteria-tools/charon",
   "CHARON_COMMIT_HASH": "4986f2907dbe5899b0756ab623b5ef661ed2c58c",
   "OBOL_REPO": "soteria-tools/obol",
-  "OBOL_COMMIT_HASH": "42f11d00b19ba8bda50fd6fd43d860ef4dd4946d",
+  "OBOL_COMMIT_HASH": "7eef0668b9385042a379efe785b049517a304cc3",
   "OCAMLFORMAT_VERSION": "0.28.1",
   "OCAML_VERSION": "5.4.1",
   "DUNE_VERSION": "3.23.1"

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -3,7 +3,7 @@
   "CHARON_REPO": "soteria-tools/charon",
   "CHARON_COMMIT_HASH": "4986f2907dbe5899b0756ab623b5ef661ed2c58c",
   "OBOL_REPO": "soteria-tools/obol",
-  "OBOL_COMMIT_HASH": "0fff449d6c2ca9dc4ea6bf44b999d4d1b67bf670",
+  "OBOL_COMMIT_HASH": "7eef0668b9385042a379efe785b049517a304cc3",
   "OCAMLFORMAT_VERSION": "0.28.1",
   "OCAML_VERSION": "5.4.1",
   "DUNE_VERSION": "3.23.1"

--- a/soteria-rust/lib/frontend.ml
+++ b/soteria-rust/lib/frontend.ml
@@ -274,7 +274,7 @@ let parse_ullbc ~mode ~cmd ~output ~pwd () =
   in
   if (Config.get ()).output_crate then (
     (* save pretty-printed crate to local file *)
-    let crate_file = Printf.sprintf "%s.crate" output in
+    let crate_file = Filename.chop_suffix output ".ullbc" ^ ".crate" in
     let str = Charon.Print.crate_to_string crate in
     let oc = open_out_bin crate_file in
     output_string oc str;
@@ -292,7 +292,7 @@ let with_entry_points ~filter (crate : Charon.UllbcAst.crate) =
 (** Given a Rust file, parse it into LLBC, using Charon. *)
 let parse_ullbc_of_file ~(mk_cmd : mk_cmd) file_name =
   let parent_folder = Filename.dirname file_name in
-  let output = Printf.sprintf "%s.llbc.json" file_name in
+  let output = Printf.sprintf "%s.ullbc" file_name in
   let cmd = mk_cmd ~input:file_name ~output () in
   parse_ullbc ~mode:Rustc ~cmd ~output ~pwd:parent_folder ()
 
@@ -300,8 +300,8 @@ let parse_ullbc_of_file ~(mk_cmd : mk_cmd) file_name =
 let parse_ullbc_of_crate ~(mk_cmd : mk_cmd) crate_dir =
   let filename =
     match (Config.get ()).test with
-    | Some test -> "test-" ^ test ^ ".llbc.json"
-    | None -> "crate.llbc.json"
+    | Some test -> "test-" ^ test ^ ".ullbc"
+    | None -> "crate.ullbc"
   in
   let output = crate_dir / filename in
   let cmd = mk_cmd ~output () in

--- a/soteria-rust/scripts/cliopts.py
+++ b/soteria-rust/scripts/cliopts.py
@@ -58,8 +58,10 @@ class FakeCliOpts:
         raise RuntimeError("Call parse_flags before accessing OPTS")
 
 
-def parse_flags() -> CliOpts:
-    opts: CliOpts = {
+def default_opts() -> CliOpts:
+    """A fresh CliOpts with all defaults; the starting point of parse_flags and
+    a way to drive commands programmatically (e.g. the conformance benchmark)."""
+    return {
         "cmd": cast(Cmd, None),
         "tool": "Soteria",
         "tool_cmd": [],
@@ -73,6 +75,10 @@ def parse_flags() -> CliOpts:
         "output_file": None,
         "categorise": categorise_soteria,
     }
+
+
+def parse_flags() -> CliOpts:
+    opts: CliOpts = default_opts()
 
     sys.argv.pop(0)  # remove script name
     if len(sys.argv) == 0:

--- a/soteria-rust/scripts/config.py
+++ b/soteria-rust/scripts/config.py
@@ -195,8 +195,6 @@ def miri(opts: CliOpts) -> TestConfig:
                 "-Zmiri-disable-isolation",
                 # We don't allow disabling overflow checks
                 "-Coverflow-checks=off",
-                # Miri-specific optimisation flags
-                "-Zmiri-provenance-gc=0",
                 "-Zmiri-disable-leak-backtraces",
                 "-Zmiri-track-alloc-accesses",
             ]:
@@ -207,6 +205,7 @@ def miri(opts: CliOpts) -> TestConfig:
                 miri_flag.startswith(prefix)
                 for prefix in [
                     "-Zmir-opt-level",
+                    "-Zmir-enable-passes",
                     "-Zinline-mir",
                     "-Zinline-mir-hint-threshold",
                     "-Zmiri-track-alloc-id",
@@ -214,6 +213,60 @@ def miri(opts: CliOpts) -> TestConfig:
                     "-Zoom=panic",
                     "-Cpanic",
                     "-Cdebug-assertions",
+                    # Target CPU/feature selection (e.g. enabling AVX2 for SIMD
+                    # intrinsic tests); Soteria doesn't gate on these.
+                    "-Ctarget-feature",
+                    "-Ctarget-cpu",
+                ]
+            ):
+                continue
+
+            # Miri runtime flags that tune its interpreter, scheduler, RNG,
+            # floating-point determinism, diagnostics, FFI, GenMC backend or
+            # concurrency model. Soteria has no equivalent (it explores paths
+            # symbolically rather than via Miri's runtime), so these are safely
+            # ignored. See Miri's README for the full list; new ones are added
+            # here as upstream introduces them.
+            if any(
+                miri_flag.startswith(prefix)
+                for prefix in [
+                    # Scheduling / concurrency / RNG
+                    "-Zmiri-deterministic-concurrency",
+                    "-Zmiri-fixed-schedule",
+                    "-Zmiri-preemption-rate",
+                    "-Zmiri-compare-exchange-weak-failure-rate",
+                    "-Zmiri-address-reuse-rate",
+                    "-Zmiri-address-reuse-cross-thread-rate",
+                    "-Zmiri-many-seeds",
+                    "-Zmiri-seed",
+                    "-Zmiri-num-cpus",
+                    "-Zmiri-disable-data-race-detector",
+                    "-Zmiri-disable-weak-memory-emulation",
+                    "-Zmiri-track-weak-memory-loads",
+                    # GenMC backend
+                    "-Zmiri-genmc",
+                    # Floating-point determinism
+                    "-Zmiri-deterministic-floats",
+                    "-Zmiri-no-extra-rounding-error",
+                    "-Zmiri-max-extra-rounding-error",
+                    # Tree Borrows tuning (we always use Tree Borrows)
+                    "-Zmiri-tree-borrows-implicit-writes",
+                    "-Zmiri-tree-borrows-relax-custom-allocator-uniqueness",
+                    # Memory / provenance-GC tuning
+                    "-Zmiri-force-page-size",
+                    "-Zmiri-provenance-gc",
+                    # Isolation, environment, IO, FFI and diagnostics
+                    "-Zmiri-isolation-error",
+                    "-Zmiri-env-forward",
+                    "-Zmiri-env-set",
+                    "-Zmiri-native-lib",
+                    "-Zmiri-report-progress",
+                    "-Zmiri-backtrace",
+                    "-Zmiri-track-pointer-tag",
+                    "-Zmiri-no-short-fd-operations",
+                    "-Zmiri-measureme",
+                    "-Zmiri-user-relevant-crates",
+                    "-Zmiri-force-intrinsic-fallback",
                 ]
             ):
                 continue

--- a/soteria-rust/scripts/test.py
+++ b/soteria-rust/scripts/test.py
@@ -361,8 +361,6 @@ def benchmark(tool: Optional[ToolName], suite: Optional[SuiteName], opts: CliOpt
     interrupts = 0
 
     def run_benchmark(opts: CliOpts):
-        if tool is not None and opts["tool"] != tool:
-            return
         if opts["tool"] == "Soteria":
             build()
         for name, callback in TEST_SUITES.items():
@@ -431,8 +429,12 @@ def benchmark(tool: Optional[ToolName], suite: Optional[SuiteName], opts: CliOpt
 
     pprint(f"{BOLD}Running benchmark{RESET}")
     try:
-        run_benchmark(opts_for_soteria(opts, force_obol=True))
-        run_benchmark(opts_for_kani(opts, timeout=None))
+        if tool is None or tool == "Soteria":
+            run_benchmark(opts_for_soteria(opts, force_obol=True))
+        if tool is None or tool == "Kani":
+            run_benchmark(opts_for_kani(opts, timeout=None))
+        if tool is None or tool == "Miri":
+            run_benchmark(opts_for_miri(opts))
     except Exception as e:
         print(e)
 

--- a/soteria-rust/scripts/test.py
+++ b/soteria-rust/scripts/test.py
@@ -11,6 +11,7 @@ from typing import Sequence, Union, assert_never
 from cliopts import (
     ArgError,
     CliOpts,
+    default_opts,
     opts_for_kani,
     opts_for_miri,
     opts_for_soteria,
@@ -552,6 +553,40 @@ def benchmark(tool: Optional[ToolName], suite: Optional[SuiteName], opts: CliOpt
 
     pprint()
     pptable(pretty_table)
+
+    # Per-suite summary for Soteria, returned so callers (e.g. the dashboard's
+    # conformance benchmark) can consume the outcome counts and total time
+    # without re-parsing the CSV. Outcomes here are already simplified.
+    summary: dict[str, dict[str, float]] = {}
+    for suite_name in ["kani", "miri"]:
+        suite_res = [res["Soteria"] for (_, s), res in results.items() if s == suite_name]
+        summary[suite_name] = {
+            "passed": sum(1 for o, _ in suite_res if o.is_pass()),
+            "failed": sum(1 for o, _ in suite_res if o.is_fail()),
+            "unsupported": sum(1 for o, _ in suite_res if o.is_unsupported()),
+            "timed_out": sum(1 for o, _ in suite_res if o.is_timeout()),
+            "total_time": sum(max(t, 0) for _, t in suite_res),
+        }
+    return summary
+
+
+def soteria_conformance(
+    timeout: Optional[int] = None,
+) -> dict[str, dict[str, float]]:
+    """Run the Soteria conformance benchmark over the Kani and Miri suites and
+    return, per suite, {passed, failed, unsupported, timed_out, total_time}.
+
+    `timeout` caps each test's runtime in seconds (None uses the per-suite
+    defaults). A low cap trades a few extra timeouts for a much shorter run,
+    since a small tail of slow tests dominates the total time.
+
+    Used by scripts/run_benchmarks.py to feed the dashboard's conformance
+    benchmark. KANI_SUITE_PATH / MIRI_SUITE_PATH must point at the suites.
+    """
+    opts = default_opts()
+    opts["timeout"] = timeout
+    opts["cmd"] = ("benchmark", ("Soteria", None))
+    return benchmark("Soteria", None, opts)
 
 
 def kani_comparison(opts: CliOpts, path: Path, cached: bool):

--- a/soteria-rust/test/cram/cleanup.sh
+++ b/soteria-rust/test/cram/cleanup.sh
@@ -1,1 +1,1 @@
-rm -rf *.llbc.json *.llbc.json.crate target/ Cargo.lock
+rm -rf *.ullbc *.crate target/ Cargo.lock

--- a/soteria-rust/test/cram/perf.t/array_init.rs
+++ b/soteria-rust/test/cram/perf.t/array_init.rs
@@ -9,7 +9,8 @@ struct LinkedList<T> {
 
 fn main() {
     // A pattern that gets executed during tokio's runtime initialisation and caused performance issues in Soteria in the past.
-    let arr: [LinkedList<u32>; 64] = std::array::from_fn(|_| LinkedList {
+    // The array is sized larger than tokio's (64) so the benchmark runs for ~1s+.
+    let arr: [LinkedList<u32>; 1024] = std::array::from_fn(|_| LinkedList {
         head: None,
         tail: None,
         _marker: PhantomData,

--- a/soteria-rust/test/cram/perf.t/writealot.rs
+++ b/soteria-rust/test/cram/perf.t/writealot.rs
@@ -62,14 +62,31 @@ macro_rules! access {
         access!($x, 8000);
         access!($x, 2000);
     };
+    ($x:expr, 20000) => {
+        access!($x, 10000);
+        access!($x, 10000);
+    };
+    ($x:expr, 40000) => {
+        access!($x, 20000);
+        access!($x, 20000);
+    };
+    ($x:expr, 80000) => {
+        access!($x, 40000);
+        access!($x, 40000);
+    };
+    ($x:expr, 100000) => {
+        access!($x, 80000);
+        access!($x, 20000);
+    };
 }
 
 fn access(x: &mut u32) {
-    access!(x, 10000);
+    access!(x, 100000);
+    access!(x, 100000);
 }
 
 fn main() {
     let mut x = 0;
     access(&mut x);
-    assert_eq!(x, 10_000);
+    assert_eq!(x, 2_000_000);
 }

--- a/soteria-rust/test/cram/perf.t/writealotloop.rs
+++ b/soteria-rust/test/cram/perf.t/writealotloop.rs
@@ -1,5 +1,5 @@
 fn access(x: &mut u32) {
-    for _ in 0..500 {
+    for _ in 0..2000 {
         *x += 1;
     }
 }
@@ -7,5 +7,5 @@ fn access(x: &mut u32) {
 fn main() {
     let mut x = 0;
     access(&mut x);
-    soteria::assert(x == 500, "ok");
+    soteria::assert(x == 2000, "ok");
 }


### PR DESCRIPTION
Add our pre-existing Kani and Miri conformance test suite to CI; when benchmarks are run, we also run against the Kani and Miri suite, and check what tests we do and don't pass :) 

It will also output when run-benchmarks is used if there are any test changes.

I also redid the styling of the benchmarks, its nicer now.