### PR TITLE
`not_impl` receives an fmt instead of a string

### DIFF
--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -32,8 +32,8 @@ module M (StateM : State.StateM.S) = struct
         else error `UBPointerComparison
     | TBitVector _, TPointer _ -> equality_check v2 v1
     | _ ->
-        Fmt.kstr not_impl "Unexpected types in cval equality: %a and %a"
-          Typed.ppa v1 Typed.ppa v2
+        not_impl "Unexpected types in cval equality: %a and %a" Typed.ppa v1
+          Typed.ppa v2
 
   (** Rust allows shift operations on integers of differents sizes, which isn't
       possible in SMT-Lib, so we normalise the righthand side to match the left
@@ -172,9 +172,7 @@ module M (StateM : State.StateM.S) = struct
     | Eq, Ptr (p, _), Int v | Eq, Int v, Ptr (p, _) ->
         let v = cast_i Usize v in
         if%sat v ==@ Usize.(0s) then ok (BV.of_bool (Sptr.is_null p))
-        else
-          Fmt.kstr not_impl "Don't know how to eval %a == %a" Sptr.pp p
-            Typed.ppa v
+        else not_impl "Don't know how to eval %a == %a" Sptr.pp p Typed.ppa v
     | Eq, Int v1, Int v2 -> ok (BV.of_bool (v1 ==@ v2))
     | (Lt | Le | Gt | Ge), Ptr (l, ml), Ptr (r, mr) -> (
         let* dist = Sptr.distance l r in
@@ -200,8 +198,7 @@ module M (StateM : State.StateM.S) = struct
               ok (BV.of_bool (bop ml mr))
             else ok (BV.of_bool v))
     | op, l, r ->
-        Fmt.kstr not_impl
-          "Unexpected operation or value in eval_ptr_binop: %a, %a, %a"
+        not_impl "Unexpected operation or value in eval_ptr_binop: %a, %a, %a"
           Expressions.pp_binop op pp_rust_val l pp_rust_val r
 
   let zero_valid ~ty =

--- a/soteria-rust/lib/builtins/eval.ml
+++ b/soteria-rust/lib/builtins/eval.ml
@@ -140,6 +140,5 @@ module M (StateM : State.StateM.S) = struct
     match SMap.find_opt name extern_functions with
     | Some extern_fn -> extern_fn_to_stub extern_fn
     | None ->
-        fun _args ->
-          Fmt.kstr StateM.not_impl "Extern function %s is not handled" name
+        fun _args -> StateM.not_impl "Extern function %s is not handled" name
 end

--- a/soteria-rust/lib/builtins/fixme/fixme.ml
+++ b/soteria-rust/lib/builtins/fixme/fixme.ml
@@ -51,7 +51,7 @@ module M (StateM : State.StateM.S) = struct
         let payload = as_ptr payload in
         cleanup ~payload
     | _, tys, cs, args ->
-        Fmt.kstr not_impl
+        not_impl
           "Custom stub found but called with the wrong arguments; got:@.Types: \
            %a@.Consts: %a@.Args: %a"
           Fmt.(list ~sep:comma Charon_util.pp_ty)

--- a/soteria-rust/lib/builtins/intrinsics/intrinsics.ml
+++ b/soteria-rust/lib/builtins/intrinsics/intrinsics.ml
@@ -833,7 +833,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
         let+ () = write_via_move ~t ~ptr ~value in
         Tuple []
     | name, tys, cs, args ->
-        Fmt.kstr not_impl
+        not_impl
           "Intrinsic %s not found, or not called with the right arguments; \
            got:@.Types: %a@.Consts: %a@.Args: %a"
           name

--- a/soteria-rust/lib/builtins/optim/optim.ml
+++ b/soteria-rust/lib/builtins/optim/optim.ml
@@ -294,7 +294,7 @@ module M (StateM : State.StateM.S) = struct
         let+ () = begin_panic ~m ~msg in
         Tuple []
     | _, tys, cs, args ->
-        Fmt.kstr not_impl
+        not_impl
           "Custom stub found but called with the wrong arguments; got:@.Types: \
            %a@.Consts: %a@.Args: %a"
           Fmt.(list ~sep:comma Charon_util.pp_ty)

--- a/soteria-rust/lib/builtins/soteria_lib/soteria_lib.ml
+++ b/soteria-rust/lib/builtins/soteria_lib/soteria_lib.ml
@@ -63,7 +63,7 @@ module M (StateM : State.StateM.S) = struct
     | SoteriaNondetBytes, _, _, _ -> nondet_bytes ~types:generics.types ~args
     | SoteriaPanic, _, _, _ -> soteria_panic ~args
     | _, tys, cs, args ->
-        Fmt.kstr not_impl
+        not_impl
           "Custom stub found but called with the wrong arguments; got:@.Types: \
            %a@.Consts: %a@.Args: %a"
           Fmt.(list ~sep:comma Charon_util.pp_ty)

--- a/soteria-rust/lib/builtins/system/impl.ml
+++ b/soteria-rust/lib/builtins/system/impl.ml
@@ -18,7 +18,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
       match args with
       | [ Ptr dtor_ptr; arg_ptr ] -> ok (dtor_ptr, arg_ptr)
       | _ ->
-          Fmt.kstr not_impl "tlv_atexit: unexpected arguments: %a"
+          not_impl "tlv_atexit: unexpected arguments: %a"
             Fmt.(list pp_rust_val)
             args
     in

--- a/soteria-rust/lib/builtins/system/system.ml
+++ b/soteria-rust/lib/builtins/system/system.ml
@@ -66,7 +66,7 @@ module M (StateM : State.StateM.S) = struct
     | StdThreadFunctionsAvailableParallelism, [], [], [] ->
         available_parallelism ~fun_sig:_fun_sig
     | _, tys, cs, args ->
-        Fmt.kstr not_impl
+        not_impl
           "Custom stub found but called with the wrong arguments; got:@.Types: \
            %a@.Consts: %a@.Args: %a"
           Fmt.(list ~sep:comma Charon_util.pp_ty)

--- a/soteria-rust/lib/builtins/tokio/tokio.ml
+++ b/soteria-rust/lib/builtins/tokio/tokio.ml
@@ -42,7 +42,7 @@ module M (StateM : State.StateM.S) = struct
     with
     | TokioUtilRandRngSeedNew, [], [], [] -> new_ ~fun_sig:_fun_sig
     | _, tys, cs, args ->
-        Fmt.kstr not_impl
+        not_impl
           "Custom stub found but called with the wrong arguments; got:@.Types: \
            %a@.Consts: %a@.Args: %a"
           Fmt.(list ~sep:comma Charon_util.pp_ty)

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -120,12 +120,12 @@ module Make (StateImpl : State.S) = struct
               match trait_decl.item_meta.lang_item with
               | Some "destruct" -> ok (`Synth GenericDropInPlace)
               | Some _ | None ->
-                  Fmt.kstr not_impl "trait call %a::%s on generic" Crate.pp_name
+                  not_impl "trait call %a::%s on generic" Crate.pp_name
                     trait_decl.item_meta.name
                     (Crate.get_method_name tref method_id))
           | _ ->
-              Fmt.kstr not_impl "Unexpected tref kind, got: %a"
-                Types.pp_trait_ref_kind tref.kind
+              not_impl "Unexpected tref kind, got: %a" Types.pp_trait_ref_kind
+                tref.kind
         in
         match timplref with
         | `Synth kind -> ok (Synthetic kind)
@@ -145,7 +145,7 @@ module Make (StateImpl : State.S) = struct
                 with
                 | Some fn -> ok (Real fn)
                 | None ->
-                    Fmt.kstr not_impl "Could not resolve trait method %a#%a"
+                    not_impl "Could not resolve trait method %a#%a"
                       Crate.pp_trait_impl_ref timplref Types.pp_trait_method_id
                       method_id)))
     | FunId (FBuiltin _) -> failwith "Can't resolve a builtin function"
@@ -206,8 +206,8 @@ module Make (StateImpl : State.S) = struct
                 let glob = Crate.get_global global.id in
                 State.load glob_ptr glob.ty
             | None ->
-                Fmt.kstr not_impl "unsupported trait const: %s in %a for %a"
-                  assoc.name Crate.pp_trait_ref tref
+                not_impl "unsupported trait const: %s in %a for %a" assoc.name
+                  Crate.pp_trait_ref tref
                   (Crate.pp_region_binder Crate.pp_trait_decl_ref)
                   tref.trait_decl_ref))
     | CRawMemory bytes ->
@@ -304,15 +304,13 @@ module Make (StateImpl : State.S) = struct
         let+ ptr = State.declare_fn fn in
         Ptr ptr
     | CVTableRef _ ->
-        Fmt.kstr not_impl "vtable-reference constants are not yet supported: %a"
+        not_impl "vtable-reference constants are not yet supported: %a"
           Crate.pp_constant_expr const
     | CTypeId _ ->
-        Fmt.kstr (not_impl ~issue:187)
-          "TypeId constants are not yet supported: %a" Crate.pp_constant_expr
-          const
+        (not_impl ~issue:187) "TypeId constants are not yet supported: %a"
+          Crate.pp_constant_expr const
     | COpaque msg ->
-        Fmt.kstr not_impl
-          "opaque constant: %s; something went wrong in the frontend" msg
+        not_impl "opaque constant: %s; something went wrong in the frontend" msg
 
   (** Resolves a place to a pointer *)
   and resolve_place (place : Expressions.place) : full_ptr t =
@@ -543,8 +541,7 @@ module Make (StateImpl : State.S) = struct
     | MetaUnknown -> (
         match help with
         | None -> not_impl "unknown unsizing metadata"
-        | Some help ->
-            Fmt.kstr not_impl "unknown unsizing metadata: %s" (help ()))
+        | Some help -> not_impl "unknown unsizing metadata: %s" (help ()))
 
   (** Resolve a function operand, returning a callable symbolic function to
       execute it. It also returns the types expected of the function, which is
@@ -1248,16 +1245,15 @@ module Make (StateImpl : State.S) = struct
         | None -> (
             match fundef.body with
             | OpaqueBody ->
-                Fmt.kstr not_impl
-                  "can't execute function %a, compilation skipped it"
+                not_impl "can't execute function %a, compilation skipped it"
                   Crate.pp_name name
             | TraitMethodWithoutDefaultBody ->
-                Fmt.kstr not_impl
+                not_impl
                   "can't execute function %a, this is a trait method stub"
                   Crate.pp_name name
             | MissingBody ->
                 if Option.is_some (Config.get ()).sysroot then
-                  Fmt.kstr not_impl
+                  not_impl
                     "can't execute function %a, the function's body was not \
                      found while compiling"
                     Crate.pp_name name
@@ -1267,11 +1263,11 @@ module Make (StateImpl : State.S) = struct
                       (Lazy.force Frontend_runtime.Cmd.toolchain_version)
                   in
                   let tip = ("to get a sysroot, run", Some cmd) in
-                  Fmt.kstr (not_impl ~tip ~issue:322)
+                  (not_impl ~tip ~issue:322)
                     "can't execute function %a, try using a sysroot (--sysroot)"
                     Crate.pp_name name
             | ErrorBody err ->
-                Fmt.kstr not_impl
+                not_impl
                   "can't execute function %a, the frontend does not support \
                    compiling it (%s)"
                   Crate.pp_name name err.msg

--- a/soteria-rust/lib/layout.ml
+++ b/soteria-rust/lib/layout.ml
@@ -91,9 +91,7 @@ let mk ~size ~align ?(uninhabited = false)
 let mk_concrete ~size ~align =
   mk ~size:(BV.usizei size) ~align:(BV.usizeinz align)
 
-let not_impl_layout msg ty =
-  Fmt.kstr not_impl "Can't compute layout: %s %a" msg pp_ty ty
-
+let not_impl_layout msg ty = not_impl "Can't compute layout: %s %a" msg pp_ty ty
 let layout_warning msg ty = [%l.warn "Layout: %s@.Type: %a" msg pp_ty ty]
 
 let rec layout_of (ty : Types.ty) : (t, 'e, 'f) Rustsymex.Result.t =

--- a/soteria-rust/lib/rustsymex.ml
+++ b/soteria-rust/lib/rustsymex.ml
@@ -186,9 +186,12 @@ let with_extra_call_trace ?name ~loc ~msg (f : 'a t) : 'a t =
   let+ result, st = f { st with trace = new_trace } in
   (result, { st with trace = cur_trace })
 
-let not_impl ?tip ?issue desc =
-  give_up (Unimplemented.to_string (Unimplemented.make ?tip ?issue desc))
+let not_impl ?tip ?issue fmt =
+  Fmt.kstr
+    (fun desc ->
+      give_up (Unimplemented.to_string (Unimplemented.make ?tip ?issue desc)))
+    fmt
 
 let of_opt_not_impl ?tip ?issue msg = function
   | Some x -> return x
-  | None -> not_impl ?tip ?issue msg
+  | None -> not_impl ?tip ?issue "%s" msg

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -88,7 +88,8 @@ module DecayMap = struct
   module SM = struct
     include SM
 
-    let[@inline] not_impl ?tip ?issue msg = lift @@ not_impl ?tip ?issue msg
+    let[@inline] not_impl ?tip ?issue fmt =
+      Fmt.kstr (fun msg -> lift @@ Rustsymex.not_impl ?tip ?issue "%s" msg) fmt
 
     let[@inline] of_opt_not_impl ?tip ?issue msg x =
       lift @@ of_opt_not_impl ?tip ?issue msg x

--- a/soteria-rust/lib/state/rtree_block.ml
+++ b/soteria-rust/lib/state/rtree_block.ml
@@ -118,9 +118,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
           let mask_l = BV.extract 0 ((at * 8) - 1) v in
           let mask_r = BV.extract (at * 8) ((size * 8) - 1) v in
           (Rust_val.Int mask_l, Rust_val.Int mask_r)
-      | _ ->
-          Fmt.kstr not_impl "Split unsupported: %a at %a" pp_rust_val v
-            Typed.ppa at
+      | _ -> not_impl "Split unsupported: %a at %a" pp_rust_val v Typed.ppa at
 
     let split ~at node =
       match node with
@@ -429,8 +427,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
           | Ptr (ptr, Thin) -> Sptr.decay ptr
           | Float f -> Encoder.float_to_bv_bits f
           | _ ->
-              Fmt.kstr not_impl "Unexpected rust_val in lazy decoding: %a"
-                pp_rust_val v)
+              not_impl "Unexpected rust_val in lazy decoding: %a" pp_rust_val v)
     in
     match List.rev leaves with
     | hd :: tl ->

--- a/soteria-rust/lib/state/rust_state_m.ml
+++ b/soteria-rust/lib/state/rust_state_m.ml
@@ -53,7 +53,10 @@ module type S = sig
   val vanish : unit -> ('a, 'env) t
 
   val not_impl :
-    ?tip:string * string option -> ?issue:int -> string -> ('a, 'env) t
+    ?tip:string * string option ->
+    ?issue:int ->
+    ('a, Format.formatter, unit, ('b, 'env) t) format4 ->
+    'a
 
   val bind : ('a -> ('b, 'env) t) -> ('a, 'env) t -> ('b, 'env) t
   val map : ('a -> 'b) -> ('a, 'env) t -> ('b, 'env) t
@@ -350,8 +353,11 @@ module Make (State : State_intf.S) :
   let assert_not cond err = assert_ (Typed.not cond) err
   let miss f : ('a, 'env) t = ESM.Result.miss f
 
-  let not_impl ?tip ?issue str : ('a, 'env) t =
-    ESM.lift @@ State.SM.lift @@ Rustsymex.not_impl ?tip ?issue str
+  let not_impl ?tip ?issue fmt =
+    Fmt.kstr
+      (fun str ->
+        ESM.lift @@ State.SM.lift @@ Rustsymex.not_impl ?tip ?issue "%s" str)
+      fmt
 
   let get_state () : (st, 'env) t =
     ESM.Result.lift_state @@ State.SM.get_state ()

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -845,7 +845,7 @@ module Make (Borrows : Tree_borrows.T) = struct
                  ~range:t.range ?children:t.children ()
          in
          try DecayMap.SM.Result.ok (aux tb t)
-         with Failure msg -> DecayMap.SM.not_impl msg
+         with Failure msg -> DecayMap.SM.not_impl "%s" msg
        in
        (* Applies all the tree borrow ranges to the tree we're writing,
           overwriting all previous states. *)

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -163,7 +163,8 @@ struct
     let lift_rsymex (m : ('a, 'err, 'fix) Rustsymex.Result.t) : 'a t =
      fun _handler _get_all -> SM.lift (DecayMap.SM.lift m)
 
-    let not_impl ?tip ?issue msg = lift @@ not_impl ?tip ?issue msg
+    let not_impl ?tip ?issue fmt =
+      Fmt.kstr (fun msg -> lift @@ not_impl ?tip ?issue "%s" msg) fmt
 
     let of_opt_not_impl ?tip ?issue msg x =
       lift @@ of_opt_not_impl ?tip ?issue msg x
@@ -373,8 +374,7 @@ module Encoder (Sptr : Sptr.S) = struct
               let offset = ofs +!!@ offset in
               Iter.cons (Int tag, offset) fields)
       | Enum _, _ ->
-          Fmt.kstr not_impl "encode: expected enum value for enum type %a" pp_ty
-            ty
+          not_impl "encode: expected enum value for enum type %a" pp_ty ty
 
   (** Iterates over the validity constraints of this particular value for a
       given type, traversing it recursively. For every requirement, this
@@ -604,18 +604,18 @@ module Encoder (Sptr : Sptr.S) = struct
     | TVar (Free type_var_id), (PolyVal tid as v) ->
         if Types.TypeVarId.equal_id type_var_id tid then return v
         else
-          Fmt.kstr not_impl "transmute_one: mismatched type variables %a -> %a"
+          not_impl "transmute_one: mismatched type variables %a -> %a"
             Types.pp_type_var_id type_var_id Types.pp_type_var_id tid
     | TVar (Bound _), _ ->
         failwith "transmute_one: bound type variable encountered?"
     | TVar _, _ ->
-        Fmt.kstr not_impl
+        not_impl
           "losing concrete value in %a -> %a; somewhere we lost track of \
            generics"
           pp_rust_val v pp_ty to_ty
     | _ ->
-        Fmt.kstr not_impl "unsupported transmute of value %a to type %a"
-          pp_rust_val v pp_ty to_ty
+        not_impl "unsupported transmute of value %a to type %a" pp_rust_val v
+          pp_ty to_ty
 
   (** [nondet_raw ty] returns a nondeterministic value for [ty], by traversing
       [ty]: the returned value will have the right structure, and any required
@@ -679,12 +679,12 @@ module Encoder (Sptr : Sptr.S) = struct
             let+ bytes = nondet (Typed.t_int (sizei * 8)) in
             Ok (Union [ (Int bytes, Usize.(0s)) ])
         | _ ->
-            Fmt.kstr Rustsymex.not_impl
+            Rustsymex.not_impl
               "cannot create a symbolic value of unsupported type %a" pp_ty ty)
     | TPattern (inner, _) -> nondet_raw inner
     | TVar (Free id) -> Result.ok (PolyVal id)
     | ty ->
-        Fmt.kstr Rustsymex.not_impl
+        Rustsymex.not_impl
           "cannot create a symbolic value of unsupported type %a" pp_ty ty
 
   (** Much like {!nondet_raw}, but also assumes validity invariants for the


### PR DESCRIPTION
As in the title. Something that's been annoying me for a while but I didn't know the incantation to put in the signature in the mli. Claude found it