### PR TITLE
Minor Tree Borrows optimisation

### DIFF
--- a/.claude/skills/profile-soteria/SKILL.md
+++ b/.claude/skills/profile-soteria/SKILL.md
@@ -215,6 +215,10 @@ measurement trap, or a benchmark that isolates a subsystem well, add it to
 `references/` rather than keeping it in your head.
 
 - `references/ocaml-profiling.md` — concrete CPU / allocation / Z3-boundary
-  profiling for Soteria's OCaml + subprocess architecture.
+  profiling for Soteria's OCaml + subprocess architecture, plus the settled
+  flambda / `[@inline]` findings.
+- `references/tree-borrows.md` — Tree Borrows (`soteria-rust/lib/tree_borrows/`)
+  specific findings: what `Raw.access`/`compact`/`borrow` actually cost, the
+  realized optimizations and their benches, and the hard constraints.
 - `references/measurement-pitfalls.md` — what makes these benchmarks lie and
   how to get a number you can trust.

--- a/.claude/skills/profile-soteria/references/ocaml-profiling.md
+++ b/.claude/skills/profile-soteria/references/ocaml-profiling.md
@@ -6,6 +6,9 @@ process over pipes, so the three things worth profiling are **OCaml CPU**,
 **OCaml allocations/GC**, and **the Z3 subprocess boundary**. Living
 document — add rows/recipes that worked.
 
+Tree-Borrows-specific findings live in `tree-borrows.md` (kept separate because
+that subsystem accreted a lot of detail).
+
 ## 0. First look — macOS `sample` (zero setup)
 
 ```bash
@@ -23,6 +26,18 @@ Read the aggregated tree for the **syscall vs. compute split**:
 
 This needs no build flags and is the fastest way to decide *which* of the
 next sections to spend time in.
+
+To turn a `sample` tree into an **inclusive % for one symbol**, sum the sample
+counts on every frame for that symbol and divide by the main-thread total:
+
+```bash
+total=$(grep -m1 "main-thread" s.txt | grep -oE "^ *[0-9]+" | tr -d ' ')
+grep -F 'Raw$access_1212' s.txt \
+  | awk '{for(i=1;i<=NF;i++) if($i ~ /^caml/){print $(i-1); break}}' \
+  | paste -sd+ - | bc        # ÷ $total = inclusive %
+```
+
+(Use `grep -F` — symbol names contain `$`, which is a regex anchor otherwise.)
 
 ## 1. OCaml CPU
 
@@ -159,6 +174,54 @@ The reusable conclusion to aim for: **N round-trips/spawns per run at ~M ms
 each**. Then the fix is one of: pool the process, pipeline fire-and-forget
 commands and only block on the answers you need (`check`/`get-model`),
 cache/dedupe encodings, or avoid a redundant `reset`.
+
+## What we already tried: compiler-level levers (flambda, `[@inline]`/`[@cold]`)
+
+Settled finding (2026-06) so nobody re-runs this from scratch: **a flambda
+switch and adding `[@inline]`/`[@cold]` to the monad layer do *not* speed up
+the `soteria-rust` `perf.t` benchmarks.** Measured engine time ("done in", n=6,
+`--profile release`) for base-compiler vs flambda vs flambda+annotations was
+flat to within run-to-run noise (~2%) on `writealot`, `writealotloop`,
+`btreeset_sort`, `ctpop` — if anything flambda was marginally *slower*.
+
+Why: a `sample` of `ctpop` shows the hot regions are the **memory model and
+persistent data structures**, not the monad — `PatriciaTree.filter_map_no_share`
+(persistent-map rebuild that doesn't structurally share), `Tree_borrows`
+(`Concrete.access`/`Raw.access`), `Range_tree.map_leaves`, `Tree_block`/
+`Rtree_block`, plus `caml_runstack` (effects) and `caml_modify`/`caml_call_gc`/
+`caml_alloc_small` (allocation/GC). `Monad.bind`/`Compo_res.bind`/`return`/`lift`
+appear at **1–10 samples (noise)**. The combinators in `monad.ml`/
+`state_monad.ml` are *already* `[@inline]`, so even the stock compiler's local
+inlining covers the hot bind path; there is nothing left for flambda or extra
+annotations to remove. `[@cold]` natively compiles on the 5.4.1 flambda switch
+(no `ppx_cold` needed; survives `-warn-error +53`).
+
+Confirmed at the assembly level (`-inlining-report -S` injected via
+`(ocamlopt_flags (:standard -inlining-report -S))` on the two libs, then read
+the `_build/.../native/*.s` and `*.inlining.org`): `[@inline]` *does* fire —
+`Compo_res.bind`/the StateT `bind` leave **no standalone call symbol** in the
+hot modules. But what `bind` inlines *to* is irreducible: e.g.
+`Rustsymex.bind` compiles to `ldr x3,[x1]; blr x3` (an **indirect call** through
+the runtime-built monadic value) plus a `sub x27,x27,#64` young-heap bump (a
+**closure allocation** for the captured continuation). flambda can't optimize
+either because the iterator/continuation are *data*, not statically-known
+functions — the report literally says "not inlined because there was no useful
+information" 36× in `Rustsymex`. The hot `.s` are dense with this:
+`Symex`/`Rustsymex`/`Raw` carry ~107/73/47 indirect calls and ~155/145/76 inline
+alloc sites each. So the cost is closure-alloc + indirect dispatch per monadic
+step (CPS `Iter.t` + state-passing) and persistent-map rebuilds — none of which
+inlining or flambda can touch.
+
+Takeaway for the next attempt: the lever for `perf.t` is **structural** — cut
+allocation/structural churn in the persistent maps and the Tree Borrows
+state-rebuild, not compiler flags. The realized examples of that lever (the
+`Tree_borrows.Raw.access`/`compact` rewrites) are written up in
+`tree-borrows.md`.
+
+The flambda switch built for this lives at `soteria-flambda`
+(`ocaml-variants.5.4.1+options` + `ocaml-option-flambda`, rust-only deps:
+`opam install ./soteria.opam ./soteria-rust.opam --deps-only`). `dune build`
+all-packages fails there (no cerberus); build/install just `soteria-rust`.
 
 ## Build/test gates to keep green
 

--- a/.claude/skills/profile-soteria/references/tree-borrows.md
+++ b/.claude/skills/profile-soteria/references/tree-borrows.md
@@ -1,0 +1,126 @@
+# Tree Borrows performance (`soteria-rust/lib/tree_borrows/`)
+
+Soteria-rust models pointer aliasing with Tree Borrows. The hot module is
+`raw.ml`: a per-memory-location **borrow tree** (`root`, a weak Patricia trie
+`tag -> node`) plus a per-byte **state** (`tb_state`, a weak Patricia trie
+`tag -> (protected * state)`). `borrow` adds tags to `root`; `access` updates
+`tb_state` for every tag in `root` on each memory access; `compact` reclaims
+dead tags. This file records what's been measured and changed here. For the
+general profiling tooling (sample/perf/landmarks/memtrace/Z3) see
+`ocaml-profiling.md`.
+
+## How much is Tree Borrows actually worth?
+
+Measured inclusive share of total time (sum of sample counts on every
+`Raw$access_1212` frame ÷ main-thread samples, `sample`-based):
+**`Raw.access` is ~5% on `btreeset_sort`** (the most realistic bench), ~2.4% on
+the bushy reborrow tree, and ~22% only on the pathological all-live chain. So
+`access` is a single-digit-% cost in realistic workloads — the chain just
+over-represents it. The dominant TB cost in *tree-shaped reborrow* workloads is
+instead `borrow`→`compact` (~53% inclusive there, of which the forced
+`Gc.full_major` is ~58% of `borrow` and the `filter_map_no_share` rebuild the
+rest); in `btreeset` even that is ~0 and the time is in the symex engine / value
+layer / Z3. **Bottom line: there is a low ceiling on further TB work** — keep
+this in mind before investing.
+
+## Regression benches
+
+Two shapes, because they stress different regimes (both 1-branch, concrete,
+`PC 1: empty`, in `soteria-rust/test/cram/perf.t/`):
+
+- `reborrow_chain.rs` — deep `&mut` reborrow chain; every tag stays live on the
+  recursion stack → large tree, nothing reclaimable → **sensitive `access`
+  sentinel** (−27% swing baseline→optimized).
+- `reborrow_tree.rs` — balanced binary reborrow tree (`rec(&mut *r); rec(&mut
+  *r)` per level); completed subtrees' tags **die**, so `compact` reclaims them
+  and the live tree stays small → realistic, **`compact`-bound** (the `access`
+  optimizations barely move it).
+
+`writealot.rs`/`writealotloop.rs` are the clean isolators for the per-step
+memory-model + monad cost: single path, no branching, no Z3, sub-1% variance.
+
+## Realized optimizations (2026-06, all in `raw.ml`)
+
+Each measured by clean back-to-back A/B (n=8, same build, only `raw.ml`).
+All behaviour-identical (`dune test soteria-rust` unchanged).
+
+1. **`access`: rebuild → sharing fold.** It used to rebuild the whole `tb_state`
+   trie every access with `filter_map_no_share` (O(total borrows) allocation).
+   Rewritten to fold over `root` with the prior `tb_state` as the accumulator —
+   `add`/`remove` only on tags whose `(protected, state)` changes, returning the
+   accumulator untouched otherwise → PatriciaTree structural sharing, allocation
+   O(changed-per-access). **−13%** on the chain.
+
+2. **`access`: fold + `find_opt` → single simultaneous walk.** Replace the
+   `fold` over `root` + per-tag `find_opt tag st` with
+   `Tag.WeakMap.WithForeign(Tag.WeakMap.BaseMap).update_multiple_from_foreign`,
+   which walks `root` and `st` **together** in one pass (O(|root|+|st|), no
+   `find_opt`), the closure receiving both the node and the current `st` value.
+   Returning `old` unchanged shares; `None` drops. **−19% total** vs original.
+   (`sample` had localized the cost to the `find_opt` into `st`,
+   `PatriciaTree.find_opt`/`findint` ~425 samples — *not* iterating `root`, which
+   is a cheap sequential trie walk.)
+
+3. **`compact` backoff `1.5×` → `2×`.** When a `Gc.full_major` finds the borrow
+   set still fully live, the next compaction threshold backs off; `known_size *
+   3 / 2` → `known_size * 2`. **−14%** on the chain, **−2%** on btreeset; `3×`
+   gave no further gain. Re-checked on the bushy bench: `1.5×` did *not* beat
+   `2×` there either (0.588 vs 0.584, n=10), so `2×` stands for both shapes.
+
+4. **`compact_threshold` 128 → 256.** On the bushy bench an inclusive profile
+   showed `caml_finish_major_cycle` (the forced `Gc.full_major` in `compact`) at
+   **~58%** — that single forced full-heap GC, fired every time the trie hits the
+   threshold, is almost the entire `borrow` cost. The lever is *frequency*:
+   `full_major` fires once per threshold-worth of borrows, and `access` walking a
+   bigger trie is cheap, so letting the trie grow before compacting amortises the
+   GC. Threshold sweep is a clean U-shape — 128:0.60, **256:0.52**, 512:0.54,
+   1024:0.63 — so 256 is the floor (**−12%** on reborrow_tree), neutral on
+   btreeset/chain, RSS unchanged (82 MB either way; the trie is tiny next to the
+   symex heap).
+
+## What was tried and rejected
+
+- **Remove the forced `Gc.full_major`** (rely on natural GC): regression,
+  reborrow_tree **0.6s → 1.7s**. On the small micro-bench heap, natural major
+  cycles are too rare, so promoted dead tags never clear and the trie grows
+  unbounded. The forced GC is load-bearing *here*. (For a *large* real heap the
+  better fix is to skip the forced `full_major` when a natural major cycle
+  already ran since the last compaction — but that can't be demonstrated on these
+  small-heap benches, so it was not done. This is the most promising untried
+  scalability lever.)
+- **Sharing `filter_map` rebuild in `compact`** instead of `filter_map_no_share`:
+  correct (it does drop dead-ephemeron leaves) but perf-neutral — in bulk-death
+  workloads most paths have a dead leaf, so little is shareable. Kept as
+  `filter_map_no_share`. (Note: it *must* be a full rebuild to drop the
+  dead-ephemeron orphan `Branch` nodes; sharing all-live subtrees would keep
+  them.)
+- **`[@inline]`/`[@cold]` + flambda on the monad layer:** no effect — see
+  `ocaml-profiling.md`.
+
+## Gotchas
+
+- **Load-bearing share branch (don't "simplify" it away):** the `access` closure
+  has a branch `else if protected = protected0 && equal_state st' st0 then old`
+  that returns the *existing* value unchanged for tags whose state didn't move.
+  PatriciaTree's `update`/`insert`/`add` preserve physical equality only when the
+  returned value is `==` the stored one, but `access` builds a *fresh*
+  `(protected, st')` tuple every call, so returning `Some (protected, st')` for an
+  unchanged tag still reallocates the leaf + the O(log n) spine. Dropping that
+  branch measured **+18%** — *slower than the original `filter_map_no_share`
+  baseline* — because every stored tag is rebuilt each access. Keep it.
+
+## Hard constraints (why some redesigns are off the table)
+
+- The **st/root split must stay**, **`borrow` must not propagate into `tb_state`**,
+  and the **interface must not change**. `Tree` (root) and `State` (tb_state) are
+  separate state monads threaded independently (`tree_borrows_intf.ml`).
+- Consequence: any "iterate `st` alone with cached metadata" scheme (e.g. a
+  "can't be protected" bit to avoid `root` lookups) needs `st` to be **dense**
+  (hold every tag, not just deviations-from-default), which requires `borrow` to
+  populate `tb_state` — a cross-component change that's forbidden. Without it,
+  `access` must walk `root` every call to discover new borrows, so such a scheme
+  *adds* a pass rather than removing one. The current single-pass
+  `update_multiple_from_foreign` is near-optimal under these constraints.
+- The tries must stay **persistent** (forked across symbolic branches — see the
+  soundness invariant in `CLAUDE.md`), so a mutable weak `Hashtbl` is not an
+  option; persistent weak Patricia + GC-based reclamation is essentially forced.

--- a/.gitignore
+++ b/.gitignore
@@ -247,8 +247,8 @@ soteria_logs.html
 *.rlib
 
 ### Claude ###
-.claude/
-!.claude/skills
+.claude/*
+!.claude/skills/
 
 # Created using: https://www.toptal.com/developers/gitignore/api/node,ocaml
 # and modified by hand afterwards

--- a/scripts/benchmarks.json
+++ b/scripts/benchmarks.json
@@ -20,6 +20,14 @@
     {
       "name": "btreeset sort (size 4)",
       "path": "soteria-rust/test/cram/perf.t/btreeset_sort.rs"
+    },
+    {
+      "name": "reborrow (chain)",
+      "path": "soteria-rust/test/cram/perf.t/reborrow_chain.rs"
+    },
+    {
+      "name": "reborrow (tree)",
+      "path": "soteria-rust/test/cram/perf.t/reborrow_tree.rs"
     }
   ],
   "rust_crates": [],

--- a/soteria-rust/lib/tree_borrows/raw.ml
+++ b/soteria-rust/lib/tree_borrows/raw.ml
@@ -128,10 +128,10 @@ let transition =
   fun ~protected -> if protected then transition_protected else transition
 
 (* Compact the root trie when it reaches this size. Dead ephemeron leaves become
-   Empty after GC but their parent Branch nodes persist, making
-   [filter_map_no_share] in [access] O(total borrows) instead of O(live).
-   Triggering on map size rather than tag count means small maps (e.g. a freshly
-   allocated variable with few borrows) never pay the GC cost. *)
+   Empty after GC but their parent Branch nodes persist, making the walk over
+   [root] in [access] O(total borrows) instead of O(live). Triggering on map
+   size rather than tag count means small maps (e.g. a freshly allocated
+   variable with few borrows) never pay the GC cost. *)
 let compact_threshold = 128
 let compact_map = Tag.WeakMap.filter_map_no_share (Fun.const Option.some)
 
@@ -170,7 +170,7 @@ let[@inline] compact ({ tags; known_size; next_compact_at } as st : t) =
       (* If still large after a full GC all entries are genuinely live; back off
          exponentially so we don't retry on every subsequent borrow. *)
       let next_compact_at =
-        if known_size >= next_compact_at then known_size * 3 / 2
+        if known_size >= next_compact_at then known_size * 2
         else compact_threshold
       in
       { tags; known_size; next_compact_at }))
@@ -208,6 +208,10 @@ let strong_protector_exists { tags; _ } =
     (managed outside [tb_state]) was toggled. *)
 type tb_state = (bool * state) Tag.WeakMap.t
 
+(* Lets [access] walk the [root] trie (the structure, mapping tags to nodes) and
+   the [tb_state] trie together in a single pass. *)
+module WeakMap_with_root = Tag.WeakMap.WithForeign (Tag.WeakMap.BaseMap)
+
 let pp_tb_state =
   Fmt.iter_bindings ~sep:(Fmt.any ", ") Tag.WeakMap.iter
     (fun ft (tag, (protected, st)) ->
@@ -234,23 +238,26 @@ let access accessed e ({ tags; _ } as root : t) (st : tb_state) =
   let accessed_node = Tag.WeakMap.find accessed tags in
   let parents = accessed_node.parents in
   try
-    Tag.WeakMap.filter_map_no_share
-      (fun tag { protector; initial_state; _ } ->
-        let protected, st =
-          match Tag.WeakMap.find_opt tag st with
-          | None -> (false, initial_state)
-          | Some ps -> ps
-        in
-        let rel = if Tag.WeakSet.mem parents tag then Local else Foreign in
-        (* if the tag has a protector and is accessed, this toggles the
-           protector! *)
-        let protected =
-          (Tag.equal tag accessed || protected) && Option.is_some protector
-        in
-        let st' = transition ~protected st rel e in
-        if (not protected) && Common.equal_state st' initial_state then None
-        else Some (protected, st'))
-      tags
+    WeakMap_with_root.update_multiple_from_foreign tags
+      {
+        f =
+          (fun tag old (Snd { protector; initial_state; _ }) ->
+            let protected0, st0 =
+              match old with None -> (false, initial_state) | Some ps -> ps
+            in
+            let rel = if Tag.WeakSet.mem parents tag then Local else Foreign in
+            (* if the tag has a protector and is accessed, this toggles the
+               protector! *)
+            let protected =
+              (protected0 || Tag.equal tag accessed) && Option.is_some protector
+            in
+            let st' = transition ~protected st0 rel e in
+            if (not protected) && Common.equal_state st' initial_state then None
+            else if protected = protected0 && Common.equal_state st' st0 then
+              old
+            else Some (protected, st'));
+      }
+      st
     |> Result.ok
   with AliasingError ->
     [%l.debug

--- a/soteria-rust/test/cram/perf.t/reborrow_chain.rs
+++ b/soteria-rust/test/cram/perf.t/reborrow_chain.rs
@@ -1,0 +1,19 @@
+// Deep reborrow chain: each call reborrows `&mut`, adding a child tag to the SAME
+// location's borrow tree, and every tag stays live on the recursion stack — so the
+// tree grows to ~N with nothing reclaimable. Every `*r += 1` is a TB access over
+// that whole growing tree, i.e. O(N^2) access work over a large *live* tree. This
+// is the sensitive sentinel for `Raw.access`; see reborrow_tree.rs for the bushy,
+// reclaiming counterpart where `access` is no longer the bottleneck.
+fn deep(r: &mut u32, n: u32) {
+    if n == 0 {
+        return;
+    }
+    *r += 1;
+    deep(&mut *r, n - 1);
+}
+
+fn main() {
+    let mut x = 0u32;
+    deep(&mut x, 600);
+    soteria::assert(x == 600, "ok");
+}

--- a/soteria-rust/test/cram/perf.t/reborrow_tree.rs
+++ b/soteria-rust/test/cram/perf.t/reborrow_tree.rs
@@ -1,0 +1,20 @@
+// Balanced reborrow tree: each level makes two sequential `&mut` reborrows of the
+// same location, so one location's borrow tree is bushy (depth 10, 2^10 leaves)
+// rather than a single chain. Every leaf write is Foreign to the other subtrees'
+// tags, and completed subtrees' tags die — so this exercises the Foreign
+// transitions and compaction *reclamation*, on top of the O(borrows) per-access
+// walk over the (large) tree.
+fn rec(r: &mut u32, depth: u32) {
+    if depth == 0 {
+        *r += 1;
+        return;
+    }
+    rec(&mut *r, depth - 1);
+    rec(&mut *r, depth - 1);
+}
+
+fn main() {
+    let mut x = 0u32;
+    rec(&mut x, 10);
+    soteria::assert(x == 1024, "ok");
+}

--- a/soteria-rust/test/cram/perf.t/run.t
+++ b/soteria-rust/test/cram/perf.t/run.t
@@ -4,6 +4,21 @@
   note: array_init::main: done in <time>, ran 1 branch
   PC 1: empty
   
+
+  $ soteria-rust exec reborrow_chain.rs
+  Compiling... done in <time>
+  => Running reborrow_chain::main...
+  note: reborrow_chain::main: done in <time>, ran 1 branch
+  PC 1: empty
+  
+
+  $ soteria-rust exec reborrow_tree.rs
+  Compiling... done in <time>
+  => Running reborrow_tree::main...
+  note: reborrow_tree::main: done in <time>, ran 1 branch
+  PC 1: empty
+  
+
   $ soteria-rust exec btreeset_sort.rs
   Compiling... done in <time>
   => Running btreeset_sort::test_treeset_is_ordered...


### PR DESCRIPTION
Minor thing I spotted while trying to improve Tree Borrows performance further. It doesn't do much but its a slight improvement and it's aesthetically nicer. Also the `.gitignore` was wrong so new Claude skills weren't tracked :P 

Also added two benchmarks, one that has a call nested N deep, which is worst case on the amount of tags to track (since tags can never be discarded), and one that has calls N wide (2^N total), which exercises a hopefully more realistic workload where we only track `O(log(N))` of tags