### PR TITLE
Support more atomics, some externs, fix benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -94,6 +94,12 @@ jobs:
           OBOL_COMMIT_HASH=$(jq -r .OBOL_COMMIT_HASH scripts/versions.json)
           curl https://raw.githubusercontent.com/$OBOL_REPO/$OBOL_COMMIT_HASH/rust-toolchain.toml > rust-toolchain
 
+      # Force rustup to install the pinned toolchain (with its components) now,
+      # in its own step. Otherwise the first `soteria-rust` invocation triggers
+      # a lazy install.
+      - name: Pre-install Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+
       # Packages produced by the Build workflow (.github/workflows/build.yml).
       # When artifact-run-id is set we pull them from that run (PR case),
       # otherwise from the current run (push-to-main case).

--- a/soteria-rust/lib/builtins/eval.ml
+++ b/soteria-rust/lib/builtins/eval.ml
@@ -56,6 +56,7 @@ type fn =
 (** Extern functions we must implement manually *)
 type extern_fn =
   | Alloc of Extern.Alloc.fn
+  | ExtSystem of Extern.System.fn
   | Libc of Extern.Libc.fn
   | Miri of Extern.Miri.fn
   | Std of Extern.Std.fn
@@ -65,6 +66,7 @@ let extern_functions =
   @ (Extern.Libc.fn_pats |> List.map @@ Pair.map_snd @@ fun f -> Libc f)
   @ (Extern.Miri.fn_pats |> List.map @@ Pair.map_snd @@ fun f -> Miri f)
   @ (Extern.Std.fn_pats |> List.map @@ Pair.map_snd @@ fun f -> Std f)
+  @ (Extern.System.fn_pats |> List.map @@ Pair.map_snd @@ fun f -> ExtSystem f)
   |> SMap.of_list
 
 let std_fun_pair_list =
@@ -87,6 +89,7 @@ module M (StateM : State.StateM.S) = struct
 
   (* externs *)
   module Alloc = Extern.Alloc.M (StateM)
+  module ExtSystem = Extern.System.M (StateM)
   module Libc = Extern.Libc.M (StateM)
   module Miri = Extern.Miri.M (StateM)
   module Std = Extern.Std.M (StateM)
@@ -105,8 +108,9 @@ module M (StateM : State.StateM.S) = struct
     | System f -> System.fn_to_stub f fun_sig fun_exec generics
     | Tokio f -> Tokio.fn_to_stub f fun_sig fun_exec generics
 
-  let[@inline] extern_fn_to_stub = function
+  let[@inline] extern_fn_to_stub fun_exec = function
     | Alloc f -> Alloc.fn_to_stub f
+    | ExtSystem f -> ExtSystem.fn_to_stub fun_exec f
     | Libc f -> Libc.fn_to_stub f
     | Miri f -> Miri.fn_to_stub f
     | Std f -> Std.fn_to_stub f
@@ -136,9 +140,9 @@ module M (StateM : State.StateM.S) = struct
     let generics = get_generics f generics in
     Intrinsics.eval_fun name fun_exec generics
 
-  let eval_extern name =
+  let eval_extern name fun_exec =
     match SMap.find_opt name extern_functions with
-    | Some extern_fn -> extern_fn_to_stub extern_fn
+    | Some extern_fn -> extern_fn_to_stub fun_exec extern_fn
     | None ->
         fun _args -> StateM.not_impl "Extern function %s is not handled" name
 end

--- a/soteria-rust/lib/builtins/eval.ml
+++ b/soteria-rust/lib/builtins/eval.ml
@@ -108,9 +108,9 @@ module M (StateM : State.StateM.S) = struct
     | System f -> System.fn_to_stub f fun_sig fun_exec generics
     | Tokio f -> Tokio.fn_to_stub f fun_sig fun_exec generics
 
-  let[@inline] extern_fn_to_stub fun_exec = function
+  let[@inline] extern_fn_to_stub fun_sig fun_exec = function
     | Alloc f -> Alloc.fn_to_stub f
-    | ExtSystem f -> ExtSystem.fn_to_stub fun_exec f
+    | ExtSystem f -> ExtSystem.fn_to_stub fun_sig fun_exec f
     | Libc f -> Libc.fn_to_stub f
     | Miri f -> Miri.fn_to_stub f
     | Std f -> Std.fn_to_stub f
@@ -140,9 +140,9 @@ module M (StateM : State.StateM.S) = struct
     let generics = get_generics f generics in
     Intrinsics.eval_fun name fun_exec generics
 
-  let eval_extern name fun_exec =
+  let eval_extern (f : UllbcAst.fun_decl) name fun_exec =
     match SMap.find_opt name extern_functions with
-    | Some extern_fn -> extern_fn_to_stub fun_exec extern_fn
+    | Some extern_fn -> extern_fn_to_stub f.signature fun_exec extern_fn
     | None ->
         fun _args -> StateM.not_impl "Extern function %s is not handled" name
 end

--- a/soteria-rust/lib/builtins/extern/libc.ml
+++ b/soteria-rust/lib/builtins/extern/libc.ml
@@ -2,9 +2,10 @@ open Rust_val
 open Typed.Syntax
 open Typed.Infix
 
-type fn = Exit | Sysconf
+type fn = Exit | Sysconf | Malloc | Free
 
-let fn_pats = [ ("exit", Exit); ("sysconf", Sysconf) ]
+let fn_pats =
+  [ ("exit", Exit); ("free", Free); ("malloc", Malloc); ("sysconf", Sysconf) ]
 
 module M (StateM : State.StateM.S) = struct
   open StateM
@@ -16,6 +17,32 @@ module M (StateM : State.StateM.S) = struct
         if%sat code ==@ U32.(0s) then error `OkExit else error (`Exit code)
     | _ -> L.failwith "exit: invalid arguments"
 
+  (* [malloc]/[free] return memory aligned for any fundamental type; we model
+     them as always succeeding, like the Rust allocator shims in {!Alloc}. *)
+  let malloc args =
+    let size =
+      match args with
+      | [ Int size ] -> Typed.cast_i Usize size
+      | _ -> failwith "malloc: invalid arguments"
+    in
+    let max_size = Typed.BitVec.usize (Layout.max_value_z (TInt Isize)) in
+    let* () = assert_ (size <=@ max_size) `InvalidAlloc in
+    (* we under-approximate here: the alignment can be smaller (its min size is
+       the first power of 2 greater than or equal to the requested size) *)
+    let align = Typed.BitVec.usizeinz (2 * Crate.pointer_size ()) in
+    let+ ptr = State.alloc_untyped ~zeroed:false ~size ~align () in
+    Ptr ptr
+
+  let free args =
+    match args with
+    | [ Ptr ((ptr_in, _) as ptr) ] ->
+        (* [free(NULL)] is a no-op. *)
+        if%sat Sptr.is_null ptr_in then ok (Tuple [])
+        else
+          let+ () = State.free ptr in
+          Tuple []
+    | _ -> failwith "free: invalid arguments"
+
   let sysconf args =
     match args with
     | [ Int _ ] ->
@@ -26,5 +53,9 @@ module M (StateM : State.StateM.S) = struct
         ok (Int ret)
     | _ -> L.failwith "sysconf: invalid arguments"
 
-  let[@inline] fn_to_stub = function Exit -> exit | Sysconf -> sysconf
+  let[@inline] fn_to_stub = function
+    | Exit -> exit
+    | Free -> free
+    | Malloc -> malloc
+    | Sysconf -> sysconf
 end

--- a/soteria-rust/lib/builtins/extern/system.ml
+++ b/soteria-rust/lib/builtins/extern/system.ml
@@ -1,8 +1,29 @@
+open Charon
 open Rust_val
+open Typed.Syntax
+open Typed.Infix
 
-type fn = TlvAtexit
+type fn =
+  | TlvAtexit
+  | CxaThreadAtexitImpl
+  | DsoHandle
+  | PthreadKeyCreate
+  | PthreadKeyNoop
 
-let fn_pats = [ ("_tlv_atexit", TlvAtexit) ]
+let fn_pats =
+  [
+    ("_tlv_atexit", TlvAtexit);
+    (* Linux weak `extern` symbols read by the thread-local destructor
+       registration. We don't link against the C runtime, so these weak symbols
+       resolve to null. *)
+    ("__cxa_thread_atexit_impl", CxaThreadAtexitImpl);
+    ("__dso_handle", DsoHandle);
+    (* Linux falls back to a pthread TLS key whose destructor drains the
+       thread-local destructor list at thread exit. *)
+    ("pthread_key_create", PthreadKeyCreate);
+    ("pthread_setspecific", PthreadKeyNoop);
+    ("pthread_key_delete", PthreadKeyNoop);
+  ]
 
 module M (StateM : State.StateM.S) = struct
   open StateM
@@ -25,11 +46,49 @@ module M (StateM : State.StateM.S) = struct
     let+ () =
       State.register_thread_exit (fun () ->
           let* fn = State.lookup_fn dtor in
-          let* _ = fun_exec fn [ arg ] in
-          ok ())
+          map ignore @@ fun_exec fn [ arg ])
     in
     Tuple []
 
-  let[@inline] fn_to_stub fun_exec = function
+  (** [__cxa_thread_atexit_impl: Option<extern "C" fn(...)>] is a weak symbol we
+      don't link against, so it reads as [None]; the destructor registration
+      then takes its fallback (`register_dtor_fallback`) path. *)
+  let cxa_thread_atexit_impl ~(fun_sig : Types.fun_sig) _args =
+    ok (mk_enum ~ty:fun_sig.output "None" [])
+
+  (** [__dso_handle: *mut u8] is likewise an unlinked weak symbol, i.e. null. *)
+  let dso_handle _args = ok (Ptr (Sptr.null (), Thin))
+
+  (** [pthread_key_create] takes a key out-pointer and an optional destructor.
+      We don't model pthread TLS storage, so any non-sentinel key works; std
+      asserts the created key isn't [KEY_SENTVAL] (0), so we write [1]. The
+      key's destructor (which ignores its argument and just drains the
+      thread-local destructor list) is registered to run at thread exit. *)
+  let pthread_key_create ~fun_exec args =
+    let key, dtor =
+      match args with
+      | [ Ptr key; dtor ] -> (key, dtor)
+      | _ -> failwith "pthread_key_create: unexpected arguments"
+    in
+    let* () = State.store key (TLiteral (TUInt U32)) (Int U32.(1s)) in
+    let+ () =
+      match dtor with
+      | Ptr dtor | Enum (_, [ Ptr dtor ]) ->
+          State.register_thread_exit (fun () ->
+              let* fn = State.lookup_fn dtor in
+              map ignore @@ fun_exec fn [ Ptr (Sptr.null (), Thin) ])
+      | _ -> ok () (* [None]: no destructor to register *)
+    in
+    Int U32.(0s)
+
+  (** [pthread_setspecific]/[pthread_key_delete] only manage the (unmodelled)
+      TLS storage and marker; returning success is enough. *)
+  let pthread_key_noop _args = ok (Int U32.(0s))
+
+  let[@inline] fn_to_stub fun_sig fun_exec = function
     | TlvAtexit -> tlv_atexit ~fun_exec
+    | CxaThreadAtexitImpl -> cxa_thread_atexit_impl ~fun_sig
+    | DsoHandle -> dso_handle
+    | PthreadKeyCreate -> pthread_key_create ~fun_exec
+    | PthreadKeyNoop -> pthread_key_noop
 end

--- a/soteria-rust/lib/builtins/extern/system.ml
+++ b/soteria-rust/lib/builtins/extern/system.ml
@@ -1,0 +1,35 @@
+open Rust_val
+
+type fn = TlvAtexit
+
+let fn_pats = [ ("_tlv_atexit", TlvAtexit) ]
+
+module M (StateM : State.StateM.S) = struct
+  open StateM
+  open Syntax
+
+  (** Used on macOS to register thread local destructors; receives a function
+      pointer and an argument. Should call the destructor with the argument at
+      the end of the thread.
+
+      [_tlv_atexit(dtor: unsafe extern "C" fn( *mut u8), arg: *mut u8)] *)
+  let tlv_atexit ~fun_exec args =
+    let* dtor, arg =
+      match args with
+      | [ Ptr dtor_ptr; arg_ptr ] -> ok (dtor_ptr, arg_ptr)
+      | _ ->
+          Fmt.kstr not_impl "tlv_atexit: unexpected arguments: %a"
+            Fmt.(list pp_rust_val)
+            args
+    in
+    let+ () =
+      State.register_thread_exit (fun () ->
+          let* fn = State.lookup_fn dtor in
+          let* _ = fun_exec fn [ arg ] in
+          ok ())
+    in
+    Tuple []
+
+  let[@inline] fn_to_stub fun_exec = function
+    | TlvAtexit -> tlv_atexit ~fun_exec
+end

--- a/soteria-rust/lib/builtins/extern/system.ml
+++ b/soteria-rust/lib/builtins/extern/system.ml
@@ -39,7 +39,7 @@ module M (StateM : State.StateM.S) = struct
       match args with
       | [ Ptr dtor_ptr; arg_ptr ] -> ok (dtor_ptr, arg_ptr)
       | _ ->
-          Fmt.kstr not_impl "tlv_atexit: unexpected arguments: %a"
+          not_impl "tlv_atexit: unexpected arguments: %a"
             Fmt.(list pp_rust_val)
             args
     in

--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -147,6 +147,9 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
       ok (Tuple [ curr; Int (BV.of_bool Typed.v_true) ])
     else ok (Tuple [ curr; Int (BV.of_bool Typed.v_false) ])
 
+  (* In our sequential model the strong compare-exchange behaves exactly like
+     the weak one (the weak variant is only allowed to spuriously fail). *)
+  let atomic_cxchg = atomic_cxchgweak
   let black_box ~t:_ ~dummy = ok dummy
   let breakpoint () : unit ret = error `Breakpoint
 

--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -93,39 +93,6 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let+ () = State.store dst t src in
     old
 
-  let atomic_xadd ~t ~(u : Types.ty) ~ord:_ ~(dst : full_ptr) ~(src : rust_val)
-      =
-    atomic_warn ();
-    let* old = State.load dst t in
-    match (t, u) with
-    (* - `T` must be an integer or pointer *)
-    (* - `U` must be the same as `T`if it is an integer, or `usize` if it is a pointer. *)
-    | (TRawPtr _ | TRef _), TLiteral (TUInt Usize) ->
-        (* The operation adds `src` without multiplying by the size of the
-           data. *)
-        let src = as_base_i Usize src in
-        let old_v =
-          match as_ptr old with
-          | old, Thin -> old
-          | _ -> L.failwith "atomic_xadd: pointer with metadata other than Thin"
-        in
-        (* Wrapping add: no overflow check *)
-        let* new_ = Sptr.offset ~check:false ~signed:false src old_v in
-        let new_ = Ptr (new_, Thin) in
-        let* () = State.store dst t new_ in
-        ok old
-    | TLiteral lit, TLiteral lit' when Types.equal_literal_type lit lit' ->
-        let src = as_base lit src in
-        let old_v = as_base lit old in
-        (* Wrapping add. *)
-        let* new_ = Core.eval_lit_binop (Add OWrap) lit old_v src in
-        let+ () = State.store dst t (Int new_) in
-        old
-    | _ ->
-        L.failwith
-          "atomic_xadd: invalid types, expects to follow the rules of \
-           atomic_xadd"
-
   let atomic_cxchgweak ~t ~ord_succ:_ ~ord_fail:_ ~dst ~old ~src =
     atomic_warn ();
     let* curr = State.load dst t in
@@ -150,6 +117,92 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
   (* In our sequential model the strong compare-exchange behaves exactly like
      the weak one (the weak variant is only allowed to spuriously fail). *)
   let atomic_cxchg = atomic_cxchgweak
+
+  (* Atomic read-modify-write for the intrinsics whose [T] may be an integer or
+     a pointer (these take a [u] type parameter, [usize] for pointers). [int_op]
+     computes the new integer value; [ptr_op] the new pointer from [src] (a
+     [usize]) and the old pointer. (Executed sequentially -- see
+     {!atomic_warn}.) *)
+  let atomic_rmw ~(t : Types.ty) ~(u : Types.ty) ~dst ~src ~int_op ~ptr_op =
+    atomic_warn ();
+    let* old = State.load dst t in
+    match (t, u) with
+    | (TRawPtr _ | TRef _), TLiteral (TUInt Usize) ->
+        let old_ptr, meta = as_ptr old in
+        let* new_ptr = ptr_op (as_base_i Usize src) old_ptr in
+        let+ () = State.store dst t (Ptr (new_ptr, meta)) in
+        old
+    | TLiteral lit, _ ->
+        let* res = int_op lit (as_base lit old) (as_base lit src) in
+        let+ () = State.store dst t (Int res) in
+        old
+    | _ -> not_impl "atomic read-modify-write on unexpected type %a" pp_ty t
+
+  (* The pointer case of a bitwise atomic: apply [op] to the pointer's address,
+     dropping provenance -- like {!ptr_mask}. *)
+  let atomic_addr_op op src old =
+    let+ addr = Sptr.decay old in
+    Sptr.of_address (op addr src)
+
+  let atomic_and ~t ~u ~ord:_ ~dst ~src =
+    atomic_rmw ~t ~u ~dst ~src
+      ~int_op:(fun _ a b -> ok (a &@ b))
+      ~ptr_op:(atomic_addr_op ( &@ ))
+
+  let atomic_or ~t ~u ~ord:_ ~dst ~src =
+    atomic_rmw ~t ~u ~dst ~src
+      ~int_op:(fun _ a b -> ok (a |@ b))
+      ~ptr_op:(atomic_addr_op ( |@ ))
+
+  let atomic_xor ~t ~u ~ord:_ ~dst ~src =
+    atomic_rmw ~t ~u ~dst ~src
+      ~int_op:(fun _ a b -> ok (a ^@ b))
+      ~ptr_op:(atomic_addr_op ( ^@ ))
+
+  let atomic_nand ~t ~u ~ord:_ ~dst ~src =
+    let nand a b = BV.not (a &@ b) in
+    atomic_rmw ~t ~u ~dst ~src
+      ~int_op:(fun _ a b -> ok (nand a b))
+      ~ptr_op:(atomic_addr_op nand)
+
+  let atomic_xadd ~t ~u ~ord:_ ~dst ~src =
+    atomic_rmw ~t ~u ~dst ~src
+      ~int_op:(fun lit a b -> Core.eval_lit_binop (Add OWrap) lit a b)
+      ~ptr_op:(fun src old -> Sptr.offset ~check:false ~signed:false src old)
+
+  let atomic_xsub ~t ~u ~ord:_ ~dst ~src =
+    atomic_rmw ~t ~u ~dst ~src
+      ~int_op:(fun lit a b -> Core.eval_lit_binop (Sub OWrap) lit a b)
+        (* subtract [src] bytes by offsetting by [-src] *)
+      ~ptr_op:(fun src old -> Sptr.offset ~check:false ~signed:false ~-!src old)
+
+  (* Atomic read-modify-write on an integer (the min/max intrinsics, which only
+     apply to integers). *)
+  let atomic_int_rmw ~(t : Types.ty) ~dst ~src f =
+    atomic_warn ();
+    match t with
+    | TLiteral lit ->
+        let* old = State.load dst t in
+        let+ () =
+          State.store dst t (Int (f (as_base lit old) (as_base lit src)))
+        in
+        old
+    | _ -> not_impl "atomic read-modify-write on non-integer type %a" pp_ty t
+
+  (* [atomic_{min,max}] are guaranteed (signed) integers, [atomic_u{min,max}]
+     unsigned integers. *)
+  let atomic_max ~t ~ord:_ ~dst ~src =
+    atomic_int_rmw ~t ~dst ~src (BV.max ~signed:true)
+
+  let atomic_min ~t ~ord:_ ~dst ~src =
+    atomic_int_rmw ~t ~dst ~src (BV.min ~signed:true)
+
+  let atomic_umax ~t ~ord:_ ~dst ~src =
+    atomic_int_rmw ~t ~dst ~src (BV.max ~signed:false)
+
+  let atomic_umin ~t ~ord:_ ~dst ~src =
+    atomic_int_rmw ~t ~dst ~src (BV.min ~signed:false)
+
   let black_box ~t:_ ~dummy = ok dummy
   let breakpoint () : unit ret = error `Breakpoint
 

--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -897,11 +897,6 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
 
   let transmute ~t_src ~dst ~src = State.transmute ~from:t_src ~to_:dst src
 
-  let type_id ~t =
-    (* lazy but works *)
-    let hash = Hashtbl.hash t in
-    ok (Int (BV.u128i hash))
-
   let type_name ~t =
     let str = Fmt.to_to_string pp_ty t in
     Core.string_to_ptr str

--- a/soteria-rust/lib/builtins/intrinsics/intf.ml
+++ b/soteria-rust/lib/builtins/intrinsics/intf.ml
@@ -2871,20 +2871,6 @@ module M (StateM : State.StateM.S) = struct
     val truncf64 : x:[< Typed.T.sfloat ] Typed.t -> Typed.T.sfloat Typed.t ret
 
     (** {@markdown[
-          Gets an identifier which is globally unique to the specified type. This
-           function will return the same value for a type regardless of whichever
-           crate it is invoked in.
-
-           Note that, unlike most intrinsics, this can only be called at compile-time
-           as backends do not have an implementation for it. The only caller (its
-           stable counterpart) wraps this intrinsic call in a `const` block so that
-           backends only see an evaluated constant.
-
-           The stabilized version of this intrinsic is [`core::any::TypeId::of`].
-        ]} *)
-    val type_id : t:Types.ty -> rust_val ret
-
-    (** {@markdown[
           Tests (at compile-time) if two [`crate::any::TypeId`] instances identify the
            same type. This is necessary because at const-eval time the actual discriminating
            data is opaque and cannot be inspected directly.

--- a/soteria-rust/lib/builtins/intrinsics/intrinsics.ml
+++ b/soteria-rust/lib/builtins/intrinsics/intrinsics.ml
@@ -719,7 +719,6 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
         let x = as_base_f F64 x in
         let+ ret = truncf64 ~x in
         Float ret
-    | "type_id", [ t ], [], [] -> type_id ~t
     | "type_id_eq", [], [], [ a; b ] ->
         let+ ret = type_id_eq ~a ~b in
         Int (Typed.BitVec.of_bool ret)

--- a/soteria-rust/lib/builtins/intrinsics/stubs.ml
+++ b/soteria-rust/lib/builtins/intrinsics/stubs.ml
@@ -382,7 +382,6 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
   let truncf16 ~x:_ = not_impl "Unsupported intrinsic: truncf16"
   let truncf32 ~x:_ = not_impl "Unsupported intrinsic: truncf32"
   let truncf64 ~x:_ = not_impl "Unsupported intrinsic: truncf64"
-  let type_id ~t:_ = not_impl "Unsupported intrinsic: type_id"
   let type_id_eq ~a:_ ~b:_ = not_impl "Unsupported intrinsic: type_id_eq"
 
   let type_id_field_representing_type ~id:_ ~variant_index:_ ~field_index:_ =

--- a/soteria-rust/lib/builtins/optim/optim.ml
+++ b/soteria-rust/lib/builtins/optim/optim.ml
@@ -53,6 +53,7 @@ type fn =
 let fn_pats : (string * fn) list =
   [
     ("alloc::alloc::Global::alloc_impl", AllocAllocGlobalAllocImpl);
+    ("std::alloc::Global::alloc_impl", AllocAllocGlobalAllocImpl);
     ("alloc::alloc::handle_alloc_error", AllocAllocHandleAllocError);
     ("alloc::raw_vec::handle_error", AllocRawVecHandleError);
     ("core::f128::_::is_finite", CoreF128IsFinite);

--- a/soteria-rust/lib/builtins/stubs.json
+++ b/soteria-rust/lib/builtins/stubs.json
@@ -10,10 +10,6 @@
   ],
   "System": [
     {
-      "pattern": "std::sys::thread_local::guard::apple::enable::_tlv_atexit",
-      "extra_args": ["fun_exec"]
-    },
-    {
       "pattern": "std::sys::random::hashmap_random_keys",
       "extra_args": ["sig"]
     },
@@ -23,12 +19,19 @@
       "extra_args": ["sig"]
     },
     "std::sys::time::unix::Instant::now",
-    { "pattern": "std::env::_var", "extra_args": ["sig"] }
+    {
+      "pattern": "std::env::var::inner",
+      "extra_args": ["sig"],
+      "include": "std::env::var"
+    }
   ],
   "Optim": {
     "features": ["f16", "f128", "const_index"],
     "patterns": [
-      "alloc::alloc::Global::alloc_impl",
+      {
+        "pattern": "alloc::alloc::Global::alloc_impl",
+        "aliases": ["std::alloc::Global::alloc_impl"]
+      },
       "core::f16::_::is_finite",
       "core::f16::_::is_infinite",
       "core::f16::_::is_nan",

--- a/soteria-rust/lib/builtins/system/impl.ml
+++ b/soteria-rust/lib/builtins/system/impl.ml
@@ -8,34 +8,12 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
   let hashmap_random_keys ~(fun_sig : Types.fun_sig) =
     Encoder.nondet_valid fun_sig.output
 
-  (** Used on macOS to register thread local destructors; receives a function
-      pointer and an argument. Should call the destructor with the argument at
-      the end of the thread.
-
-      [_tlv_atexit(dtor: unsafe extern "C" fn( *mut u8), arg: *mut u8)] *)
-  let _tlv_atexit ~fun_exec ~args =
-    let* dtor, arg =
-      match args with
-      | [ Ptr dtor_ptr; arg_ptr ] -> ok (dtor_ptr, arg_ptr)
-      | _ ->
-          not_impl "tlv_atexit: unexpected arguments: %a"
-            Fmt.(list pp_rust_val)
-            args
-    in
-    let+ () =
-      State.register_thread_exit (fun () ->
-          let* fn = State.lookup_fn dtor in
-          let* _ = fun_exec fn [ arg ] in
-          ok ())
-    in
-    Tuple []
-
   (** {@rust[
         fn _var(key: &OsStr) -> Result<String, VarError>
       ]}
       HACK: we assume that hitting the environment never finds the variable
       we're looking for. Under-approximating behaviour. *)
-  let _var ~(fun_sig : Types.fun_sig) ~key:_ =
+  let inner ~(fun_sig : Types.fun_sig) ~key:_ =
     let var_error_ty =
       match fun_sig.output with
       | TAdt { id = TAdtId id; _ } -> (

--- a/soteria-rust/lib/builtins/system/intf.ml
+++ b/soteria-rust/lib/builtins/system/intf.ml
@@ -15,9 +15,6 @@ module M (StateM : State.StateM.S) = struct
   type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   module type S = sig
-    val _tlv_atexit : fun_exec:fun_exec -> args:rust_val list -> rust_val ret
-    val _var : fun_sig:Types.fun_sig -> key:full_ptr -> rust_val ret
-
     (** {@markdown[
           Returns an estimate of the default amount of parallelism a program should use.
 
@@ -107,6 +104,7 @@ module M (StateM : State.StateM.S) = struct
     val available_parallelism : fun_sig:Types.fun_sig -> rust_val ret
 
     val hashmap_random_keys : fun_sig:Types.fun_sig -> rust_val ret
+    val inner : fun_sig:Types.fun_sig -> key:full_ptr -> rust_val ret
     val now : unit -> rust_val ret
   end
 end

--- a/soteria-rust/lib/builtins/system/system.ml
+++ b/soteria-rust/lib/builtins/system/system.ml
@@ -7,18 +7,15 @@ open Common
 open Rust_val
 
 type fn =
-  | StdEnvVar
+  | StdEnvVarInner
   | StdSysRandomHashmapRandomKeys
-  | StdSysThreadLocalGuardAppleEnableTlvAtexit
   | StdSysTimeUnixInstantNow
   | StdThreadFunctionsAvailableParallelism
 
 let fn_pats : (string * fn) list =
   [
-    ("std::env::_var", StdEnvVar);
+    ("std::env::var::inner", StdEnvVarInner);
     ("std::sys::random::hashmap_random_keys", StdSysRandomHashmapRandomKeys);
-    ( "std::sys::thread_local::guard::apple::enable::_tlv_atexit",
-      StdSysThreadLocalGuardAppleEnableTlvAtexit );
     ("std::sys::time::unix::Instant::now", StdSysTimeUnixInstantNow);
     ( "std::thread::functions::available_parallelism",
       StdThreadFunctionsAvailableParallelism );
@@ -55,13 +52,11 @@ module M (StateM : State.StateM.S) = struct
     match[@warning "-redundant-case"]
       (stub, generics.types, generics.const_generics, args)
     with
-    | StdEnvVar, [], [], [ key ] ->
+    | StdEnvVarInner, [], [], [ key ] ->
         let key = as_ptr key in
-        _var ~fun_sig:_fun_sig ~key
+        inner ~fun_sig:_fun_sig ~key
     | StdSysRandomHashmapRandomKeys, [], [], [] ->
         hashmap_random_keys ~fun_sig:_fun_sig
-    | StdSysThreadLocalGuardAppleEnableTlvAtexit, _, _, _ ->
-        _tlv_atexit ~fun_exec:_fun_exec ~args
     | StdSysTimeUnixInstantNow, [], [], [] -> now ()
     | StdThreadFunctionsAvailableParallelism, [], [], [] ->
         available_parallelism ~fun_sig:_fun_sig

--- a/soteria-rust/lib/driver.ml
+++ b/soteria-rust/lib/driver.ml
@@ -28,8 +28,7 @@ let with_exn_and_config mode config f =
       Fmt.pr "@.%s@.%a@.@." msg Unimplemented.pp
         (Unimplemented.make
            ~tip:
-             ( "If you changed compilation flags from previous runs, you may \
-                have to rebuild the plugins",
+             ( "You can try cleaning plugins and rebuilding them",
                Some "soteria-rust build-plugins [compilation flags]" )
            ~issue:388
            ("Compilation failed while " ^ info));

--- a/soteria-rust/lib/frontend.ml
+++ b/soteria-rust/lib/frontend.ml
@@ -83,6 +83,10 @@ module Lib = struct
     let config : Cmd.t = f (path, target) in
     let lib_imports =
       [
+        "--extern";
+        name lib
+        ^ "="
+        ^ (path / "target" / target / "debug" / ("lib" ^ name lib ^ ".rlib"));
         "-L" ^ (path / "target" / target / "debug" / "deps");
         "-L" ^ (path / "target" / "debug" / "deps");
       ]
@@ -146,12 +150,6 @@ let default () =
         "crate-attr=feature(register_tool)";
         "-Z";
         "crate-attr=register_tool(soteriatool)";
-        "--extern";
-        "soteria";
-        (* include the std *)
-        (* "--extern";
-        "noprelude:std="
-        ^ (std_lib_path / "target" / target / "debug" / "libstd.rlib"); *)
       ]
     ()
 
@@ -160,7 +158,7 @@ let kani () =
   Cmd.make ~features:[ "kani" ]
     ~entry_points:[ Attrib "kanitool::proof" ]
     ~expect_error:[ Attrib "kanitool::should_panic" ]
-    ~rustc:[ "-Z"; "crate-attr=register_tool(kanitool)"; "--extern"; "kani" ]
+    ~rustc:[ "-Z"; "crate-attr=register_tool(kanitool)" ]
     ()
 
 let miri () =

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -1214,7 +1214,7 @@ module Make (StateImpl : State.S) = struct
     match fundef.body with
     | IntrinsicBody (name, _arg_names) ->
         Std_funs.eval_intrinsic fundef name generics exec_fun args
-    | ExternBody name -> Std_funs.eval_extern name exec_fun args
+    | ExternBody name -> Std_funs.eval_extern fundef name exec_fun args
     | UnstructuredBody body -> (
         match Std_funs.eval_stub fundef exec_fun generics with
         | Some stub -> stub args

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -1214,7 +1214,7 @@ module Make (StateImpl : State.S) = struct
     match fundef.body with
     | IntrinsicBody (name, _arg_names) ->
         Std_funs.eval_intrinsic fundef name generics exec_fun args
-    | ExternBody name -> Std_funs.eval_extern name args
+    | ExternBody name -> Std_funs.eval_extern name exec_fun args
     | UnstructuredBody body -> (
         match Std_funs.eval_stub fundef exec_fun generics with
         | Some stub -> stub args

--- a/soteria-rust/lib/layout.ml
+++ b/soteria-rust/lib/layout.ml
@@ -78,6 +78,21 @@ let rec dst_slice_ty : Types.ty -> Types.ty option = function
 (** If this is a dynamically sized type (requiring a fat pointer) *)
 let is_dst ty = dst_kind ty <> NoneKind
 
+(** The [Pointee::Metadata] associated type of a pointer to [pointee]: [()] for
+    sized types, [usize] for slices and [str], and [DynMetadata<Dyn>] for trait
+    objects. *)
+let pointee_metadata (pointee : Types.ty) : Types.ty =
+  match dst_kind pointee with
+  | NoneKind -> TypesUtils.mk_unit_ty
+  | LenKind -> TLiteral (TUInt Usize)
+  | VTableKind ->
+      let adt = Crate.get_adt_lang_item "dyn_metadata" in
+      TAdt
+        {
+          id = TAdtId adt.def_id;
+          generics = TypesUtils.mk_generic_args_from_types [ pointee ];
+        }
+
 let[@inline] size_to_fit ~size ~align =
   Typed.ite
     (size %@ align ==@ Usize.(0s))
@@ -380,6 +395,9 @@ and resolve_trait_ty (tref : Types.trait_ref) assoc_ty_id args =
       let trait_assoc_ty = Types.AssocTypeId.Map.find assoc_ty_id impl.types in
       (* HACK: we skip the binder here! *)
       ok trait_assoc_ty.binder_value.value
+  | BuiltinOrAuto (BuiltinPointee, _, _) ->
+      let pointee = List.hd tref.trait_decl_ref.binder_value.generics.types in
+      ok (pointee_metadata pointee)
   | _ -> not_impl_layout "trait type" (TTraitType (tref, assoc_ty_id, args))
 
 (** Normalise a type, by substituting any generics with the current generic

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -762,13 +762,10 @@ module Make (Borrows : Tree_borrows.T) = struct
       let@ () = with_loc_err ~trace:"Pointer offset" () in
       let**^ size = Layout.size_of ty in
       let loc, off = Typed.Ptr.decompose ptr in
-      let ( *? ), ( +? ) =
-        if signed then (( *$?@ ), ( +$?@ )) else (( *?@ ), ( +?@ ))
-      in
-      let off_by, off_by_ovf = size *? off_by in
-      let off, off_ovf = off +? off_by in
-      let++ () =
+      let++ off =
         if check then
+          let off_by, off_by_ovf = Typed.BV.mul_checked ~signed size off_by in
+          let off, off_ovf = Typed.BV.add_checked ~signed off off_by in
           let** () =
             assert_or_error
               (off_by
@@ -776,8 +773,14 @@ module Make (Borrows : Tree_borrows.T) = struct
               ||@ (Typed.not off_by_ovf &&@ Typed.not off_ovf))
               `UBDanglingPointer
           in
-          check_non_dangling_untyped (fptr, Thin) off_by
-        else Result.ok ()
+          let++ () = check_non_dangling_untyped (fptr, Thin) off_by in
+          off
+        else
+          (* we use the unchecked, possibly overflowing version of the
+             operators, as wrapping is permitted dhere. *)
+          let off_by = size *!@ off_by in
+          let off = off +!@ off_by in
+          Result.ok off
       in
       let ptr' = Typed.Ptr.mk loc off in
       { fptr with ptr = ptr' }

--- a/soteria-rust/test/cram/kani.t/run.t
+++ b/soteria-rust/test/cram/kani.t/run.t
@@ -228,18 +228,24 @@ Test our simple Kani demo works
   => Running demo::memory_leak...
   error: demo::memory_leak: found issues in <time>, errors in 1 branch (out of 1)
   warning: Memory leak in demo::memory_leak
-      --> $RUSTLIB/library/alloc/src/alloc.rs:449:9
-  449 |          self.alloc_impl(layout, false)
-      |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      |          |
-      |          Triggering operation
-      |          5: Allocation
+      --> $RUSTLIB/library/alloc/src/alloc.rs:101:9
+  101 |            __rust_alloc(layout.size(), layout.alignment())
+      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |            |
+      |            Triggering operation
+      |            5: Allocation
+      .    
+  331 |        const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
+  332 | /          core::intrinsics::const_eval_select(
+  333 | |              (layout, zeroed),
+  334 | |              Global::alloc_impl_const,
+  335 | |              Global::alloc_impl_runtime,
+  336 | |          )
+      | \----------' 4: Call trace
+  337 |        }
       --> $RUSTLIB/library/alloc/src/boxed.rs:286:19
-  248 |      match Global.allocate(layout) {
-      |            ----------------------- 4: Call trace
-      .  
-  286 |          let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
-      |                    -------------------------------------------------- 3: Call trace
+  286 |            let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
+      |                      -------------------------------------------------- 3: Call trace
       --> $TESTCASE_ROOT/demo.rs:33:21
    32 |    fn memory_leak() {
       |    ---------------- 1: Leaking function

--- a/soteria-rust/test/cram/kani.t/run.t
+++ b/soteria-rust/test/cram/kani.t/run.t
@@ -228,24 +228,18 @@ Test our simple Kani demo works
   => Running demo::memory_leak...
   error: demo::memory_leak: found issues in <time>, errors in 1 branch (out of 1)
   warning: Memory leak in demo::memory_leak
-      --> $RUSTLIB/library/alloc/src/alloc.rs:101:9
-  101 |            __rust_alloc(layout.size(), layout.alignment())
-      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      |            |
-      |            Triggering operation
-      |            5: Allocation
-      .    
-  331 |        const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
-  332 | /          core::intrinsics::const_eval_select(
-  333 | |              (layout, zeroed),
-  334 | |              Global::alloc_impl_const,
-  335 | |              Global::alloc_impl_runtime,
-  336 | |          )
-      | \----------' 4: Call trace
-  337 |        }
+      --> $RUSTLIB/library/alloc/src/alloc.rs:449:9
+  449 |          self.alloc_impl(layout, false)
+      |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |          |
+      |          Triggering operation
+      |          5: Allocation
       --> $RUSTLIB/library/alloc/src/boxed.rs:286:19
-  286 |            let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
-      |                      -------------------------------------------------- 3: Call trace
+  248 |      match Global.allocate(layout) {
+      |            ----------------------- 4: Call trace
+      .  
+  286 |          let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
+      |                    -------------------------------------------------- 3: Call trace
       --> $TESTCASE_ROOT/demo.rs:33:21
    32 |    fn memory_leak() {
       |    ---------------- 1: Leaking function

--- a/soteria-rust/test/cram/perf.t/writealot.rs
+++ b/soteria-rust/test/cram/perf.t/writealot.rs
@@ -62,31 +62,16 @@ macro_rules! access {
         access!($x, 8000);
         access!($x, 2000);
     };
-    ($x:expr, 20000) => {
-        access!($x, 10000);
-        access!($x, 10000);
-    };
-    ($x:expr, 40000) => {
-        access!($x, 20000);
-        access!($x, 20000);
-    };
-    ($x:expr, 80000) => {
-        access!($x, 40000);
-        access!($x, 40000);
-    };
-    ($x:expr, 100000) => {
-        access!($x, 80000);
-        access!($x, 20000);
-    };
 }
 
 fn access(x: &mut u32) {
-    access!(x, 100000);
-    access!(x, 100000);
+    for _ in 0..20 {
+        access!(x, 10000);
+    }
 }
 
 fn main() {
     let mut x = 0;
     access(&mut x);
-    assert_eq!(x, 2_000_000);
+    assert_eq!(x, 200_000);
 }

--- a/soteria-rust/test/cram/poly.t/run.t
+++ b/soteria-rust/test/cram/poly.t/run.t
@@ -138,8 +138,6 @@ Test linked lists, to ensure dropping the list works despite the generic type
         ((0b000 == extract[0-2](V|1|)) || (0xfffffffffffffff0 <s ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) /\
         !(((0b000 == extract[0-2](V|1|)) ? ((0b000 != extract[0-2](V|1|)) && (V|1| <s ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) : ((0b000 == extract[0-2](V|1|)) && (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || (0x0000000000000000 <s ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) /\
-        ((0b000 == extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) != 0xfffffffffffffff0)) /\
-        ((0b000 == extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) != 0xfffffffffffffff0)) /\
         (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x00000000000003ff) /\
         (0x0000000000000008 <=u V|2|) /\
         (V|1| == ((0b000 == extract[0-2](V|1|)) ? V|1| : ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) /\
@@ -172,8 +170,6 @@ Test linked lists, to ensure dropping the list works despite the generic type
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) ? ((0b000 == extract[0-2](V|1|)) || (V|1| <s (0x0000000000000010 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|)))))) : ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000010 +ck V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
-        ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
-        ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         !(((0b000 == extract[0-2](V|1|)) ? ((0b000 != extract[0-2](V|1|)) && ((0x0000000000000008 +ck V|1|) <s ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) : ((0b000 == extract[0-2](V|1|)) && ((0x0000000000000008 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|)))) <s V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         (((0b000 == extract[0-2](V|1|)) ? (0x0000000000000010 +ck V|1|) : (0x0000000000000010 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) != ((0b000 == extract[0-2](V|1|)) ? (0x0000000000000008 +ck V|1|) : (0x0000000000000008 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|)))))) /\
@@ -189,8 +185,6 @@ Test linked lists, to ensure dropping the list works despite the generic type
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
-        ((0b000 == extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) != 0xfffffffffffffff0)) /\
-        ((0b000 == extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) != 0xfffffffffffffff0)) /\
         (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x00000000000003ff) /\
         (0x0000000000000008 <=u V|2|) /\
         (((0b000 == extract[0-2](V|1|)) ? (0x0000000000000010 +ck V|1|) : (0x0000000000000010 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) == (((0b000 == extract[0-2](V|1|)) ? (0b000 == extract[0-2](V|1|)) : (0b000 == extract[0-2](((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|)))))) ? ((0b000 == extract[0-2](V|1|)) ? (0x0000000000000010 +ck V|1|) : (0x0000000000000010 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) : (((0b000 == extract[0-2](V|1|)) ? (0x0000000000000018 +ck V|1|) : (0x0000000000000018 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) -ck ((0b000 == extract[0-2](V|1|)) ? extend[u61](extract[0-2](V|1|)) : extend[u61](extract[0-2](((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))))))) /\

--- a/soteria-rust/test/cram/poly.t/run.t
+++ b/soteria-rust/test/cram/poly.t/run.t
@@ -138,6 +138,8 @@ Test linked lists, to ensure dropping the list works despite the generic type
         ((0b000 == extract[0-2](V|1|)) || (0xfffffffffffffff0 <s ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) /\
         !(((0b000 == extract[0-2](V|1|)) ? ((0b000 != extract[0-2](V|1|)) && (V|1| <s ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) : ((0b000 == extract[0-2](V|1|)) && (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || (0x0000000000000000 <s ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) /\
+        ((0b000 == extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) != 0xfffffffffffffff0)) /\
+        ((0b000 == extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) != 0xfffffffffffffff0)) /\
         (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x00000000000003ff) /\
         (0x0000000000000008 <=u V|2|) /\
         (V|1| == ((0b000 == extract[0-2](V|1|)) ? V|1| : ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) /\
@@ -170,6 +172,8 @@ Test linked lists, to ensure dropping the list works despite the generic type
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) ? ((0b000 == extract[0-2](V|1|)) || (V|1| <s (0x0000000000000010 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|)))))) : ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000010 +ck V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
+        ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
+        ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         !(((0b000 == extract[0-2](V|1|)) ? ((0b000 != extract[0-2](V|1|)) && ((0x0000000000000008 +ck V|1|) <s ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) : ((0b000 == extract[0-2](V|1|)) && ((0x0000000000000008 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|)))) <s V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         (((0b000 == extract[0-2](V|1|)) ? (0x0000000000000010 +ck V|1|) : (0x0000000000000010 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) != ((0b000 == extract[0-2](V|1|)) ? (0x0000000000000008 +ck V|1|) : (0x0000000000000008 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|)))))) /\
@@ -185,6 +189,8 @@ Test linked lists, to ensure dropping the list works despite the generic type
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
         ((0b000 == extract[0-2](V|1|)) || ((0b000 != extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) <s (0x0000000000000008 +ck V|1|)))) /\
+        ((0b000 == extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) != 0xfffffffffffffff0)) /\
+        ((0b000 == extract[0-2](V|1|)) || (((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))) != 0xfffffffffffffff0)) /\
         (0x0000000000000001 <=u V|1|) /\ (V|1| <=u 0x00000000000003ff) /\
         (0x0000000000000008 <=u V|2|) /\
         (((0b000 == extract[0-2](V|1|)) ? (0x0000000000000010 +ck V|1|) : (0x0000000000000010 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) == (((0b000 == extract[0-2](V|1|)) ? (0b000 == extract[0-2](V|1|)) : (0b000 == extract[0-2](((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|)))))) ? ((0b000 == extract[0-2](V|1|)) ? (0x0000000000000010 +ck V|1|) : (0x0000000000000010 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) : (((0b000 == extract[0-2](V|1|)) ? (0x0000000000000018 +ck V|1|) : (0x0000000000000018 +ck ((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))) -ck ((0b000 == extract[0-2](V|1|)) ? extend[u61](extract[0-2](V|1|)) : extend[u61](extract[0-2](((0x0000000000000008 +ck V|1|) -ck extend[u61](extract[0-2](V|1|))))))))) /\

--- a/soteria-rust/test/cram/simple.t/atomics.rs
+++ b/soteria-rust/test/cram/simple.t/atomics.rs
@@ -1,0 +1,45 @@
+#![feature(strict_provenance_atomic_ptr)]
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU32, Ordering::SeqCst};
+
+#[soteria::test]
+fn bitwise() {
+    let a = AtomicU32::new(0b1100);
+    assert!(a.fetch_and(0b1010, SeqCst) == 0b1100);
+    assert!(a.fetch_or(0b0001, SeqCst) == 0b1000);
+    assert!(a.fetch_xor(0b1111, SeqCst) == 0b1001);
+    assert!(a.load(SeqCst) == 0b0110);
+
+    let b = AtomicBool::new(true);
+    assert!(b.fetch_nand(true, SeqCst) == true);
+    assert!(b.load(SeqCst) == false);
+}
+
+#[soteria::test]
+fn min_max_sub() {
+    let a = AtomicU32::new(10);
+    assert!(a.fetch_sub(3, SeqCst) == 10);
+    assert!(a.fetch_max(20, SeqCst) == 7);
+    assert!(a.fetch_min(5, SeqCst) == 20);
+    assert!(a.load(SeqCst) == 5);
+
+    // unsigned comparison: u32::MAX is the largest value
+    let u = AtomicU32::new(1);
+    assert!(u.fetch_max(u32::MAX, SeqCst) == 1);
+    assert!(u.load(SeqCst) == u32::MAX);
+
+    // signed comparison: -10 < 2
+    let s = AtomicI32::new(-3);
+    assert!(s.fetch_max(2, SeqCst) == -3);
+    assert!(s.fetch_min(-10, SeqCst) == 2);
+    assert!(s.load(SeqCst) == -10);
+}
+
+#[soteria::test]
+fn pointer() {
+    // Bitwise atomics on a pointer operate on its address.
+    let q = AtomicPtr::<u8>::new(std::ptr::without_provenance_mut(0b1100));
+    assert!(q.fetch_or(0b0011, SeqCst).addr() == 0b1100);
+    assert!(q.fetch_and(0b1010, SeqCst).addr() == 0b1111);
+    assert!(q.fetch_xor(0b0101, SeqCst).addr() == 0b1010);
+    assert!(q.load(SeqCst).addr() == 0b1111);
+}

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -636,7 +636,7 @@ Boolean BitOr must not be assumed true; both operands can be false (issue #376).
   [1]
 
 Test that allocating a box only requires two heap allocation (thanks to the store optimisation): one for the contents of the box, and one for the box that we pass to the drop glue.
-FIXME: because of the sysroot, there's a bunch of extra allocations from added function calls... i'm not sure we can avoid them all.
+FIXME: now that named consts are globals, there is in fact a third allocation: the one for <i32 as SizedTypeProperties>::LAYOUT. We should extend the store optimisation to handle globals; in particular we have a guarantee they can't be written to, so it's likely the optimisation will perform really well.
   $ soteria-rust exec box.rs --stats stats.json && check_stat stats.json allocs 2
   Compiling... done in <time>
   => Running box::main...

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -4,24 +4,18 @@ Test memory leaks
   => Running leak::main...
   error: leak::main: found issues in <time>, errors in 1 branch (out of 1)
   warning: Memory leak in leak::main
-      --> $RUSTLIB/library/alloc/src/alloc.rs:101:9
-  101 |            __rust_alloc(layout.size(), layout.alignment())
-      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      |            |
-      |            Triggering operation
-      |            5: Allocation
-      .    
-  331 |        const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
-  332 | /          core::intrinsics::const_eval_select(
-  333 | |              (layout, zeroed),
-  334 | |              Global::alloc_impl_const,
-  335 | |              Global::alloc_impl_runtime,
-  336 | |          )
-      | \----------' 4: Call trace
-  337 |        }
+      --> $RUSTLIB/library/alloc/src/alloc.rs:449:9
+  449 |          self.alloc_impl(layout, false)
+      |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |          |
+      |          Triggering operation
+      |          5: Allocation
       --> $RUSTLIB/library/alloc/src/boxed.rs:286:19
-  286 |            let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
-      |                      -------------------------------------------------- 3: Call trace
+  248 |      match Global.allocate(layout) {
+      |            ----------------------- 4: Call trace
+      .  
+  286 |          let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
+      |                    -------------------------------------------------- 3: Call trace
       --> $TESTCASE_ROOT/leak.rs:2:22
     1 |    fn main() {
       |    --------- 1: Leaking function
@@ -246,24 +240,19 @@ Test thread local statics; the two warnings due to opaque functions are to be ex
   PC 1: empty
   
   => Running thread_local::static_ref_cell...
-  warning: thread_local::static_ref_cell (<time>): an unsupported feature was reached
-  Can't execute function std::sys::thread_local::destructors::list::register, try using a sysroot (--sysroot)
-  
-  tip: to get a sysroot, run
-       cargo +nightly-2026-06-01 miri setup --print-sysroot
-  
-  This is tracked at https://github.com/soteria-tools/soteria/issues/322
+  note: thread_local::static_ref_cell: done in <time>, ran 1 branch
+  PC 1: Distinct(V|1-2|) /\ (0x0000000000000010 <=u V|1|) /\
+        (V|1| <=u 0x7fffffffffffffbe) /\ (0x0000000000000008 <=u V|2|) /\
+        (V|2| <=u 0x7fffffffffffffd6) /\ (0x0 == extract[0-3](V|1|)) /\
+        (0b000 == extract[0-2](V|2|))
   
   => Running thread_local::pub_static_from_const_expr...
-  warning: thread_local::pub_static_from_const_expr (<time>): an unsupported feature was reached
-  Can't execute function std::sys::thread_local::destructors::list::register, try using a sysroot (--sysroot)
+  note: thread_local::pub_static_from_const_expr: done in <time>, ran 1 branch
+  PC 1: Distinct(V|1-2|) /\ (0x0000000000000010 <=u V|1|) /\
+        (V|1| <=u 0x7fffffffffffffbe) /\ (0x0000000000000008 <=u V|2|) /\
+        (V|2| <=u 0x7fffffffffffffd6) /\ (0x0 == extract[0-3](V|1|)) /\
+        (0b000 == extract[0-2](V|2|))
   
-  tip: to get a sysroot, run
-       cargo +nightly-2026-06-01 miri setup --print-sysroot
-  
-  This is tracked at https://github.com/soteria-tools/soteria/issues/322
-  
-  [2]
 
 This test must be run separtely on linux and macos as it yields different error messages.
   $ soteria-rust exec thread_local.rs --target x86_64-unknown-linux-gnu
@@ -273,24 +262,24 @@ This test must be run separtely on linux and macos as it yields different error 
   PC 1: empty
   
   => Running thread_local::static_ref_cell...
-  warning: thread_local::static_ref_cell (<time>): an unsupported feature was reached
-  Can't execute function std::sys::thread_local::destructors::linux_like::register, try using a sysroot (--sysroot)
-  
-  tip: to get a sysroot, run
-       cargo +nightly-2026-06-01 miri setup --print-sysroot
-  
-  This is tracked at https://github.com/soteria-tools/soteria/issues/322
+  warning: An atomic intrinsic was encountered; it will be executed as sequential code
+  note: thread_local::static_ref_cell: done in <time>, ran 1 branch
+  PC 1: Distinct(V|1-2|) /\ Distinct(V|1-3|) /\
+        (0x0000000000000010 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffe) /\
+        (0x0000000000000010 <=u V|2|) /\ (V|2| <=u 0x7fffffffffffffbe) /\
+        (0x0000000000000008 <=u V|3|) /\ (V|3| <=u 0x7fffffffffffffd6) /\
+        (0x0 == extract[0-3](V|1|)) /\ (0x0 == extract[0-3](V|2|)) /\
+        (0b000 == extract[0-2](V|3|))
   
   => Running thread_local::pub_static_from_const_expr...
-  warning: thread_local::pub_static_from_const_expr (<time>): an unsupported feature was reached
-  Can't execute function std::sys::thread_local::destructors::linux_like::register, try using a sysroot (--sysroot)
+  note: thread_local::pub_static_from_const_expr: done in <time>, ran 1 branch
+  PC 1: Distinct(V|1-2|) /\ Distinct(V|1-3|) /\
+        (0x0000000000000010 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffe) /\
+        (0x0000000000000010 <=u V|2|) /\ (V|2| <=u 0x7fffffffffffffbe) /\
+        (0x0000000000000008 <=u V|3|) /\ (V|3| <=u 0x7fffffffffffffd6) /\
+        (0x0 == extract[0-3](V|1|)) /\ (0x0 == extract[0-3](V|2|)) /\
+        (0b000 == extract[0-2](V|3|))
   
-  tip: to get a sysroot, run
-       cargo +nightly-2026-06-01 miri setup --print-sysroot
-  
-  This is tracked at https://github.com/soteria-tools/soteria/issues/322
-  
-  [2]
 
 Test cloning ZSTs works; in particular, this generates a function with an empty body that just returns, so if we don't handle the ZST case we get an uninit access.
   $ soteria-rust exec clone_zst.rs
@@ -473,41 +462,57 @@ Print the callgraph
   digraph callgraph {
     node [shape=box fontname="monospace"];
     n0 [label="Range<A>>::next" tooltip="std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next::<i32>"];
-    n13 [label="io::_print" tooltip="std::io::_print"];
-    n7 [label="callgraph::limit" tooltip="callgraph::limit"];
-    n2 [label="callgraph::choose" tooltip="callgraph::choose"];
-    n12 [label="callgraph::main" tooltip="callgraph::main"];
-    n6 [label="callgraph::run" tooltip="callgraph::run"];
-    n16 [label="Step>::forward_unchecked" tooltip="<i32 as std::iter::Step>::forward_unchecked"];
-    n3 [label="callgraph::twice" tooltip="callgraph::twice"];
-    n14 [label="Argument::<'_>::new_display" tooltip="core::fmt::rt::Argument::<'_>::new_display::<'_, i32>"];
-    n4 [label="callgraph::dec" tooltip="callgraph::dec"];
-    n8 [label="callgraph::score" tooltip="callgraph::score"];
-    n17 [label="PartialOrd for i32>::lt" tooltip="std::cmp::impls::<impl std::cmp::PartialOrd for i32>::lt"];
-    n10 [label="callgraph::ping" tooltip="callgraph::ping"];
-    n9 [label="IntoIterator>::into_iter" tooltip="<I as std::iter::IntoIterator>::into_iter::<Range::<i32>>"];
-    n15 [label="Arguments::<'a>::new" tooltip="std::fmt::Arguments::<'a>::new::<'_, 12usize, 1usize>"];
-    n11 [label="callgraph::pong" tooltip="callgraph::pong"];
-    n5 [label="callgraph::inc" tooltip="callgraph::inc"];
+    n21 [label="io::_print" tooltip="std::io::_print"];
+    n14 [label="callgraph::limit" tooltip="callgraph::limit"];
+    n8 [label="NonNull::<T>::as_ptr" tooltip="std::ptr::NonNull::<T>::as_ptr::<i32>"];
+    n24 [label="NonNull::<T>::from_ref" tooltip="std::ptr::NonNull::<T>::from_ref::<i32>"];
+    n9 [label="callgraph::choose" tooltip="callgraph::choose"];
+    n20 [label="callgraph::main" tooltip="callgraph::main"];
+    n13 [label="callgraph::run" tooltip="callgraph::run"];
+    n10 [label="callgraph::twice" tooltip="callgraph::twice"];
+    n5 [label="Option::<T>::unwrap_unchecked" tooltip="std::option::Option::<T>::unwrap_unchecked::<i32>"];
+    n4 [label="Step>::forward_unchecked" tooltip="<i32 as std::iter::Step>::forward_unchecked"];
+    n2 [label="num::<impl i32>::overflowing_add_unsigned" tooltip="core::num::<impl i32>::overflowing_add_unsigned"];
+    n22 [label="Argument::<'_>::new_display" tooltip="core::fmt::rt::Argument::<'_>::new_display::<'_, i32>"];
+    n11 [label="callgraph::dec" tooltip="callgraph::dec"];
+    n15 [label="callgraph::score" tooltip="callgraph::score"];
+    n6 [label="num::<impl i32>::checked_add_unsigned" tooltip="core::num::<impl i32>::checked_add_unsigned"];
+    n3 [label="num::<impl i32>::overflowing_add" tooltip="core::num::<impl i32>::overflowing_add"];
+    n25 [label="PartialOrd for i32>::lt" tooltip="std::cmp::impls::<impl std::cmp::PartialOrd for i32>::lt"];
+    n18 [label="callgraph::ping" tooltip="callgraph::ping"];
+    n17 [label="intrinsics::unlikely" tooltip="std::intrinsics::unlikely"];
+    n7 [label="NonNull::<T>::cast" tooltip="std::ptr::NonNull::<T>::cast::<i32, ()>"];
+    n16 [label="IntoIterator>::into_iter" tooltip="<I as std::iter::IntoIterator>::into_iter::<Range::<i32>>"];
+    n23 [label="Arguments::<'a>::new" tooltip="std::fmt::Arguments::<'a>::new::<'_, 12usize, 1usize>"];
+    n19 [label="callgraph::pong" tooltip="callgraph::pong"];
+    n12 [label="callgraph::inc" tooltip="callgraph::inc"];
     n1 [label="RangeIteratorImpl>::spec_next" tooltip="<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next::<i32>"];
     n0 -> n1;
     n2 -> n3;
-    n2 -> n4;
-    n2 -> n5;
-    n6 -> n0;
-    n6 -> n7;
-    n6 -> n8;
-    n6 -> n9;
-    n10 -> n11;
-    n12 -> n13;
-    n12 -> n6;
-    n12 -> n14;
-    n12 -> n15;
-    n8 -> n2;
-    n8 -> n10;
-    n11 -> n10;
-    n1 -> n16;
-    n1 -> n17;
+    n4 -> n5;
+    n4 -> n6;
+    n7 -> n8;
+    n9 -> n10;
+    n9 -> n11;
+    n9 -> n12;
+    n13 -> n0;
+    n13 -> n14;
+    n13 -> n15;
+    n13 -> n16;
+    n6 -> n2;
+    n6 -> n17;
+    n18 -> n19;
+    n20 -> n21;
+    n20 -> n13;
+    n20 -> n22;
+    n20 -> n23;
+    n22 -> n24;
+    n22 -> n7;
+    n15 -> n9;
+    n15 -> n18;
+    n19 -> n18;
+    n1 -> n4;
+    n1 -> n25;
   }
 
 Check we trust addresses for pointer alignment
@@ -636,14 +641,14 @@ Boolean BitOr must not be assumed true; both operands can be false (issue #376).
   [1]
 
 Test that allocating a box only requires two heap allocation (thanks to the store optimisation): one for the contents of the box, and one for the box that we pass to the drop glue.
-FIXME: now that named consts are globals, there is in fact a third allocation: the one for <i32 as SizedTypeProperties>::LAYOUT. We should extend the store optimisation to handle globals; in particular we have a guarantee they can't be written to, so it's likely the optimisation will perform really well.
+FIXME: because of the sysroot, there's a bunch of extra allocations from added function calls... i'm not sure we can avoid them all.
   $ soteria-rust exec box.rs --stats stats.json && check_stat stats.json allocs 2
   Compiling... done in <time>
   => Running box::main...
   note: box::main: done in <time>, ran 1 branch
   PC 1: empty
   
-  check_stat: expected '2', got '3' for allocs
+  check_stat: expected '2', got '7' for allocs
   [1]
 
 Test that taking a reference to a ZST doesn't allocate it on the heap; the reference is a dangling pointer, so the value stays in the store.

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -734,3 +734,19 @@ Test calls to FnOnce trait objects.
   note: box_fnonce::main: done in <time>, ran 1 branch
   PC 1: empty
   
+Test the atomic read-modify-write intrinsics (fetch_and/or/xor/nand/sub/min/max), on both integers and pointers.
+  $ soteria-rust exec atomics.rs
+  Compiling... done in <time>
+  => Running atomics::bitwise...
+  warning: An atomic intrinsic was encountered; it will be executed as sequential code
+  note: atomics::bitwise: done in <time>, ran 1 branch
+  PC 1: empty
+  
+  => Running atomics::min_max_sub...
+  note: atomics::min_max_sub: done in <time>, ran 1 branch
+  PC 1: empty
+  
+  => Running atomics::pointer...
+  note: atomics::pointer: done in <time>, ran 1 branch
+  PC 1: empty
+  

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -4,18 +4,24 @@ Test memory leaks
   => Running leak::main...
   error: leak::main: found issues in <time>, errors in 1 branch (out of 1)
   warning: Memory leak in leak::main
-      --> $RUSTLIB/library/alloc/src/alloc.rs:449:9
-  449 |          self.alloc_impl(layout, false)
-      |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      |          |
-      |          Triggering operation
-      |          5: Allocation
+      --> $RUSTLIB/library/alloc/src/alloc.rs:101:9
+  101 |            __rust_alloc(layout.size(), layout.alignment())
+      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |            |
+      |            Triggering operation
+      |            5: Allocation
+      .    
+  331 |        const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
+  332 | /          core::intrinsics::const_eval_select(
+  333 | |              (layout, zeroed),
+  334 | |              Global::alloc_impl_const,
+  335 | |              Global::alloc_impl_runtime,
+  336 | |          )
+      | \----------' 4: Call trace
+  337 |        }
       --> $RUSTLIB/library/alloc/src/boxed.rs:286:19
-  248 |      match Global.allocate(layout) {
-      |            ----------------------- 4: Call trace
-      .  
-  286 |          let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
-      |                    -------------------------------------------------- 3: Call trace
+  286 |            let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
+      |                      -------------------------------------------------- 3: Call trace
       --> $TESTCASE_ROOT/leak.rs:2:22
     1 |    fn main() {
       |    --------- 1: Leaking function
@@ -240,19 +246,24 @@ Test thread local statics; the two warnings due to opaque functions are to be ex
   PC 1: empty
   
   => Running thread_local::static_ref_cell...
-  note: thread_local::static_ref_cell: done in <time>, ran 1 branch
-  PC 1: Distinct(V|1-2|) /\ (0x0000000000000010 <=u V|1|) /\
-        (V|1| <=u 0x7fffffffffffffbe) /\ (0x0000000000000008 <=u V|2|) /\
-        (V|2| <=u 0x7fffffffffffffd6) /\ (0x0 == extract[0-3](V|1|)) /\
-        (0b000 == extract[0-2](V|2|))
+  warning: thread_local::static_ref_cell (<time>): an unsupported feature was reached
+  Can't execute function std::sys::thread_local::destructors::list::register, try using a sysroot (--sysroot)
+  
+  tip: to get a sysroot, run
+       cargo +nightly-2026-06-01 miri setup --print-sysroot
+  
+  This is tracked at https://github.com/soteria-tools/soteria/issues/322
   
   => Running thread_local::pub_static_from_const_expr...
-  note: thread_local::pub_static_from_const_expr: done in <time>, ran 1 branch
-  PC 1: Distinct(V|1-2|) /\ (0x0000000000000010 <=u V|1|) /\
-        (V|1| <=u 0x7fffffffffffffbe) /\ (0x0000000000000008 <=u V|2|) /\
-        (V|2| <=u 0x7fffffffffffffd6) /\ (0x0 == extract[0-3](V|1|)) /\
-        (0b000 == extract[0-2](V|2|))
+  warning: thread_local::pub_static_from_const_expr (<time>): an unsupported feature was reached
+  Can't execute function std::sys::thread_local::destructors::list::register, try using a sysroot (--sysroot)
   
+  tip: to get a sysroot, run
+       cargo +nightly-2026-06-01 miri setup --print-sysroot
+  
+  This is tracked at https://github.com/soteria-tools/soteria/issues/322
+  
+  [2]
 
 This test must be run separtely on linux and macos as it yields different error messages.
   $ soteria-rust exec thread_local.rs --target x86_64-unknown-linux-gnu
@@ -262,24 +273,24 @@ This test must be run separtely on linux and macos as it yields different error 
   PC 1: empty
   
   => Running thread_local::static_ref_cell...
-  warning: An atomic intrinsic was encountered; it will be executed as sequential code
-  note: thread_local::static_ref_cell: done in <time>, ran 1 branch
-  PC 1: Distinct(V|1-2|) /\ Distinct(V|1-3|) /\
-        (0x0000000000000010 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffe) /\
-        (0x0000000000000010 <=u V|2|) /\ (V|2| <=u 0x7fffffffffffffbe) /\
-        (0x0000000000000008 <=u V|3|) /\ (V|3| <=u 0x7fffffffffffffd6) /\
-        (0x0 == extract[0-3](V|1|)) /\ (0x0 == extract[0-3](V|2|)) /\
-        (0b000 == extract[0-2](V|3|))
+  warning: thread_local::static_ref_cell (<time>): an unsupported feature was reached
+  Can't execute function std::sys::thread_local::destructors::linux_like::register, try using a sysroot (--sysroot)
+  
+  tip: to get a sysroot, run
+       cargo +nightly-2026-06-01 miri setup --print-sysroot
+  
+  This is tracked at https://github.com/soteria-tools/soteria/issues/322
   
   => Running thread_local::pub_static_from_const_expr...
-  note: thread_local::pub_static_from_const_expr: done in <time>, ran 1 branch
-  PC 1: Distinct(V|1-2|) /\ Distinct(V|1-3|) /\
-        (0x0000000000000010 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffe) /\
-        (0x0000000000000010 <=u V|2|) /\ (V|2| <=u 0x7fffffffffffffbe) /\
-        (0x0000000000000008 <=u V|3|) /\ (V|3| <=u 0x7fffffffffffffd6) /\
-        (0x0 == extract[0-3](V|1|)) /\ (0x0 == extract[0-3](V|2|)) /\
-        (0b000 == extract[0-2](V|3|))
+  warning: thread_local::pub_static_from_const_expr (<time>): an unsupported feature was reached
+  Can't execute function std::sys::thread_local::destructors::linux_like::register, try using a sysroot (--sysroot)
   
+  tip: to get a sysroot, run
+       cargo +nightly-2026-06-01 miri setup --print-sysroot
+  
+  This is tracked at https://github.com/soteria-tools/soteria/issues/322
+  
+  [2]
 
 Test cloning ZSTs works; in particular, this generates a function with an empty body that just returns, so if we don't handle the ZST case we get an uninit access.
   $ soteria-rust exec clone_zst.rs
@@ -462,57 +473,41 @@ Print the callgraph
   digraph callgraph {
     node [shape=box fontname="monospace"];
     n0 [label="Range<A>>::next" tooltip="std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next::<i32>"];
-    n21 [label="io::_print" tooltip="std::io::_print"];
-    n14 [label="callgraph::limit" tooltip="callgraph::limit"];
-    n8 [label="NonNull::<T>::as_ptr" tooltip="std::ptr::NonNull::<T>::as_ptr::<i32>"];
-    n24 [label="NonNull::<T>::from_ref" tooltip="std::ptr::NonNull::<T>::from_ref::<i32>"];
-    n9 [label="callgraph::choose" tooltip="callgraph::choose"];
-    n20 [label="callgraph::main" tooltip="callgraph::main"];
-    n13 [label="callgraph::run" tooltip="callgraph::run"];
-    n10 [label="callgraph::twice" tooltip="callgraph::twice"];
-    n5 [label="Option::<T>::unwrap_unchecked" tooltip="std::option::Option::<T>::unwrap_unchecked::<i32>"];
-    n4 [label="Step>::forward_unchecked" tooltip="<i32 as std::iter::Step>::forward_unchecked"];
-    n2 [label="num::<impl i32>::overflowing_add_unsigned" tooltip="core::num::<impl i32>::overflowing_add_unsigned"];
-    n22 [label="Argument::<'_>::new_display" tooltip="core::fmt::rt::Argument::<'_>::new_display::<'_, i32>"];
-    n11 [label="callgraph::dec" tooltip="callgraph::dec"];
-    n15 [label="callgraph::score" tooltip="callgraph::score"];
-    n6 [label="num::<impl i32>::checked_add_unsigned" tooltip="core::num::<impl i32>::checked_add_unsigned"];
-    n3 [label="num::<impl i32>::overflowing_add" tooltip="core::num::<impl i32>::overflowing_add"];
-    n25 [label="PartialOrd for i32>::lt" tooltip="std::cmp::impls::<impl std::cmp::PartialOrd for i32>::lt"];
-    n18 [label="callgraph::ping" tooltip="callgraph::ping"];
-    n17 [label="intrinsics::unlikely" tooltip="std::intrinsics::unlikely"];
-    n7 [label="NonNull::<T>::cast" tooltip="std::ptr::NonNull::<T>::cast::<i32, ()>"];
-    n16 [label="IntoIterator>::into_iter" tooltip="<I as std::iter::IntoIterator>::into_iter::<Range::<i32>>"];
-    n23 [label="Arguments::<'a>::new" tooltip="std::fmt::Arguments::<'a>::new::<'_, 12usize, 1usize>"];
-    n19 [label="callgraph::pong" tooltip="callgraph::pong"];
-    n12 [label="callgraph::inc" tooltip="callgraph::inc"];
+    n13 [label="io::_print" tooltip="std::io::_print"];
+    n7 [label="callgraph::limit" tooltip="callgraph::limit"];
+    n2 [label="callgraph::choose" tooltip="callgraph::choose"];
+    n12 [label="callgraph::main" tooltip="callgraph::main"];
+    n6 [label="callgraph::run" tooltip="callgraph::run"];
+    n16 [label="Step>::forward_unchecked" tooltip="<i32 as std::iter::Step>::forward_unchecked"];
+    n3 [label="callgraph::twice" tooltip="callgraph::twice"];
+    n14 [label="Argument::<'_>::new_display" tooltip="core::fmt::rt::Argument::<'_>::new_display::<'_, i32>"];
+    n4 [label="callgraph::dec" tooltip="callgraph::dec"];
+    n8 [label="callgraph::score" tooltip="callgraph::score"];
+    n17 [label="PartialOrd for i32>::lt" tooltip="std::cmp::impls::<impl std::cmp::PartialOrd for i32>::lt"];
+    n10 [label="callgraph::ping" tooltip="callgraph::ping"];
+    n9 [label="IntoIterator>::into_iter" tooltip="<I as std::iter::IntoIterator>::into_iter::<Range::<i32>>"];
+    n15 [label="Arguments::<'a>::new" tooltip="std::fmt::Arguments::<'a>::new::<'_, 12usize, 1usize>"];
+    n11 [label="callgraph::pong" tooltip="callgraph::pong"];
+    n5 [label="callgraph::inc" tooltip="callgraph::inc"];
     n1 [label="RangeIteratorImpl>::spec_next" tooltip="<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next::<i32>"];
     n0 -> n1;
     n2 -> n3;
-    n4 -> n5;
-    n4 -> n6;
-    n7 -> n8;
-    n9 -> n10;
-    n9 -> n11;
-    n9 -> n12;
-    n13 -> n0;
-    n13 -> n14;
-    n13 -> n15;
-    n13 -> n16;
-    n6 -> n2;
-    n6 -> n17;
-    n18 -> n19;
-    n20 -> n21;
-    n20 -> n13;
-    n20 -> n22;
-    n20 -> n23;
-    n22 -> n24;
-    n22 -> n7;
-    n15 -> n9;
-    n15 -> n18;
-    n19 -> n18;
-    n1 -> n4;
-    n1 -> n25;
+    n2 -> n4;
+    n2 -> n5;
+    n6 -> n0;
+    n6 -> n7;
+    n6 -> n8;
+    n6 -> n9;
+    n10 -> n11;
+    n12 -> n13;
+    n12 -> n6;
+    n12 -> n14;
+    n12 -> n15;
+    n8 -> n2;
+    n8 -> n10;
+    n11 -> n10;
+    n1 -> n16;
+    n1 -> n17;
   }
 
 Check we trust addresses for pointer alignment
@@ -648,7 +643,7 @@ FIXME: because of the sysroot, there's a bunch of extra allocations from added f
   note: box::main: done in <time>, ran 1 branch
   PC 1: empty
   
-  check_stat: expected '2', got '7' for allocs
+  check_stat: expected '2', got '3' for allocs
   [1]
 
 Test that taking a reference to a ZST doesn't allocate it on the heap; the reference is a dangling pointer, so the value stays in the store.

--- a/soteria/lib/bv_values/typed.ml
+++ b/soteria/lib/bv_values/typed.ml
@@ -87,6 +87,17 @@ module BitVec = struct
     if i = 0 then L.failwith "Zero value in mki_nonzero" else mki_masked n i
 
   let no_ovf_unsafe x = x
+
+  let add_checked ~signed l r =
+    (add ~checked:true l r, add_overflows ~signed l r)
+
+  let sub_checked ~signed l r =
+    (sub ~checked:true l r, sub_overflows ~signed l r)
+
+  let mul_checked ~signed l r =
+    (mul ~checked:true l r, mul_overflows ~signed l r)
+
+  let neg_checked x = (neg x, neg_overflows x)
 end
 
 module Infix = struct
@@ -99,14 +110,13 @@ module Infix = struct
   let ( *!@ ) = ( *@ )
   let ( *!!@ ) = BitVec.mul ~checked:true
   let ( ~-! ) = ( ~- )
-  let mk_checked_op op ovf = fun l r -> (op ?checked:(Some true) l r, ovf l r)
-  let ( +?@ ) = mk_checked_op BitVec.add (BitVec.add_overflows ~signed:false)
-  let ( +$?@ ) = mk_checked_op BitVec.add (BitVec.add_overflows ~signed:true)
-  let ( -?@ ) = mk_checked_op BitVec.sub (BitVec.sub_overflows ~signed:false)
-  let ( -$?@ ) = mk_checked_op BitVec.sub (BitVec.sub_overflows ~signed:true)
-  let ( *?@ ) = mk_checked_op BitVec.mul (BitVec.mul_overflows ~signed:false)
-  let ( *$?@ ) = mk_checked_op BitVec.mul (BitVec.mul_overflows ~signed:true)
-  let ( ~-? ) x = (~-x, BitVec.neg_overflows x)
+  let ( +?@ ) = BitVec.add_checked ~signed:false
+  let ( +$?@ ) = BitVec.add_checked ~signed:true
+  let ( -?@ ) = BitVec.sub_checked ~signed:false
+  let ( -$?@ ) = BitVec.sub_checked ~signed:true
+  let ( *?@ ) = BitVec.mul_checked ~signed:false
+  let ( *$?@ ) = BitVec.mul_checked ~signed:true
+  let ( ~-? ) = BitVec.neg_checked
 end
 
 module Expr = Expr

--- a/soteria/lib/bv_values/typed.mli
+++ b/soteria/lib/bv_values/typed.mli
@@ -191,6 +191,18 @@ module BitVec : sig
   val mul_overflows : signed:bool -> [< sint ] t -> [< sint ] t -> [> sbool ] t
   val neg_overflows : [< sint ] t -> [> sbool ] t
 
+  (* checked operators *)
+  val add_checked :
+    signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t * [> sbool ] t
+
+  val sub_checked :
+    signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t * [> sbool ] t
+
+  val mul_checked :
+    signed:bool -> [< sint ] t -> [< sint ] t -> [> sint ] t * [> sbool ] t
+
+  val neg_checked : [< sint ] t -> [> sint ] t * [> sbool ] t
+
   (* Unsafe mark as not overflow *)
   val no_ovf_unsafe : [< sint_ovf ] t -> [> sint ] t
 


### PR DESCRIPTION
Minor improvements extracted from #391 while we figure that out
- Ensure plugin building doesn't break when compilation settings change -- closes #388 
- Fix a couple stubs (`_tlv_atexit`, `_env`) that were incorrectly handled with function stubs, when they're externs
- support `std::ptr::Pointee` with polymorphism
- add the missing externs to suppport thread locals on Linux: `__cxa_thread_atexit_impl`, `__dso_handle`, `pthread_key_create`, `pthread_setspecific`, `pthread_key_delete` in system + `malloc` and `free` in libc
- fix a potential soundness bug where `Sptr` used checked operators even when overflow wasn't actually checked
- fix the first test of our benchmark never being run lmao
