### PR TITLE
More efficient Logging

### DIFF
--- a/soteria/bench/dune
+++ b/soteria/bench/dune
@@ -1,0 +1,5 @@
+(executable
+ (name logs_bench)
+ (libraries soteria unix)
+ (preprocess
+  (pps ppx_symex)))

--- a/soteria/bench/logs_bench.ml
+++ b/soteria/bench/logs_bench.ml
@@ -1,0 +1,37 @@
+open Soteria.Logs.Import
+
+let iters = 50_000_000
+
+let bench name f =
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let t0 = Unix.gettimeofday () in
+  f ();
+  let t1 = Unix.gettimeofday () in
+  let w1 = Gc.minor_words () in
+  Printf.printf "%-22s %7.3fs  %14.0f words  %5.2f words/iter\n%!" name
+    (t1 -. t0) (w1 -. w0)
+    ((w1 -. w0) /. float_of_int iters)
+
+let () =
+  (* Disabled hot path: level Error, so Debug is below the threshold. *)
+  Soteria.Logs.Config.(
+    set_and_lock (make ~level:(Some Soteria.Logs.Level.Error) ()));
+  Printf.printf "== logging DISABLED (Debug below threshold), %d iters ==\n"
+    iters;
+  bench "old closure 1 arg" (fun () ->
+      for i = 1 to iters do
+        L.debug (fun m -> m "value %d" i)
+      done);
+  bench "new ppx 1 arg" (fun () ->
+      for i = 1 to iters do
+        [%l.debug "value %d" i]
+      done);
+  bench "old closure 3 args" (fun () ->
+      for i = 1 to iters do
+        L.debug (fun m -> m "%d %d %d" i (i + 1) (i + 2))
+      done);
+  bench "new ppx 3 args" (fun () ->
+      for i = 1 to iters do
+        [%l.debug "%d %d %d" i (i + 1) (i + 2)]
+      done)

--- a/soteria/lib/logs/logs.ml
+++ b/soteria/lib/logs/logs.ml
@@ -103,21 +103,24 @@ module L = struct
     start_section ~is_branch str;
     Fun.protect ~finally:end_section f
 
-  let log ~level msgf =
-    if Config.should_log level then
-      msgf @@ fun fmt ->
-      Format.kasprintf
-        (fun msg ->
-          let msg =
-            (* TODO: Write a different logger for each kind, instead of pattern
-               matching in each function *)
-            match (Config.get ()).kind with
-            | Html -> Html.message level msg
-            | Stderr -> Printf.sprintf "%s %s" (format_level level) msg
-          in
-          write_string msg)
-        fmt
+  module Level = Level
 
+  let should_log = Config.should_log
+
+  let force_log ~level fmt =
+    Format.kasprintf
+      (fun msg ->
+        let msg =
+          (* TODO: Write a different logger for each kind, instead of pattern
+             matching in each function *)
+          match (Config.get ()).kind with
+          | Html -> Html.message level msg
+          | Stderr -> Printf.sprintf "%s %s" (format_level level) msg
+        in
+        write_string msg)
+      fmt
+
+  let log ~level msgf = if should_log level then msgf (force_log ~level)
   let trace msgf = log ~level:Trace msgf
   let debug msgf = log ~level:Debug msgf
   let info msgf = log ~level:Info msgf
@@ -128,8 +131,9 @@ module L = struct
   let failwith msgf =
     msgf
     |> Fmt.kstr @@ fun msg ->
-       let trace = Printexc.(raw_backtrace_to_string @@ get_callstack 52) in
-       log ~level:Error (fun m -> m "INTERNAL ERROR: %s@.%s" msg trace);
+       (if should_log Error then
+          let trace = Printexc.(raw_backtrace_to_string @@ get_callstack 52) in
+          force_log ~level:Error "INTERNAL ERROR: %s@.%s" msg trace);
        failwith msg
 end
 

--- a/soteria/lib/logs/logs.mli
+++ b/soteria/lib/logs/logs.mli
@@ -76,6 +76,19 @@ module L : sig
   *)
   val with_section : ?is_branch:bool -> string -> (unit -> 'a) -> 'a
 
+  module Level = Level
+
+  (** [should_log level] is [true] when messages at [level] are currently
+      enabled by the configuration. Used by the [%l.*] PPX to guard logging
+      without allocating a message closure. *)
+  val should_log : Level.t -> bool
+
+  (** [force_log ~level fmt ...] formats and writes a message at [level],
+      {b without} checking whether [level] is enabled. Callers must guard with
+      {!should_log}; the [%l.*] PPX does this automatically. *)
+  val force_log :
+    level:Level.t -> ('a, Format.formatter, unit, unit) format4 -> 'a
+
   (** Logs a message at a given level.
 
       For instance, one can log the string "The number is 42" at level [Info]

--- a/soteria/ppx/logs.ml
+++ b/soteria/ppx/logs.ml
@@ -12,13 +12,13 @@ module Extension_name = struct
     | Smt -> "l.smt"
 end
 
-let associated_fn ~loc = function
-  | Extension_name.Debug -> [%expr L.debug]
-  | Info -> [%expr L.info]
-  | Warn -> [%expr L.warn]
-  | Error -> [%expr L.error]
-  | Trace -> [%expr L.trace]
-  | Smt -> [%expr L.smt]
+let associated_level ~loc = function
+  | Extension_name.Debug -> [%expr L.Level.Debug]
+  | Info -> [%expr L.Level.Info]
+  | Warn -> [%expr L.Level.Warn]
+  | Error -> [%expr L.Level.Error]
+  | Trace -> [%expr L.Level.Trace]
+  | Smt -> [%expr L.Level.Smt]
 
 let split_apply expr =
   let rec aux acc expr =
@@ -51,12 +51,13 @@ let validate_payload ~ext fmt args =
 
 let expand ~ext expr =
   let loc = { expr.pexp_loc with loc_ghost = true } in
-  let fn = associated_fn ~loc ext in
+  let level = associated_level ~loc ext in
   let fmt, args = split_apply expr in
   let () = validate_payload ~ext fmt args in
-  (* we use "m__" as the name of the argument to the function passed to [fn] to
-     avoid potential name clashes with variables in the original expression *)
-  let m_call =
-    Ast_builder.Default.pexp_apply ~loc [%expr m__] ((Nolabel, fmt) :: args)
+  (* Guard the log on [should_log] so that, when the level is disabled, no
+     message is formatted and no closure is allocated. *)
+  let log_call =
+    Ast_builder.Default.pexp_apply ~loc [%expr L.force_log]
+      ((Labelled "level", level) :: (Nolabel, fmt) :: args)
   in
-  [%expr [%e fn] (fun m__ -> [%e m_call])]
+  [%expr if L.should_log [%e level] then [%e log_call]]

--- a/soteria/tests/ppx/logs/prelude.ml
+++ b/soteria/tests/ppx/logs/prelude.ml
@@ -1,9 +1,10 @@
 module L = struct
-  let sink fmt = Format.ifprintf Format.std_formatter fmt
-  let debug f = f sink
-  let info f = f sink
-  let warn f = f sink
-  let error f = f sink
-  let trace f = f sink
-  let smt f = f sink
+  module Level = struct
+    type t = Smt | Trace | Debug | Info | Warn | Error
+  end
+
+  let should_log (_ : Level.t) = false
+
+  let force_log ~level:(_ : Level.t) fmt =
+    Format.ifprintf Format.std_formatter fmt
 end

--- a/soteria/tests/ppx/logs/simple.t
+++ b/soteria/tests/ppx/logs/simple.t
@@ -2,10 +2,13 @@
   open Prelude
   
   let () =
-    L.debug (fun m__ -> m__ "debug %d" 1);
-    L.info (fun m__ -> m__ "info %s" "x");
-    L.warn (fun m__ -> m__ "warn %a" Fmt.int 2);
-    L.error (fun m__ -> m__ "error");
-    L.trace (fun m__ -> m__ "trace");
-    L.smt (fun m__ -> m__ "smt")
+    if L.should_log L.Level.Debug then
+      L.force_log ~level:L.Level.Debug "debug %d" 1;
+    if L.should_log L.Level.Info then
+      L.force_log ~level:L.Level.Info "info %s" "x";
+    if L.should_log L.Level.Warn then
+      L.force_log ~level:L.Level.Warn "warn %a" Fmt.int 2;
+    if L.should_log L.Level.Error then L.force_log ~level:L.Level.Error "error";
+    if L.should_log L.Level.Trace then L.force_log ~level:L.Level.Trace "trace";
+    if L.should_log L.Level.Smt then L.force_log ~level:L.Level.Smt "smt"
   Success ✅


### PR DESCRIPTION
## Improvement

So here's a fun one. The old logging interface used to take the form:
```ml
L.debug (fun m ->m "%a" pp x)
```
Why would we allocate a closure? One could have just had `L.debug "%a" pp x` and we could make it work (just like `Fmt.failwith` or, currently, `L.failwith`.

Well, there is a perf improvement in the case where you *don't* want to log. I originally implemented this following the results given by this benchmark: https://github.com/mirage/ocaml-git/pull/130#issuecomment-149326614, which noted that keeping everything in a closure would make it faster in the case where the closure isn't applied.

**But** it still requires allocating a closure, even when we don't care about the logging at all! The only way to avoid this is to manually guard on the log level for callsite:
```
if should_log Debug then L.log "%a" pp x;
```

Obviously this is unwieldy and you don't want the user to be typing all of that. **Except** we now have a ppx for our logging. So really we can just change the way it desugars to do the right thing. And that's what this PR does

## Micro benchmarks

When not logging, the cost is no reduced:
- from 4 allocated words to 0 allocated words, reducing GC pressure on the minor heap
- by 40% in cpu clock

When logging is enabled, nothing changes.

## Will it change anything?

No. It's just cute.

That being said, if we ever parallelise Soteria, we might want to have a separate thread that is in charge exclusively of logging. This means we will have to send data across threads, even if no logging is performed. This transformation means that we, in fact, will never do this if we don't need to log, freeing up the logging thread.