### PR TITLE
Hardcode `Sptr` and `Ptr_tag`

### DIFF
--- a/soteria-rust/lib/analyses/wpst.ml
+++ b/soteria-rust/lib/analyses/wpst.ml
@@ -98,7 +98,7 @@ let exec_crate (crate : Charon.UllbcAst.crate)
   let@ () = print_outcomes entry_name in
   Fmt.pr "%a %a@." (pp_clr `Teal) "=>" (pp_style `Bold)
     ("Running " ^ entry_name ^ "...");
-  let args : State.Sptr.t Rust_val.t list =
+  let args : Rust_val.t list =
     if entry_name = "miri_start" then
       [ Int (Typed.BV.usizei 0); Ptr (State.Sptr.null (), Thin) ]
     else []

--- a/soteria-rust/lib/builtins/fixme/fixme.ml
+++ b/soteria-rust/lib/builtins/fixme/fixme.ml
@@ -18,10 +18,8 @@ module M (StateM : State.StateM.S) = struct
   open StateM
   open Syntax
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   let[@inline] as_ptr (v : rust_val) =
     match v with
@@ -30,7 +28,7 @@ module M (StateM : State.StateM.S) = struct
         let v = Typed.cast_i Usize v in
         let ptr = Sptr.of_address v in
         (ptr, Thin)
-    | _ -> L.failwith "expected pointer"
+    | _ -> failwith "expected pointer"
 
   let as_base ty (v : rust_val) = Rust_val.as_base ty v
   let as_base_i ty (v : rust_val) = Rust_val.as_base_i ty v

--- a/soteria-rust/lib/builtins/fixme/intf.ml
+++ b/soteria-rust/lib/builtins/fixme/intf.ml
@@ -5,14 +5,13 @@
 
 open Charon
 open Common
+open Rust_val
 
 module M (StateM : State.StateM.S) = struct
   open StateM
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   module type S = sig
     val cleanup : payload:full_ptr -> rust_val ret

--- a/soteria-rust/lib/builtins/intrinsics/intf.ml
+++ b/soteria-rust/lib/builtins/intrinsics/intf.ml
@@ -3,13 +3,12 @@
 
 open Charon
 open Common
+open Rust_val
 
 module M (StateM : State.StateM.S) = struct
   module type Impl = sig
-    type rust_val := StateM.Sptr.t Rust_val.t
     type 'a ret := ('a, unit) StateM.t
     type fun_exec := Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-    type full_ptr := StateM.Sptr.t Rust_val.full_ptr
 
     (** {@markdown[
           Aborts the execution of the process.
@@ -4331,7 +4330,6 @@ module M (StateM : State.StateM.S) = struct
   module type S = sig
     include Impl
 
-    type rust_val := StateM.Sptr.t Rust_val.t
     type 'a ret := ('a, unit) StateM.t
     type fun_exec := Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
 

--- a/soteria-rust/lib/builtins/intrinsics/intrinsics.ml
+++ b/soteria-rust/lib/builtins/intrinsics/intrinsics.ml
@@ -8,8 +8,6 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
   open StateM
   open Syntax
 
-  type rust_val = Sptr.t Rust_val.t
-
   let[@inline] as_ptr (v : rust_val) =
     match v with
     | Ptr ptr -> ptr
@@ -17,7 +15,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
         let v = Typed.cast_i Usize v in
         let ptr = Sptr.of_address v in
         (ptr, Thin)
-    | _ -> L.failwith "expected pointer"
+    | _ -> failwith "expected pointer"
 
   let as_base ty (v : rust_val) = Rust_val.as_base ty v
   let as_base_i ty (v : rust_val) = Rust_val.as_base_i ty v

--- a/soteria-rust/lib/builtins/optim/intf.ml
+++ b/soteria-rust/lib/builtins/optim/intf.ml
@@ -5,14 +5,13 @@
 
 open Charon
 open Common
+open Rust_val
 
 module M (StateM : State.StateM.S) = struct
   open StateM
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   module type S = sig
     val _eprint : args:rust_val -> unit ret

--- a/soteria-rust/lib/builtins/optim/optim.ml
+++ b/soteria-rust/lib/builtins/optim/optim.ml
@@ -107,10 +107,8 @@ module M (StateM : State.StateM.S) = struct
   open StateM
   open Syntax
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   let[@inline] as_ptr (v : rust_val) =
     match v with
@@ -119,7 +117,7 @@ module M (StateM : State.StateM.S) = struct
         let v = Typed.cast_i Usize v in
         let ptr = Sptr.of_address v in
         (ptr, Thin)
-    | _ -> L.failwith "expected pointer"
+    | _ -> failwith "expected pointer"
 
   let as_base ty (v : rust_val) = Rust_val.as_base ty v
   let as_base_i ty (v : rust_val) = Rust_val.as_base_i ty v

--- a/soteria-rust/lib/builtins/soteria_lib/impl.ml
+++ b/soteria-rust/lib/builtins/soteria_lib/impl.ml
@@ -32,7 +32,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
       | [ ty ] -> ty
       | _ -> L.failwith "unexpected type args in nondet_bytes"
     in
-    Encoder.nondet_valid output
+    Value_codec.nondet_valid output
 
   let soteria_panic ~args =
     let* msg =

--- a/soteria-rust/lib/builtins/soteria_lib/intf.ml
+++ b/soteria-rust/lib/builtins/soteria_lib/intf.ml
@@ -5,14 +5,13 @@
 
 open Charon
 open Common
+open Rust_val
 
 module M (StateM : State.StateM.S) = struct
   open StateM
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   module type S = sig
     val kani_assert : args:rust_val list -> rust_val ret

--- a/soteria-rust/lib/builtins/soteria_lib/soteria_lib.ml
+++ b/soteria-rust/lib/builtins/soteria_lib/soteria_lib.ml
@@ -30,10 +30,8 @@ module M (StateM : State.StateM.S) = struct
   open StateM
   open Syntax
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   let[@inline] as_ptr (v : rust_val) =
     match v with
@@ -42,7 +40,7 @@ module M (StateM : State.StateM.S) = struct
         let v = Typed.cast_i Usize v in
         let ptr = Sptr.of_address v in
         (ptr, Thin)
-    | _ -> L.failwith "expected pointer"
+    | _ -> failwith "expected pointer"
 
   let as_base ty (v : rust_val) = Rust_val.as_base ty v
   let as_base_i ty (v : rust_val) = Rust_val.as_base_i ty v

--- a/soteria-rust/lib/builtins/system/intf.ml
+++ b/soteria-rust/lib/builtins/system/intf.ml
@@ -5,14 +5,13 @@
 
 open Charon
 open Common
+open Rust_val
 
 module M (StateM : State.StateM.S) = struct
   open StateM
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   module type S = sig
     (** {@markdown[

--- a/soteria-rust/lib/builtins/system/system.ml
+++ b/soteria-rust/lib/builtins/system/system.ml
@@ -27,10 +27,8 @@ module M (StateM : State.StateM.S) = struct
   open StateM
   open Syntax
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   let[@inline] as_ptr (v : rust_val) =
     match v with
@@ -39,7 +37,7 @@ module M (StateM : State.StateM.S) = struct
         let v = Typed.cast_i Usize v in
         let ptr = Sptr.of_address v in
         (ptr, Thin)
-    | _ -> L.failwith "expected pointer"
+    | _ -> failwith "expected pointer"
 
   let as_base ty (v : rust_val) = Rust_val.as_base ty v
   let as_base_i ty (v : rust_val) = Rust_val.as_base_i ty v

--- a/soteria-rust/lib/builtins/tokio/impl.ml
+++ b/soteria-rust/lib/builtins/tokio/impl.ml
@@ -2,5 +2,5 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
   open StateM
 
   let new_ ~(fun_sig : Charon.Types.fun_sig) =
-    Encoder.nondet_valid fun_sig.output
+    Value_codec.nondet_valid fun_sig.output
 end

--- a/soteria-rust/lib/builtins/tokio/intf.ml
+++ b/soteria-rust/lib/builtins/tokio/intf.ml
@@ -5,14 +5,13 @@
 
 open Charon
 open Common
+open Rust_val
 
 module M (StateM : State.StateM.S) = struct
   open StateM
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   module type S = sig
     val new_ : fun_sig:Types.fun_sig -> rust_val ret

--- a/soteria-rust/lib/builtins/tokio/tokio.ml
+++ b/soteria-rust/lib/builtins/tokio/tokio.ml
@@ -15,10 +15,8 @@ module M (StateM : State.StateM.S) = struct
   open StateM
   open Syntax
 
-  type rust_val = Sptr.t Rust_val.t
   type 'a ret = ('a, unit) StateM.t
   type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-  type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
   let[@inline] as_ptr (v : rust_val) =
     match v with
@@ -27,7 +25,7 @@ module M (StateM : State.StateM.S) = struct
         let v = Typed.cast_i Usize v in
         let ptr = Sptr.of_address v in
         (ptr, Thin)
-    | _ -> L.failwith "expected pointer"
+    | _ -> failwith "expected pointer"
 
   let as_base ty (v : rust_val) = Rust_val.as_base ty v
   let as_base_i ty (v : rust_val) = Rust_val.as_base_i ty v

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -18,7 +18,7 @@ module Make (StateImpl : State.S) = struct
   open StateM
   open Syntax
 
-  type 'a t = ('a, Sptr.t Store.t) StateM.t
+  type 'a t = ('a, Store.t) StateM.t
   type 'err fun_exec = rust_val list -> (rust_val, unit) StateM.t
 
   type lazy_ptr = Store of Store.Place.t | Heap of full_ptr
@@ -77,7 +77,7 @@ module Make (StateImpl : State.S) = struct
     |> fold_list ~init:[] ~f:(fun acc ((local : GAst.local), value) ->
         (* Passed (nested) references must be protected and be valid. *)
         let* value, protected' =
-          Encoder.ref_tys_in local.local_ty value ~init:acc
+          Value_codec.ref_tys_in local.local_ty value ~init:acc
             ~f:(fun acc ptr_ty ptr ->
               let+ ptr' = State.borrow ~protect:true ptr ptr_ty in
               let pointee = Charon_util.get_pointee ptr_ty in
@@ -481,7 +481,7 @@ module Make (StateImpl : State.S) = struct
       the operation fails (returns [None]), uses [heap] instead. *)
   and try_lazy :
       'a.
-      store:(Store.Place.t -> _ Store.t -> 'a option t) ->
+      store:(Store.Place.t -> Store.t -> 'a option t) ->
       heap:(full_ptr -> 'a t) ->
       lazy_ptr ->
       'a t =
@@ -707,7 +707,7 @@ module Make (StateImpl : State.S) = struct
                 (* expose provenance *)
                 let v, _ = as_ptr v in
                 let+ v' = Sptr.expose v in
-                Encoder.cast_literal ~from_ty:(TUInt Usize) ~to_ty v'
+                Value_codec.cast_literal ~from_ty:(TUInt Usize) ~to_ty v'
             | TLiteral _, (TRef _ | TRawPtr _ | TFnPtr _) ->
                 (* with provenance *)
                 let v = as_base_i Usize v in
@@ -738,7 +738,7 @@ module Make (StateImpl : State.S) = struct
               | Float f -> ok (f :> T.cval Typed.t)
               | _ -> L.failwith "Invalid value for CastScalar"
             in
-            Encoder.cast_literal ~from_ty ~to_ty v
+            Value_codec.cast_literal ~from_ty ~to_ty v
         | Cast (CastUnsize (from_ty, to_ty, meta)) -> (
             let rec with_ptr_meta v = function
               | [] ->
@@ -916,7 +916,9 @@ module Make (StateImpl : State.S) = struct
         let field = Types.FieldId.to_int field in
         let* layout = Layout.layout_of (TAdt adt) in
         let offset = Layout.Fields_shape.offset_of field layout.fields in
-        let+ op_blocks = Encoder.encode ~offset value (type_of_operand op) in
+        let+ op_blocks =
+          Value_codec.encode ~offset value (type_of_operand op)
+        in
         let op_blocks = Iter.to_list op_blocks in
         Union op_blocks
     (* Struct aggregate *)
@@ -1093,7 +1095,8 @@ module Make (StateImpl : State.S) = struct
         let ret_place = Charon_util.return_place body in
         let* loc = resolve_place_lazy ret_place in
         let* value = load_lazy loc ret_place.ty in
-        Encoder.ref_tys_in ret_place.ty value ~init:() ~f:(fun () ptr_ty ptr ->
+        Value_codec.ref_tys_in ret_place.ty value ~init:()
+          ~f:(fun () ptr_ty ptr ->
             let pointee = get_pointee ptr_ty in
             let+ () = State.tb_load ptr pointee in
             (ptr, ()))
@@ -1259,7 +1262,7 @@ module Make (StateImpl : State.S) = struct
   let exec_fun_as_whole_prog ~args ~state (fundef : UllbcAst.fun_decl) =
     let@ () = run ~env:() ~state in
     let* value = exec_fun ~args ~state fundef in
-    let value = Rust_val.to_syn Sptr.to_syn value in
+    let value = Rust_val.to_syn value in
     let* () = State.run_thread_exits () in
     if (Config.get ()).ignore_leaks then ok value
     else

--- a/soteria-rust/lib/rust_val.ml
+++ b/soteria-rust/lib/rust_val.ml
@@ -1,10 +1,10 @@
 open Typed
 
 type ('v, 'ptr) meta_raw = Thin | Len of 'v | VTable of 'ptr
-type 'ptr meta = (T.sint Typed.t, 'ptr) meta_raw
-type 'ptr meta_syn = (Expr.t, 'ptr) meta_raw
+type meta = (T.sint Typed.t, Sptr.t) meta_raw
+type meta_syn = (Expr.t, Sptr.syn) meta_raw
 type ('v, 'ptr) full_ptr_raw = 'ptr * ('v, 'ptr) meta_raw
-type 'ptr full_ptr = 'ptr * 'ptr meta
+type full_ptr = (T.sint Typed.t, Sptr.t) full_ptr_raw
 
 type ('sint, 'snz, 'sfloat, 'ptr) raw =
   | Int of 'sint
@@ -21,9 +21,9 @@ type ('sint, 'snz, 'sfloat, 'ptr) raw =
       (** The opaque value of a type variable, identified by (type variable
           index, unique identifier). *)
 
-type 'ptr t = (T.sint Typed.t, T.nonzero Typed.t, T.sfloat Typed.t, 'ptr) raw
-type 'ptr rust_val = 'ptr t
-type 'ptr syn = (Expr.t, Expr.t, Expr.t, 'ptr) raw
+type t = (T.sint Typed.t, T.nonzero Typed.t, T.sfloat Typed.t, Sptr.t) raw
+type rust_val = t
+type syn = (Expr.t, Expr.t, Expr.t, Sptr.syn) raw
 
 let pp_meta_raw pp_v pp_ptr fmt = function
   | Thin -> Fmt.pf fmt "-"
@@ -35,22 +35,21 @@ let pp_meta_kind fmt = function
   | Len _ -> Fmt.pf fmt "length"
   | VTable _ -> Fmt.pf fmt "vtable"
 
-let pp_meta pp_ptr = pp_meta_raw Typed.ppa pp_ptr
-let pp_meta_syn pp_ptr_syn = pp_meta_raw Expr.pp pp_ptr_syn
+let pp_meta ft x = pp_meta_raw Typed.ppa Sptr.pp ft x
+let pp_meta_syn ft x = pp_meta_raw Expr.pp Sptr.pp ft x
 
 let pp_full_ptr_raw pp_v pp_ptr fmt = function
   | p, Thin -> Fmt.pf fmt "(%a)" pp_ptr p
   | p, meta -> Fmt.pf fmt "(%a, %a)" pp_ptr p (pp_meta_raw pp_v pp_ptr) meta
 
-let pp_full_ptr pp_ptr = pp_full_ptr_raw Typed.ppa pp_ptr
-let pp_full_ptr_syn pp_ptr_syn = pp_full_ptr_raw Expr.pp pp_ptr_syn
+let pp_full_ptr ft x = pp_full_ptr_raw Typed.ppa Sptr.pp ft x
+let pp_full_ptr_syn ft x = pp_full_ptr_raw Expr.pp Sptr.pp_syn ft x
 
-let rec pp pp_ptr fmt t =
-  let pp = pp pp_ptr in
+let rec pp fmt t =
   match t with
   | Int v -> Typed.ppa fmt v
   | Float v -> Typed.ppa fmt v
-  | Ptr ptr -> Fmt.pf fmt "Ptr%a" (pp_full_ptr pp_ptr) ptr
+  | Ptr ptr -> Fmt.pf fmt "Ptr%a" pp_full_ptr ptr
   | Enum (disc, vals) ->
       Fmt.pf fmt "Enum(%a: %a)" Typed.ppa disc
         (Fmt.list ~sep:(Fmt.any ", ") pp)
@@ -65,12 +64,11 @@ let rec pp pp_ptr fmt t =
 
 let pp_rust_val = pp
 
-let rec pp_syn pp_ptr fmt t =
-  let pp_syn = pp_syn pp_ptr in
+let rec pp_syn fmt t =
   match t with
   | Int v -> Expr.pp fmt v
   | Float v -> Expr.pp fmt v
-  | Ptr ptr -> Fmt.pf fmt "Ptr%a" (pp_full_ptr_raw Expr.pp pp_ptr) ptr
+  | Ptr ptr -> Fmt.pf fmt "Ptr%a" pp_full_ptr_syn ptr
   | Enum (disc, vals) ->
       Fmt.pf fmt "Enum(%a: %a)" Expr.pp disc
         (Fmt.list ~sep:(Fmt.any ", ") @@ pp_syn)
@@ -84,35 +82,33 @@ let rec pp_syn pp_ptr fmt t =
       Fmt.pf fmt "Union(%a)" (Fmt.list ~sep:(Fmt.any ", ") pp_block) vs
   | PolyVal tid -> Fmt.pf fmt "PolyVal(%a)" Charon.Types.pp_type_var_id tid
 
-let ppa_syn ft t = pp_syn (Fmt.any "?") ft t
-let ppa ft rv = pp (Fmt.any "?") ft rv
+let ppa_syn = pp_syn
+let ppa = pp
 let unit_ = Tuple []
 
-let meta_exprs_syn ptr_exprs_syn : 'ptr meta_syn -> Expr.t list = function
+let meta_exprs_syn : meta_syn -> Expr.t list = function
   | Thin -> []
   | Len v -> [ v ]
-  | VTable p -> ptr_exprs_syn p
+  | VTable p -> Sptr.exprs_syn p
 
-let rec exprs_syn ptr_exprs_syn x =
-  let exprs_syn = exprs_syn ptr_exprs_syn in
+let rec exprs_syn x =
   match x with
   | Int v | Float v -> [ v ]
-  | Ptr (p, meta) -> ptr_exprs_syn p @ meta_exprs_syn ptr_exprs_syn meta
+  | Ptr (p, meta) -> Sptr.exprs_syn p @ meta_exprs_syn meta
   | Enum (disc, vals) -> disc :: List.concat_map exprs_syn vals
   | Tuple vals -> List.concat_map exprs_syn vals
   | Union vs ->
       List.concat_map (fun (v, ofs, sz) -> ofs :: sz :: exprs_syn v) vs
   | PolyVal _ -> []
 
-let rec to_syn ptr_to_syn x =
-  let meta_to_syn (m : 'ptr meta) =
+let rec to_syn x =
+  let meta_to_syn (m : meta) =
     match m with
     | Thin -> Thin
     | Len v -> Len (Expr.of_value v)
-    | VTable p -> VTable (ptr_to_syn p)
+    | VTable p -> VTable (Sptr.to_syn p)
   in
-  let full_ptr_to_syn (ptr, meta) = (ptr_to_syn ptr, meta_to_syn meta) in
-  let to_syn = to_syn ptr_to_syn in
+  let full_ptr_to_syn (ptr, meta) = (Sptr.to_syn ptr, meta_to_syn meta) in
   match x with
   | Int v -> Int (Expr.of_value v)
   | Float v -> Float (Expr.of_value v)
@@ -131,19 +127,18 @@ let rec to_syn ptr_to_syn x =
   | Ptr p -> Ptr (full_ptr_to_syn p)
   | PolyVal v -> PolyVal v
 
-module Learn_eq (Symex : Soteria.Symex.Base with module Value = Rustsymex.Value) =
-struct
-  let learn_eq_meta learn_eq_ptr s t =
-    let open Symex.Consumer in
+module Learn_eq = struct
+  let learn_eq_meta s t =
+    let open Sptr.DecayMap.SM.Consumer in
     match (s, t) with
     | Thin, Thin -> ok ()
     | Len s, Len v -> learn_eq s v
-    | VTable ps, VTable p -> learn_eq_ptr ps p
+    | VTable ps, VTable p -> Sptr.learn_eq ps p
     | _ -> lfail Typed.v_false
 
-  let rec learn_eq learn_eq_ptr syn t =
-    let rec_call = learn_eq learn_eq_ptr in
-    let open Symex.Consumer in
+  let rec learn_eq syn t =
+    let rec_call = learn_eq in
+    let open Sptr.DecayMap.SM.Consumer in
     let open Syntax in
     let learn_list ~learn ls l =
       let* combined =
@@ -155,8 +150,8 @@ struct
     | Int s, Int v -> learn_eq s v
     | Float s, Float v -> learn_eq s v
     | Ptr (ps, meta_s), Ptr (p, meta) ->
-        let* () = learn_eq_ptr ps p in
-        learn_eq_meta learn_eq_ptr meta_s meta
+        let* () = Sptr.learn_eq ps p in
+        learn_eq_meta meta_s meta
     | Enum (disc_s, vals_s), Enum (disc, vals) ->
         let* () = learn_eq disc_s disc in
         learn_list ~learn:rec_call vals_s vals
@@ -169,7 +164,8 @@ struct
             learn_eq ofs1 ofs2)
           vs1 vs2
     | PolyVal _, PolyVal _ ->
-        lift @@ Symex.give_up "Learning equality of polymorphic values"
+        lift
+        @@ Sptr.DecayMap.SM.give_up "Learning equality of polymorphic values"
     | _ -> L.failwith "Mismatching rust_val kinds: %a vs %a" ppa_syn syn ppa t
 end
 
@@ -237,8 +233,8 @@ let as_enum = function
   | Enum (disc, vals) -> (disc, vals)
   | v -> L.failwith "Unexpected rust_val kind, expected an enum, got: %a" ppa v
 
-let rec subst subst_ptr subst_val rv =
-  let subst = subst subst_ptr subst_val in
+let rec subst subst_val rv =
+  let subst = subst subst_val in
   let subst_expr = Expr.subst subst_val in
   match rv with
   | Int v -> Int (subst_expr v)
@@ -256,9 +252,9 @@ let rec subst subst_ptr subst_val rv =
         match meta with
         | Thin -> Thin
         | Len len -> Len (subst_expr len)
-        | VTable ptr -> VTable (subst_ptr subst_val ptr)
+        | VTable ptr -> VTable (Sptr.subst subst_val ptr)
       in
-      Ptr (subst_ptr subst_val p, meta)
+      Ptr (Sptr.subst subst_val p, meta)
 
 let mk_enum ~ty variant fields =
   let open Charon in

--- a/soteria-rust/lib/sptr.ml
+++ b/soteria-rust/lib/sptr.ml
@@ -181,65 +181,149 @@ module DecayMap : DecayMapS = struct
 end
 
 module D_abstr = Soteria.Data.Abstr.M (DecayMap.SM)
+module Tag = Tree_borrows.Ptr_tag
 
-(** The base type of pointers, permitting simple operations on the pointer type.
-    The majority of relevant operations are exposed via the state monad's
-    pointer module, {{!State.StateM.S.Sptr}Sptr}. *)
-module type S = sig
-  (** pointer type *)
-  type t [@@mixins D_abstr.S_with_syn]
+type ('sptr, 'snonzero, 'sint, 'tag) base = {
+  ptr : 'sptr;
+  tag : 'tag option;
+  align : 'snonzero;
+  size : 'sint;
+}
 
-  (** Converts an address into a pointer, without provenance. *)
-  val of_address : [< sint ] Typed.t -> t
+type t = (T.sptr Typed.t, T.nonzero Typed.t, T.sint Typed.t, Tag.t) base
+type syn = (Typed.Expr.t, Typed.Expr.t, Typed.Expr.t, Tag.t) base
 
-  (** Creates a dangling pointer to the given type, if that type is a ZST;
-      returns [None] otherwise. *)
-  val dangling_if_zst : Types.ty -> (t option, [> Error.t ], 'f) Result.t
+let pp' pp_v pp_tag fmt { ptr; tag; _ } =
+  Fmt.pf fmt "%a[%a]" pp_v ptr Fmt.(option ~none:(any "*") pp_tag) tag
 
-  (** The null pointer, which always decays to 0, and has no provenance.
-      Equivalent to [of_address 0]. *)
-  val null : unit -> t
+let pp ft x = pp' Typed.ppa Tag.pp ft x
+let show x = Fmt.to_to_string pp x
+let pp_syn ft x = pp' Typed.Expr.pp Tag.pp ft x
+let show_syn x = Fmt.to_to_string pp_syn x
 
-  (** Whether this is the null pointer, meaning it always decays to 0. *)
-  val is_null : t -> sbool Typed.t
+let to_syn { ptr; tag; align; size } =
+  {
+    ptr = Typed.Expr.of_value ptr;
+    align = Typed.Expr.of_value align;
+    size = Typed.Expr.of_value size;
+    tag;
+  }
 
-  (** The offset of this pointer within its allocation. *)
-  val ofs : t -> [> sint ] Typed.t
+(** Returns a symbolic boolean characterising whether the pointer is in bound to
+    its allocation. *)
+let in_bound { ptr; size; _ } =
+  let ofs = Typed.Ptr.ofs ptr in
+  Usize.(0s) <=@ ofs &&@ (ofs <@ size)
 
-  (** Returns a symbolic boolean characterising whether the pointer is in bound
-      to its allocation. *)
-  val in_bound : t -> sbool Typed.t
+let learn_eq syn t =
+  let open DecayMap.SM.Consumer in
+  let open Syntax in
+  let* () =
+    if Option.equal Tag.equal syn.tag t.tag then ok () else lfail Typed.v_false
+  in
+  let* () = learn_eq syn.ptr t.ptr in
+  let* () = learn_eq syn.align t.align in
+  learn_eq syn.size t.size
 
-  (** Whether this pointer has provenance, i.e. points to some allocation. *)
-  val has_provenance : t -> sbool Typed.t
+let exprs_syn { ptr; align; size; tag } = [ ptr; align; size ]
+let fresh () = L.failwith "Fresh unimplemented for sptr (for now)"
 
-  (** If these two pointers have the same provenance, i.e. point to the same
-      allocation (or if they both have no provenance). *)
-  val have_same_provenance : t -> t -> sbool Typed.t
+let subst subst_val p =
+  let se = Typed.Expr.subst subst_val in
+  let ptr = se p.ptr in
+  let align = se p.align in
+  let size = se p.size in
+  { ptr; align; size; tag = p.tag }
 
-  (** The distance, in bytes, between two pointers; if they point to different
-      allocations, they are decayed and substracted. *)
-  val distance : t -> t -> sint Typed.t DecayMap.SM.t
+(** The null pointer, which always decays to 0, and has no provenance.
+    Equivalent to [of_address 0]. *)
+let null () =
+  { ptr = Typed.Ptr.null (); tag = None; align = Usize.(1s); size = Usize.(0s) }
 
-  (** Generates a nondeterministic pointer, that is valid for accesses to the
-      given type. The location of the pointer is nondeterministic; it could
-      point to any allocation. *)
-  val nondet : Types.ty -> (t, [> Error.t ], 'a) Result.t
+(** Converts an address into a pointer, without provenance. *)
+let of_address ofs =
+  let null_ptr = null () in
+  let ptr = Typed.Ptr.add_ofs null_ptr.ptr ofs in
+  { null_ptr with ptr }
 
-  (** Decay a pointer into an integer value, losing provenance.
-      {b This does not expose the address of the allocation; for that, use
-         [expose]} *)
-  val decay : t -> [> sint ] Typed.t DecayMap.SM.t
+(** Creates a dangling pointer to the given type, if that type is a ZST; returns
+    [None] otherwise. *)
+let dangling_if_zst ty =
+  let open Rustsymex in
+  let open Syntax in
+  let** layout = Layout.layout_of ty in
+  if%sat layout.size ==@ Usize.(0s) then
+    (* UX: really any address that is well-aligned is valid, we
+       under-approximate here to make our life easier. *)
+    Result.ok (Some (of_address layout.align))
+  else Result.ok None
 
-  (** Decay a pointer into an integer value, exposing the address of the
-      allocation, allowing it to be retrieved with [DecayMapS.from_exposed]
-      later. *)
-  val expose : t -> [> sint ] Typed.t DecayMap.SM.t
+(** Whether this is the null pointer, meaning it always decays to 0. *)
+let is_null { ptr; _ } = Typed.Ptr.is_null ptr
 
-  (** For Miri: the allocation ID of this location, as a u64 *)
-  val as_id : t -> [> sint ] Typed.t
+(** The offset of this pointer within its allocation. *)
+let ofs { ptr; _ } = Typed.Ptr.ofs ptr
 
-  (** For Miri: get the allocation info for this pointer: its size and alignment
-  *)
-  val allocation_info : t -> [> sint ] Typed.t * [> nonzero ] Typed.t
-end
+(** Whether this pointer has provenance, i.e. points to some allocation. *)
+let has_provenance { ptr; _ } = Typed.not (Typed.Ptr.is_at_null_loc ptr)
+
+(** If these two pointers have the same provenance, i.e. point to the same
+    allocation (or if they both have no provenance). *)
+let have_same_provenance { ptr = ptr1; _ } { ptr = ptr2; _ } =
+  Typed.Ptr.loc ptr1 ==@ Typed.Ptr.loc ptr2
+
+(** A simplified (and unsafe) version of [offset], that adds a signed bitvector
+    to this pointer's offset. *)
+let raw_offset ptr off_by =
+  let open Rustsymex.Syntax in
+  let loc, ofs = Typed.Ptr.decompose ptr.ptr in
+  let ofs', ovf = ofs +$?@ off_by in
+  let++ () = assert_or_error (Typed.not ovf) `UBDanglingPointer in
+  { ptr with ptr = Typed.Ptr.mk loc ofs' }
+
+let[@inline] _decay ~expose { ptr; align; size; _ } =
+  let open DecayMap.SM.Syntax in
+  let loc, ofs = Typed.Ptr.decompose ptr in
+  let+ loc_int = DecayMap.decay ~expose ~size ~align loc in
+  [%l.debug "Decay %a -> %a" Typed.ppa loc Typed.ppa loc_int];
+  loc_int +!!@ ofs
+
+(** Decay a pointer into an integer value, losing provenance.
+    {b This does not expose the address of the allocation; for that, use
+       {!expose}} *)
+let decay p = _decay ~expose:false p
+
+(** Decay a pointer into an integer value, exposing the address of the
+    allocation, allowing it to be retrieved with [DecayMapS.from_exposed] later.
+*)
+let expose p = _decay ~expose:true p
+
+(** The distance, in bytes, between two pointers; if they point to different
+    allocations, they are decayed and substracted. *)
+let distance ({ ptr = ptr1; _ } as p1) ({ ptr = ptr2; _ } as p2) =
+  let open DecayMap.SM.Syntax in
+  if%sat have_same_provenance p1 p2 then
+    DecayMap.SM.return (Typed.Ptr.ofs ptr1 -!@ Typed.Ptr.ofs ptr2)
+  else
+    let* ptr1 = decay p1 in
+    let+ ptr2 = decay p2 in
+    ptr1 -!@ ptr2
+
+(** For Miri: the allocation ID of this location, as a u64 *)
+let as_id { ptr; _ } = Typed.cast @@ Typed.Ptr.loc ptr
+
+(** For Miri: get the allocation info for this pointer: its size and alignment
+*)
+let allocation_info { size; align; _ } = (Typed.cast size, Typed.cast align)
+
+(** Generates a nondeterministic pointer, that is valid for accesses to the
+    given type. The location of the pointer is nondeterministic; it could point
+    to any allocation. *)
+let nondet ty =
+  let open Rustsymex.Syntax in
+  let** layout = Layout.layout_of ty in
+  let* loc = nondet (Typed.t_loc ()) in
+  let* ofs = nondet (Typed.t_usize ()) in
+  let ptr = Typed.Ptr.mk loc ofs in
+  let ptr = { ptr; tag = None; align = layout.align; size = layout.size } in
+  Result.ok ptr

--- a/soteria-rust/lib/state/rtree_block.ml
+++ b/soteria-rust/lib/state/rtree_block.ml
@@ -8,13 +8,7 @@ open DecayMap.SM
 open Result
 open Syntax
 
-module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
-  module Encoder = Value_codec.Encoder (Sptr)
-
-  type rust_val = Sptr.t Rust_val.t
-
-  let pp_rust_val = Rust_val.pp Sptr.pp
-
+module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) = struct
   module MemVal = struct
     module TB = Soteria.Sym_states.Tree_block
     module S_bool = Typed.Bool
@@ -52,7 +46,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
     end
 
     type qty = Totally | Partially [@@deriving show { with_path = false }]
-    type leaf = Init of rust_val | Zeros | Uninit | Any | Unowned
+    type leaf = Init of Rust_val.t | Zeros | Uninit | Any | Unowned
     type t = Leaf of leaf * Borrows.State.t option | Lazy
 
     let pp_leaf ft =
@@ -60,7 +54,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
       function
       | Zeros -> pf ft "Zeros"
       | Uninit -> pf ft "Uninit"
-      | Init mv -> pp_rust_val ft mv
+      | Init mv -> Rust_val.pp ft mv
       | Any -> pf ft "Any"
       | Unowned -> pf ft "Unowned"
 
@@ -83,7 +77,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
           left
       | _, _ -> Lazy
 
-    let rec split_rval (v : rust_val) at =
+    let rec split_rval (v : Rust_val.t) at =
       match v with
       | Ptr (ptr, meta) ->
           let* v = Sptr.decay ptr in
@@ -97,7 +91,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
           in
           split_rval (Int v) at
       | Float f ->
-          let* v = Encoder.float_to_bv_bits f in
+          let* v = Value_codec.float_to_bv_bits f in
           split_rval (Int v) at
       | Int v ->
           (* get our starting size and unsigned integer *)
@@ -118,7 +112,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
           let mask_l = BV.extract 0 ((at * 8) - 1) v in
           let mask_r = BV.extract (at * 8) ((size * 8) - 1) v in
           (Rust_val.Int mask_l, Rust_val.Int mask_r)
-      | _ -> not_impl "Split unsupported: %a at %a" pp_rust_val v Typed.ppa at
+      | _ -> not_impl "Split unsupported: %a at %a" Rust_val.pp v Typed.ppa at
 
     let split ~at node =
       match node with
@@ -132,7 +126,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
       | Lazy -> L.failwith "Should never split an intermediate node"
 
     type syn =
-      | SInit of Sptr.syn Rust_val.syn
+      | SInit of Rust_val.syn
       | SUninit
       | SZeros
       | SAny
@@ -141,7 +135,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
     [@@deriving show { with_path = false }]
 
     let ins_outs = function
-      | SInit v -> ([], Rust_val.exprs_syn Sptr.exprs_syn v)
+      | SInit v -> ([], Rust_val.exprs_syn v)
       | SUninit | SZeros | SAny -> ([], [])
       | STree_borrow_st s -> Borrows.State.ins_outs s
       | STree_borrow s -> Borrows.Tree.ins_outs s
@@ -170,7 +164,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
       | Leaf (leaf, tb) ->
           let leaf_ser =
             match leaf with
-            | Init v -> SInit ((Rust_val.to_syn Sptr.to_syn) v)
+            | Init v -> SInit (Rust_val.to_syn v)
             | Uninit -> SUninit
             | Zeros -> SZeros
             | Any -> SAny
@@ -185,11 +179,11 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
       | Lazy -> None
 
     let mk_fix_typed ty () =
-      let+^ v = Encoder.nondet_valid ty in
+      let+^ v = Value_codec.nondet_valid ty in
       (* we're basically guaranteed this won't error (ie. layout error) by now,
          so we can safely unwrap. *)
       let v = get_ok v in
-      [ SInit (Rust_val.to_syn Sptr.to_syn v) ]
+      [ SInit (Rust_val.to_syn v) ]
 
     type tree = (t, Typed.(T.sint t)) TB.tree
 
@@ -201,7 +195,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
       in
       TB.build_tree_leaf ~range:t.range ~node ()
 
-    module Rust_val_consumer = Rust_val.Learn_eq (DecayMap.SM)
+    module Rust_val_consumer = Rust_val.Learn_eq
 
     let consume (s : syn) (t : tree) : (tree, syn list) DecayMap.SM.Consumer.t =
       let open DecayMap.SM.Consumer in
@@ -216,7 +210,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
         match (s, v) with
         (* init *)
         | SInit e, Init v ->
-            let+ () = Rust_val_consumer.learn_eq Sptr.learn_eq e v in
+            let+ () = Rust_val_consumer.learn_eq e v in
             Unowned
         | SInit _, Zeros -> lift @@ not_impl "Assume rust_val.syn == 0s"
         | SInit _, _ -> lfail Typed.v_false
@@ -254,7 +248,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
           let* v =
             match s with
             | SInit v ->
-                let+ v = Producer.apply_subst (Rust_val.subst Sptr.subst) v in
+                let+ v = Producer.apply_subst Rust_val.subst v in
                 Init v
             | SZeros -> return Zeros
             | SUninit -> return Uninit
@@ -276,15 +270,15 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
             match s with
             | SZeros | SUninit | SAny -> return (s, s)
             | SInit v ->
-                let* v = Producer.apply_subst (Rust_val.subst Sptr.subst) v in
+                let* v = Producer.apply_subst Rust_val.subst v in
                 let _, middle = l.range in
                 let+^ vl, vr = split_rval v middle in
                 (* HACK: is this sound? Doing it this way because we can't have
                    a split_rval for exprs, given it requires decaying pointers.
                    An alternative would be to have a [produce_leaf] which takes
                    in a [Leaf _], so we only subst once. *)
-                let vl = Rust_val.to_syn Sptr.to_syn vl in
-                let vr = Rust_val.to_syn Sptr.to_syn vr in
+                let vl = Rust_val.to_syn vl in
+                let vr = Rust_val.to_syn vr in
                 (SInit vl, SInit vr)
             | _ -> assert false
           in
@@ -401,13 +395,13 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
 
   let decode_mem_val ~ty = function
     | Init value ->
-        let+ res = Encoder.transmute_one ~to_ty:ty value in
+        let+ res = Value_codec.transmute_one ~to_ty:ty value in
         Ok res
     | Zeros ->
         let**^ size = Layout.size_of ty in
         let* size = sint_to_int size in
         let zero = BV.zero (size * 8) in
-        let+ res = Encoder.transmute_one ~to_ty:ty (Int zero) in
+        let+ res = Value_codec.transmute_one ~to_ty:ty (Int zero) in
         Ok res
     | Uninit -> error `UninitializedMemoryAccess
     | Any ->
@@ -425,21 +419,21 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
     (* The tree spans the entire type we're interested in. Furthermore, we only
        read/write scalars (int, float, pointers...) which cover the whole range
        with no gaps. For lazy nodes, we convert all of these to bitvectors, the
-       concatenate them and call the encoder to decode the full value. *)
+       concatenate them and call the Value_codec to decode the full value. *)
     let** leaves = collect_leaves ~uninit:`Error t in
     let* leaves =
       DecayMap.SM.map_list leaves ~f:(fun (v, _, _) ->
           match v with
           | Int bv -> return bv
           | Ptr (ptr, Thin) -> Sptr.decay ptr
-          | Float f -> Encoder.float_to_bv_bits f
+          | Float f -> Value_codec.float_to_bv_bits f
           | _ ->
-              not_impl "Unexpected rust_val in lazy decoding: %a" pp_rust_val v)
+              not_impl "Unexpected rust_val in lazy decoding: %a" Rust_val.pp v)
     in
     match List.rev leaves with
     | hd :: tl ->
         let bv = List.fold_left BV.concat hd tl in
-        let+ res = Encoder.transmute_one ~to_ty:ty (Int bv) in
+        let+ res = Value_codec.transmute_one ~to_ty:ty (Int bv) in
         Ok res
     | _ -> L.failwith "Impossible"
 
@@ -496,7 +490,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
   (* Memory operations *)
 
   let load ~(ignore_borrow : bool) (ofs : Typed.([< T.sint ] t)) (ty : Types.ty)
-      (tag : Borrows.Tag.t option) (tb : Borrows.Tree.t option) =
+      (tag : Sptr.Tag.t option) (tb : Borrows.Tree.t option) =
     let open SM.Syntax in
     let** size = lift_symex @@ Layout.size_of ty in
     let ((_, bound) as range) = Range.of_low_and_size ofs size in
@@ -519,7 +513,7 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
         (sval, tree))
 
   let store (ofs : Typed.([< T.sint ] t)) (size : Typed.([< T.nonzero ] t))
-      (value : rust_val) (tag : Borrows.Tag.t option)
+      (value : Rust_val.t) (tag : Sptr.Tag.t option)
       (tb : Borrows.Tree.t option) : (unit, 'err, 'fix) SM.Result.t =
     let open SM.Syntax in
     (* manually coerce so types line up *)
@@ -550,7 +544,8 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) (Sptr : Sptr.S) = struct
 
   let get_init_leaves (ofs : Typed.([< T.sint ] t))
       (size : Typed.([< T.nonzero ] t)) :
-      (Typed.(rust_val * T.sint t * T.nonzero t) list, 'err, 'fix) SM.Result.t =
+      (Typed.(Rust_val.t * T.sint t * T.nonzero t) list, 'err, 'fix) SM.Result.t
+      =
     let ((_, bound) as range) = Range.of_low_and_size ofs (Typed.cast size) in
     with_bound_check bound (fun t ->
         let open DecayMap.SM.Syntax in

--- a/soteria-rust/lib/state/rust_state_m.ml
+++ b/soteria-rust/lib/state/rust_state_m.ml
@@ -2,6 +2,7 @@ open Compo_res
 open Rustsymex
 open Charon
 open Common
+open Rust_val
 
 module Compo_resT2 (I : sig
   type fix
@@ -125,7 +126,7 @@ module type S = sig
   end
 
   module Sptr : sig
-    include Sptr.S
+    include module type of Sptr
 
     val offset :
       ?check_signed:bool ->
@@ -134,23 +135,14 @@ module type S = sig
       t ->
       (t, 'env) monad
 
-    val check_aligned : t Rust_val.full_ptr -> Types.ty -> (unit, 'env) monad
-
-    val check_non_dangling :
-      t Rust_val.full_ptr -> Types.ty -> (unit, 'env) monad
-
+    val check_aligned : Rust_val.full_ptr -> Types.ty -> (unit, 'env) monad
+    val check_non_dangling : Rust_val.full_ptr -> Types.ty -> (unit, 'env) monad
     val check_non_dangling_untyped : t -> Typed.(T.sint t) -> (unit, 'env) monad
     val distance : t -> t -> (Typed.T.sint Typed.t, 'env) monad
     val decay : t -> (Typed.T.sint Typed.t, 'env) monad
     val expose : t -> (Typed.T.sint Typed.t, 'env) monad
     val dangling_if_zst : Types.ty -> (t option, 'env) monad
   end
-
-  type full_ptr = Sptr.t Rust_val.full_ptr
-  type rust_val = Sptr.t Rust_val.t
-
-  val pp_rust_val : Format.formatter -> rust_val -> unit
-  val pp_full_ptr : Format.formatter -> full_ptr -> unit
 
   module Layout : sig
     include module type of Layout
@@ -167,34 +159,37 @@ module type S = sig
     val unsize_path : Types.ty -> (int list option, 'env) monad
   end
 
-  module Encoder : sig
+  module Value_codec : sig
     val encode :
       offset:Typed.T.sint Typed.t ->
-      rust_val ->
+      Rust_val.t ->
       Types.ty ->
-      (Typed.(rust_val * T.sint t * T.nonzero t) Iter.t, 'env) monad
+      (Typed.(Rust_val.t * T.sint t * T.nonzero t) Iter.t, 'env) monad
 
     val cast_literal :
       from_ty:Values.literal_type ->
       to_ty:Values.literal_type ->
       [< Typed.T.cval ] Typed.t ->
-      rust_val
+      Rust_val.t
 
-    val nondet_valid : Types.ty -> (rust_val, 'env) monad
+    val nondet_valid : Types.ty -> (Rust_val.t, 'env) monad
 
     val ref_tys_in :
       f:('acc -> Types.ty -> full_ptr -> (full_ptr * 'acc, 'env) monad) ->
       init:'acc ->
       Types.ty ->
-      rust_val ->
-      (rust_val * 'acc, 'env) monad
+      Rust_val.t ->
+      (Rust_val.t * 'acc, 'env) monad
   end
 
   module State : sig
     val empty : st
-    val load : ?ignore_borrow:bool -> full_ptr -> Types.ty -> (rust_val, 'env) t
-    val load_discriminant : full_ptr -> Types.ty -> (rust_val, 'env) t
-    val store : full_ptr -> Types.ty -> rust_val -> (unit, 'env) t
+
+    val load :
+      ?ignore_borrow:bool -> full_ptr -> Types.ty -> (Rust_val.t, 'env) t
+
+    val load_discriminant : full_ptr -> Types.ty -> (Rust_val.t, 'env) t
+    val store : full_ptr -> Types.ty -> Rust_val.t -> (unit, 'env) t
     val zeros : full_ptr -> Typed.T.sint Typed.t -> (unit, 'env) t
     val alloc_ty : ?span:Meta.span_data -> Types.ty -> (full_ptr, 'env) t
 
@@ -216,7 +211,7 @@ module type S = sig
       (unit, 'env) t
 
     val transmute :
-      from:Types.ty -> to_:Types.ty -> rust_val -> (rust_val, 'env) t
+      from:Types.ty -> to_:Types.ty -> Rust_val.t -> (Rust_val.t, 'env) t
 
     val transmute_raw :
       to_:Types.ty ->
@@ -237,7 +232,7 @@ module type S = sig
     val lookup_fn : full_ptr -> (Fun_kind.t, 'env) t
 
     val lookup_const_generic :
-      Types.const_generic_var_id -> Types.ty -> (rust_val, 'env) t
+      Types.const_generic_var_id -> Types.ty -> (Rust_val.t, 'env) t
 
     val register_thread_exit : (unit -> (unit, unit) t) -> (unit, 'env) t
     val run_thread_exits : unit -> (unit, 'env) t
@@ -248,7 +243,7 @@ module type S = sig
 
     val size_and_align_of_val :
       Types.ty ->
-      Sptr.t Rust_val.meta ->
+      Rust_val.meta ->
       (Typed.T.sint Typed.t * Typed.T.nonzero Typed.t, 'env) t
   end
 
@@ -311,11 +306,6 @@ module Make (State : State_intf.S) :
 
   type st = State.t option
   type syn = State.syn
-  type full_ptr = State.Sptr.t Rust_val.full_ptr
-  type rust_val = State.Sptr.t Rust_val.t
-
-  let pp_rust_val = Rust_val.pp State.Sptr.pp
-  let pp_full_ptr = Rust_val.pp_full_ptr State.Sptr.pp
 
   module ESM = struct
     module MONAD = Monad.StateT_p (State.SM)
@@ -492,8 +482,8 @@ module Make (State : State_intf.S) :
     let[@inline] unsize_path ty = lift_err (unsize_path ty)
   end
 
-  module Encoder = struct
-    include Value_codec.Encoder (State.Sptr)
+  module Value_codec = struct
+    include Value_codec
 
     let[@inline] encode ~offset v ty = lift_err (encode ~offset v ty)
     let[@inline] nondet_valid ty = lift_err (nondet_valid ty)
@@ -502,8 +492,8 @@ module Make (State : State_intf.S) :
        having to re-define. *)
     let ref_tys_in
         ~(f : 'acc -> Types.ty -> full_ptr -> (full_ptr * 'acc, 'env) monad)
-        ~(init : 'acc) (ty : Types.ty) (v : rust_val) :
-        (rust_val * 'acc, 'env) monad =
+        ~(init : 'acc) (ty : Types.ty) (v : Rust_val.t) :
+        (Rust_val.t * 'acc, 'env) monad =
      fun env state ->
       let open Rustsymex.Syntax in
       (* The inner function operates in Rustsymex.Result.t, carrying (acc, env,

--- a/soteria-rust/lib/state/state_intf.ml
+++ b/soteria-rust/lib/state/state_intf.ml
@@ -12,7 +12,7 @@ module type S = sig
   type 'a ret := ('a, Error.with_trace, syn list) SM.Result.t
 
   module Sptr : sig
-    include Sptr.S
+    include module type of Sptr
 
     (** [offset ?check_signed ?ty ptr off] Offsets [ptr] by the size of [ty] *
         [off]. [ty] defaults to u8.
@@ -31,7 +31,7 @@ module type S = sig
     (** Checks this pointer isn't dangling for the given pointee type, i.e. it
         points to an allocation and doesn't range outside of it. This also
         checks the allocation is live, and that the type is inhabited, *)
-    val check_non_dangling : t full_ptr -> Types.ty -> unit ret
+    val check_non_dangling : full_ptr -> Types.ty -> unit ret
 
     (** Same as {!check_non_dangling}, but for untyped ranges, where only a size
         is known. The size is signed: if less than 0, the range preceding the
@@ -41,11 +41,8 @@ module type S = sig
     (** Checks this pointer is sufficiently aligned for the given type. This
         takes into account the metadata: for a [&dyn Trait], it will access the
         VTable to check alignment. *)
-    val check_aligned : t full_ptr -> Types.ty -> unit ret
+    val check_aligned : full_ptr -> Types.ty -> unit ret
   end
-
-  type full_ptr := Sptr.t full_ptr
-  type rust_val := Sptr.t rust_val
 
   (** Prettier but expensive printing. *)
   val pp_pretty : ignore_freed:bool -> t Fmt.t
@@ -68,7 +65,7 @@ module type S = sig
   val free : full_ptr -> unit ret
 
   val size_and_align_of_val :
-    Types.ty -> Sptr.t Rust_val.meta -> (T.sint Typed.t * T.nonzero Typed.t) ret
+    Types.ty -> Rust_val.meta -> (T.sint Typed.t * T.nonzero Typed.t) ret
 
   val fake_read : full_ptr -> Types.ty -> unit ret
 

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -12,145 +12,6 @@ open Sptr
 module Make (Borrows : Tree_borrows.T) = struct
   module Borrows = Borrows (DecayMap.SM)
 
-  (* Pointer implementation *)
-
-  module Sptr_base = struct
-    module Logic = Soteria.Logic.Make (DecayMap.SM)
-    module L_option = Logic.Util.Option
-
-    (* TODO: we need a derive for S_with_syn; with the right abstractions in
-       Logic.Util it should be very straightforward. *)
-
-    type ('sptr, 'snonzero, 'sint, 'tag) base = {
-      ptr : 'sptr;
-      tag : 'tag option;
-      align : 'snonzero;
-      size : 'sint;
-    }
-
-    type t =
-      (T.sptr Typed.t, T.nonzero Typed.t, T.sint Typed.t, Borrows.Tag.t) base
-
-    type syn = (Typed.Expr.t, Typed.Expr.t, Typed.Expr.t, Borrows.Tag.syn) base
-
-    let pp' pp_v pp_tag fmt { ptr; tag; _ } =
-      Fmt.pf fmt "%a[%a]" pp_v ptr Fmt.(option ~none:(any "*") pp_tag) tag
-
-    let pp = pp' Typed.ppa Borrows.Tag.pp
-    let show = Fmt.to_to_string pp
-    let pp_syn = pp' Typed.Expr.pp Borrows.Tag.pp_syn
-    let show_syn = Fmt.to_to_string pp_syn
-
-    let to_syn { ptr; tag; align; size } =
-      {
-        ptr = Typed.Expr.of_value ptr;
-        align = Typed.Expr.of_value align;
-        size = Typed.Expr.of_value size;
-        tag = L_option.to_syn Borrows.Tag.to_syn tag;
-      }
-
-    let in_bound { ptr; size; _ } =
-      let ofs = Typed.Ptr.ofs ptr in
-      Usize.(0s) <=@ ofs &&@ (ofs <@ size)
-
-    let learn_eq syn t =
-      let open DecayMap.SM.Consumer in
-      let open Syntax in
-      let* () = L_option.learn_eq Borrows.Tag.learn_eq syn.tag t.tag in
-      let* () = learn_eq syn.ptr t.ptr in
-      let* () = learn_eq syn.align t.align in
-      learn_eq syn.size t.size
-
-    let exprs_syn { ptr; align; size; tag } =
-      L_option.exprs_syn Borrows.Tag.exprs_syn tag @ [ ptr; align; size ]
-
-    let fresh () = L.failwith "Fresh unimplemented for sptr (for now)"
-
-    let subst subst_val p =
-      let se = Typed.Expr.subst subst_val in
-      let ptr = se p.ptr in
-      let align = se p.align in
-      let size = se p.size in
-      let tag = L_option.subst Borrows.Tag.subst subst_val p.tag in
-      { ptr; align; size; tag }
-
-    let null () =
-      {
-        ptr = Typed.Ptr.null ();
-        tag = None;
-        align = Usize.(1s);
-        size = Usize.(0s);
-      }
-
-    let of_address ofs =
-      let null_ptr = null () in
-      let ptr = Typed.Ptr.add_ofs null_ptr.ptr ofs in
-      { null_ptr with ptr }
-
-    let dangling_if_zst ty =
-      let open Rustsymex in
-      let open Syntax in
-      let** layout = Layout.layout_of ty in
-      if%sat layout.size ==@ Usize.(0s) then
-        (* UX: really any address that is well-aligned is valid, we
-           under-approximate here to make our life easier. *)
-        Result.ok (Some (of_address layout.align))
-      else Result.ok None
-
-    let is_null { ptr; _ } = Typed.Ptr.is_null ptr
-    let ofs { ptr; _ } = Typed.Ptr.ofs ptr
-    let has_provenance { ptr; _ } = Typed.not (Typed.Ptr.is_at_null_loc ptr)
-
-    let have_same_provenance { ptr = ptr1; _ } { ptr = ptr2; _ } =
-      Typed.Ptr.loc ptr1 ==@ Typed.Ptr.loc ptr2
-
-    (** A simplified (and unsafe) version of [offset], that adds a signed
-        bitvector to this pointer's offset. *)
-    let raw_offset ptr off_by =
-      let open Rustsymex.Syntax in
-      let loc, ofs = Typed.Ptr.decompose ptr.ptr in
-      let ofs', ovf = ofs +$?@ off_by in
-      let++ () = assert_or_error (Typed.not ovf) `UBDanglingPointer in
-      { ptr with ptr = Typed.Ptr.mk loc ofs' }
-
-    let[@inline] _decay ~expose { ptr; align; size; _ } =
-      let open DecayMap.SM.Syntax in
-      let loc, ofs = Typed.Ptr.decompose ptr in
-      let+ loc_int = DecayMap.decay ~expose ~size ~align loc in
-      [%l.debug "Decay %a -> %a" Typed.ppa loc Typed.ppa loc_int];
-      loc_int +!!@ ofs
-
-    let decay p = _decay ~expose:false p
-    let expose p = _decay ~expose:true p
-
-    let distance ({ ptr = ptr1; _ } as p1) ({ ptr = ptr2; _ } as p2) =
-      let open DecayMap.SM.Syntax in
-      if%sat have_same_provenance p1 p2 then
-        DecayMap.SM.return (Typed.Ptr.ofs ptr1 -!@ Typed.Ptr.ofs ptr2)
-      else
-        let* ptr1 = decay p1 in
-        let+ ptr2 = decay p2 in
-        ptr1 -!@ ptr2
-
-    let as_id { ptr; _ } = Typed.cast @@ Typed.Ptr.loc ptr
-    let allocation_info { size; align; _ } = (Typed.cast size, Typed.cast align)
-
-    let nondet ty =
-      let open Rustsymex.Syntax in
-      let** layout = Layout.layout_of ty in
-      let* loc = nondet (Typed.t_loc ()) in
-      let* ofs = nondet (Typed.t_usize ()) in
-      let* tag, _ =
-        DecayMap.SM.run_with_state ~state:None @@ Borrows.Tag.nondet ()
-      in
-      let ptr = Typed.Ptr.mk loc ofs in
-      let ptr = { ptr; tag; align = layout.align; size = layout.size } in
-      Result.ok ptr
-  end
-
-  (* State details *)
-  module Encoder = Value_codec.Encoder (Sptr_base)
-
   (* State combinators *)
 
   module StateKey = struct
@@ -183,13 +44,13 @@ module Make (Borrows : Tree_borrows.T) = struct
   end
 
   module Freeable = Soteria.Sym_states.Freeable.Make (DecayMap.SM)
-  module Tree_block = Rtree_block.Make (Borrows) (Sptr_base)
+  module Tree_block = Rtree_block.Make (Borrows)
 
   module Meta = struct
     type t = {
       align : Typed.T.nonzero Typed.t;
       size : Typed.T.sint Typed.t;
-      tb_root : Borrows.Tag.t;
+      tb_root : Sptr.Tag.t;
       kind : Alloc_kind.t;
       trace : Trace.t;
     }
@@ -265,8 +126,8 @@ module Make (Borrows : Tree_borrows.T) = struct
 
     (** Borrows a given pointer. [ty] is the type of the pointer/reference/box
         being reborrowed. *)
-    let borrow ?(protect = false) ((ptr : Sptr_base.t), meta) tag
-        (ty : Types.ty) ofs =
+    let borrow ?(protect = false) ((ptr : Sptr.t), meta) tag (ty : Types.ty) ofs
+        =
       let pointee = get_pointee ty in
       (* FIXME: this logic is tree borrows related and should be handled there.
          https://github.com/soteria-tools/soteria/issues/301 *)
@@ -289,7 +150,7 @@ module Make (Borrows : Tree_borrows.T) = struct
       [%l.debug
         "%s pointer %a -> %a (%a)"
           (if protect then "Protecting" else "Borrowing")
-          Sptr_base.pp ptr Sptr_base.pp ptr' Tree_borrows.pp_state state];
+          Sptr.pp ptr Sptr.pp ptr' Tree_borrows.pp_state state];
       if not protect then Result.ok (ptr', meta)
       else
         let**^ size = DecayMap.SM.lift @@ Layout.size_of pointee in
@@ -329,7 +190,7 @@ module Make (Borrows : Tree_borrows.T) = struct
       | _ -> None
 
     let make ?span ?zeroed ~size ~align () :
-        (t * Borrows.Tag.t option) DecayMap.SM.t =
+        (t * Sptr.Tag.t option) DecayMap.SM.t =
       let open DecayMap.SM.Syntax in
       let* tag, block = Block.alloc ?zeroed size in
       let*^ kind = get_alloc_kind () in
@@ -354,10 +215,10 @@ module Make (Borrows : Tree_borrows.T) = struct
       let open SM.Syntax in
       let+ st = SM.get_state () in
       [%l.debug
-        "%a access to the state at pointer %a" pp_access access Sptr_base.pp ptr];
+        "%a access to the state at pointer %a" pp_access access Sptr.pp ptr];
       [%l.trace "STATE:@\n%a" (Fmt.Dump.option pp) st]
 
-    let with_ptr (access : access) (ptr : Sptr_base.t)
+    let with_ptr (access : access) (ptr : Sptr.t)
         (f : [< T.sint ] Typed.t -> ('a, 'err, 'fix list) Block.SM.Result.t) :
         ('a, 'err, syn list) SM.Result.t =
       let open SM in
@@ -384,7 +245,7 @@ module Make (Borrows : Tree_borrows.T) = struct
       match (res, Config.get_mode ()) with
       | (Missing _ as miss), Whole_program ->
           (* HACK: a miss in WPST means there is a dangling pointer. *)
-          if%sat Typed.not (Sptr_base.has_provenance ptr) then
+          if%sat Typed.not (Sptr.has_provenance ptr) then
             Result.error `UBDanglingPointer
           else return miss
       | ok_or_err, _ -> return ok_or_err
@@ -398,14 +259,11 @@ module Make (Borrows : Tree_borrows.T) = struct
          | Some { node = Freed; _ } -> SM.Result.ok true
          | _ -> SM.Result.ok false)
 
-    module Decoder =
-      Value_codec.Decoder
-        (Sptr_base)
-        (struct
-          module SM = SM
+    module Decoder = Value_codec.Decoder (struct
+      module SM = SM
 
-          type fix = syn list
-        end)
+      type fix = syn list
+    end)
   end
 
   type t = {
@@ -417,12 +275,12 @@ module Make (Borrows : Tree_borrows.T) = struct
             is_empty = FunBiMap.is_empty;
             pp = FunBiMap.pp;
           }]
-    globals : Sptr_base.t Rust_val.full_ptr GlobMap.t;
+    globals : Rust_val.full_ptr GlobMap.t;
         [@sym_state.ignore
           {
             empty = GlobMap.empty;
             is_empty = GlobMap.is_empty;
-            pp = GlobMap.pp (pp_full_ptr Sptr_base.pp);
+            pp = GlobMap.pp pp_full_ptr;
           }]
     errors : Error.with_trace list;
         [@sym_state.ignore
@@ -434,11 +292,11 @@ module Make (Borrows : Tree_borrows.T) = struct
       ((unit, Error.with_trace, unit) Compo_res.t * t option) Rustsymex.t)
       option;
         [@sym_state.ignore { empty = None }]
-    const_generics : Sptr_base.t rust_val Types.ConstGenericVarId.Map.t;
+    const_generics : rust_val Types.ConstGenericVarId.Map.t;
         [@sym_state.ignore
           {
             empty = Types.ConstGenericVarId.Map.empty;
-            pp = Types.ConstGenericVarId.Map.pp (pp_rust_val Sptr_base.pp);
+            pp = Types.ConstGenericVarId.Map.pp pp_rust_val;
           }]
   }
   [@@deriving sym_state { symex = Rustsymex }]
@@ -466,8 +324,7 @@ module Make (Borrows : Tree_borrows.T) = struct
   let log action ptr =
     let+ st = SM.get_state () in
     [%l.trace
-      "About to execute action: %s (%a)@\n@[<2>STATE:@ %a@]" action Sptr_base.pp
-        ptr
+      "About to execute action: %s (%a)@\n@[<2>STATE:@ %a@]" action Sptr.pp ptr
         (Fmt.Dump.option (pp_pretty ~ignore_freed:true))
         st]
 
@@ -504,10 +361,9 @@ module Make (Borrows : Tree_borrows.T) = struct
 
   let with_ptr access ptr f = with_heap @@ Heap.with_ptr access ptr f
 
-  let uninit ((ptr, _) : Sptr_base.t * 'a) (ty : Types.ty) :
+  let uninit ((ptr, _) : Sptr.t * 'a) (ty : Types.ty) :
       (unit, 'err, 'fix) Result.t =
-    [%l.debug
-      "Executing Uninit with pointer %a for %a" Sptr_base.pp ptr pp_ty ty];
+    [%l.debug "Executing Uninit with pointer %a for %a" Sptr.pp ptr pp_ty ty];
     let@ () = with_loc_err ~trace:"Uninitialising memory" () in
     let* () = log "uninit" ptr in
     let**^ size = Layout.size_of ty in
@@ -521,19 +377,19 @@ module Make (Borrows : Tree_borrows.T) = struct
       let usize : Types.ty = TLiteral (TUInt Usize) in
       let** field_size = Layout.size_of usize in
       let ofs = match field with `Size -> Usize.(1s) | `Align -> Usize.(2s) in
-      let** ptr' = Sptr_base.raw_offset ptr (ofs *!!@ field_size) in
+      let** ptr' = Sptr.raw_offset ptr (ofs *!!@ field_size) in
       let ptr' = (ptr', Thin) in
       let+ res, _ = load ~ignore_borrow:true ~check_refs:false ptr' usize st in
       res
     in
-    lift @@ Encoder.size_and_align_of_val ~load_vtable ~t ~meta
+    lift @@ Value_codec.size_and_align_of_val ~load_vtable ~t ~meta
 
-  and check_ptr_align ((ptr, meta) : 'a full_ptr) (ty : Types.ty) =
+  and check_ptr_align ((ptr, meta) : full_ptr) (ty : Types.ty) =
     (* The expected alignment of a dyn pointer is stored inside the VTable *)
     let** _, exp_align = size_and_align_of_val ty meta in
     [%l.debug
-      "Checking pointer alignment of %a: expect %a for %a" Sptr_base.pp ptr
-        Typed.ppa exp_align pp_ty ty];
+      "Checking pointer alignment of %a: expect %a for %a" Sptr.pp ptr Typed.ppa
+        exp_align pp_ty ty];
     let loc, ofs = Typed.Ptr.decompose ptr.ptr in
     (* A pointer with no provenance is aligned to it's offset *)
     let align = Typed.(ite (Ptr.is_null_loc loc) exp_align (cast ptr.align)) in
@@ -549,18 +405,18 @@ module Make (Borrows : Tree_borrows.T) = struct
          This avoids going through extra branches, as a pointer can pretty much
          always be aligned; what matters most is whether it is guaranteed to be
          aligned. *)
-      let* address = with_pointers_sym @@ Sptr_base.decay ptr in
+      let* address = with_pointers_sym @@ Sptr.decay ptr in
       if%sure address %@ exp_align ==@ Usize.(0s) then Result.ok ()
       else Result.error (`MisalignedPointer (exp_align, align, ofs))
     else Result.ok ()
 
-  and check_non_dangling_untyped (ptr : Sptr_base.t) size =
+  and check_non_dangling_untyped (ptr : Sptr.t) size =
     if%sat size ==@ Usize.(0s) then Result.ok ()
     else
       let** ptr, size =
         if%sat size >$@ Usize.(0s) then Result.ok (ptr, size)
         else
-          let++^ ptr' = Sptr_base.raw_offset ptr size in
+          let++^ ptr' = Sptr.raw_offset ptr size in
           (ptr', Typed.(cast (BV.neg size)))
       in
       let open Block.SM.Syntax in
@@ -589,14 +445,14 @@ module Make (Borrows : Tree_borrows.T) = struct
         fake_read ptr ty
       else default_check
     in
-    Encoder.check_validity ~check_ref ty value
+    Value_codec.check_validity ~check_ref ty value
 
   and load ?ignore_borrow ?(check_refs = true) ((ptr, meta) as fptr) ty :
-      (Sptr_base.t rust_val, Error.t, syn list) Result.t =
+      (rust_val, Error.t, syn list) Result.t =
     let** () = check_ptr_align fptr ty in
     let parser ~offset = Heap.Decoder.decode ~meta ~offset ty in
     let** value = apply_parser ?ignore_borrow ptr parser in
-    [%l.debug "Finished reading rust value %a" (Rust_val.pp Sptr_base.pp) value];
+    [%l.debug "Finished reading rust value %a" Rust_val.pp value];
     let++ () = check_validity ~check_refs ty value in
     value
 
@@ -629,9 +485,7 @@ module Make (Borrows : Tree_borrows.T) = struct
     in
     if skip_check then Result.ok ()
     else (
-      [%l.debug
-        "Checking validity of %a for %a" (pp_full_ptr Sptr_base.pp) fptr pp_ty
-          ty];
+      [%l.debug "Checking validity of %a for %a" pp_full_ptr fptr pp_ty ty];
       let*- err =
         let++ _ = load ~ignore_borrow:true ~check_refs:false fptr ty in
         ()
@@ -649,7 +503,7 @@ module Make (Borrows : Tree_borrows.T) = struct
   (** Performs a load at the tree borrow level, by updating the borrow state,
       without attempting to validate the values or checking uninitialised memory
       accesses; all of these are ignored. *)
-  let tb_load_untyped (ptr : Sptr_base.t) size =
+  let tb_load_untyped (ptr : Sptr.t) size =
     let open SM in
     match ptr.tag with
     | None -> Result.ok ()
@@ -663,24 +517,22 @@ module Make (Borrows : Tree_borrows.T) = struct
   (** Performs a load at the tree borrow level, by updating the borrow state,
       without attempting to validate the values or checking uninitialised memory
       accesses; all of these are ignored. *)
-  let tb_load ((ptr : Sptr_base.t), _) ty =
-    [%l.debug
-      "Executing Tb_load with pointer %a for %a" Sptr_base.pp ptr pp_ty ty];
+  let tb_load ((ptr : Sptr.t), _) ty =
+    [%l.debug "Executing Tb_load with pointer %a for %a" Sptr.pp ptr pp_ty ty];
     let@ () = with_loc_err ~trace:"Tree Borrow access" () in
     let**^ size = Layout.size_of ty in
     tb_load_untyped ptr size
 
   let store ((ptr, _) as fptr) ty sval :
       (unit, Error.with_trace, syn list) Result.t =
-    [%l.debug
-      "Executing Store with pointer %a for %a" Sptr_base.pp ptr pp_ty ty];
+    [%l.debug "Executing Store with pointer %a for %a" Sptr.pp ptr pp_ty ty];
     let@ () = with_loc_err ~trace:"Memory store" () in
-    let**^ parts = Encoder.encode ~offset:Usize.(0s) sval ty in
+    let**^ parts = Value_codec.encode ~offset:Usize.(0s) sval ty in
     if Iter.is_empty parts then Result.ok ()
     else
       let** () = check_ptr_align fptr ty in
       (* [%l.debug "Parsed to parts [%a]" (Iter.pp_seq ~sep:", " (Fmt.Dump.pair
-         Encoder.pp_rust_val Typed.ppa)) parts]; *)
+         Value_codec.pp_rust_val Typed.ppa)) parts]; *)
       let* () = log "store" ptr in
       let**^ size = Layout.size_of ty in
       let@ ofs = with_ptr Write ptr in
@@ -696,14 +548,11 @@ module Make (Borrows : Tree_borrows.T) = struct
   (** We can't use {!Heap.Decoder} for [transmute], since the transmute happens
       regardless of the heap's state, so we need to re-instantiate it for tree
       block instead *)
-  module Tree_block_decoder =
-    Value_codec.Decoder
-      (Sptr_base)
-      (struct
-        module SM = Tree_block.SM
+  module Tree_block_decoder = Value_codec.Decoder (struct
+    module SM = Tree_block.SM
 
-        type fix = Tree_block.syn list
-      end)
+    type fix = Tree_block.syn list
+  end)
 
   let transmute_raw_inner ~to_ ~size blocks =
     (* a transmute is just a write of one type with a read of another type; we
@@ -741,15 +590,13 @@ module Make (Borrows : Tree_borrows.T) = struct
     value
 
   let transmute ~from ~to_ v =
-    [%l.debug
-      "Transmuting %a: %a -> %a" (pp_rust_val Sptr_base.pp) v pp_ty from pp_ty
-        to_];
+    [%l.debug "Transmuting %a: %a -> %a" Rust_val.pp v pp_ty from pp_ty to_];
     let@ () = with_loc_err ~trace:"Transmute" () in
     (* We pick [from] rather than [to_], because we can transmute to a smaller
        type, but not to a larger one, so it's guaranteed that [size(from) >=
        size(to_)] *)
     let**^ size = Layout.size_of from in
-    let**^ blocks = Encoder.encode ~offset:Usize.(0s) v from in
+    let**^ blocks = Value_codec.encode ~offset:Usize.(0s) v from in
     transmute_raw_inner ~to_ ~size blocks
 
   let transmute_raw ~to_ blocks =
@@ -757,21 +604,19 @@ module Make (Borrows : Tree_borrows.T) = struct
       "Transmuting (raw) %a -> %a"
         Fmt.(
           list ~sep:(any ", ") (fun ft (v, ofs, sz) ->
-              pf ft "(%a: %a-%a)" (pp_rust_val Sptr_base.pp) v Typed.ppa ofs
-                Typed.ppa sz))
+              pf ft "(%a: %a-%a)" Rust_val.pp v Typed.ppa ofs Typed.ppa sz))
         blocks pp_ty to_];
     let@ () = with_loc_err ~trace:"Transmute" () in
     let**^ size = Layout.size_of to_ in
     transmute_raw_inner ~to_ ~size (Iter.of_list blocks)
 
   module Sptr = struct
-    include Sptr_base
+    include Sptr
 
     let offset ?check_signed ?(ty = Types.TLiteral (TUInt U8)) off_by
         ({ ptr; _ } as fptr) =
       [%l.debug
-        "Executing Offset of pointer %a by %a" Sptr_base.pp fptr Typed.ppa
-          off_by];
+        "Executing Offset of pointer %a by %a" Sptr.pp fptr Typed.ppa off_by];
       let@ () = with_loc_err ~trace:"Pointer offset" () in
       let**^ size = Layout.size_of ty in
       let loc, off = Typed.Ptr.decompose ptr in
@@ -825,28 +670,25 @@ module Make (Borrows : Tree_borrows.T) = struct
     size_and_align_of_val ty meta
 
   let load ?ignore_borrow ((ptr, _) as fptr) ty =
-    [%l.debug "Executing Load with pointer %a for %a" Sptr_base.pp ptr pp_ty ty];
+    [%l.debug "Executing Load with pointer %a for %a" Sptr.pp ptr pp_ty ty];
     let@ () = with_loc_err ~trace:"Memory load" () in
     load ?ignore_borrow fptr ty
 
   let load_discriminant ((ptr, _) as fptr) ty =
     [%l.debug
-      "Executing Load_discriminant with pointer %a for %a" Sptr_base.pp ptr
-        pp_ty ty];
+      "Executing Load_discriminant with pointer %a for %a" Sptr.pp ptr pp_ty ty];
     let@ () = with_loc_err ~trace:"Memory load (discriminant)" () in
     load_discriminant fptr ty
 
   let fake_read ((ptr, _) as fptr) ty =
-    [%l.debug
-      "Executing Fake_read with pointer %a for %a" Sptr_base.pp ptr pp_ty ty];
+    [%l.debug "Executing Fake_read with pointer %a for %a" Sptr.pp ptr pp_ty ty];
     let@ () = with_loc_err ~trace:"Fake read" () in
     fake_read fptr ty
 
   let copy_nonoverlapping ~src:(src, _) ~dst:(dst, _) ~size :
       (unit, Error.with_trace, syn list) Result.t =
     [%l.debug
-      "Executing Copy_nonoverlapping from %a to %a" Sptr_base.pp src
-        Sptr_base.pp dst];
+      "Executing Copy_nonoverlapping from %a to %a" Sptr.pp src Sptr.pp dst];
     let@ () = with_loc_err ~trace:"Non-overlapping copy" () in
     let** tree_to_write =
       let@ ofs = with_ptr Read src in
@@ -925,7 +767,7 @@ module Make (Borrows : Tree_borrows.T) = struct
        in
        let** loc = Heap.alloc ~new_codom:block in
        let ptr = Typed.Ptr.mk loc Usize.(0s) in
-       let ptr : Sptr_base.t = { ptr; tag; align; size } in
+       let ptr : Sptr.t = { ptr; tag; align; size } in
        (* The pointer is necessarily not null *)
        let+ () = assume [ Typed.(not (Ptr.is_null_loc loc)) ] in
        ok (ptr, Thin))
@@ -953,11 +795,11 @@ module Make (Borrows : Tree_borrows.T) = struct
            (* create pointer *)
            let* () = assume [ Typed.(not (Ptr.is_null_loc loc)) ] in
            let ptr = Typed.Ptr.mk loc Usize.(0s) in
-           let ptr : Sptr_base.t = { ptr; tag; align; size } in
+           let ptr : Sptr.t = { ptr; tag; align; size } in
            return ((ptr, Thin), block)))
 
-  let free ((ptr : Sptr_base.t), _) =
-    [%l.debug "Executing Free with pointer %a" Sptr_base.pp ptr];
+  let free ((ptr : Sptr.t), _) =
+    [%l.debug "Executing Free with pointer %a" Sptr.pp ptr];
     let@ () = with_loc_err ~trace:"Freeing memory" () in
     let loc, ofs = Typed.Ptr.decompose ptr.ptr in
     let** () = assert_or_error (ofs ==@ Usize.(0s)) `InvalidFree in
@@ -978,14 +820,13 @@ module Make (Borrows : Tree_borrows.T) = struct
      *             Tree_block.SM.Result.error `InvalidFreeStrongProtector
      *           else Tree_block.SM.Result.ok ()))
      * in *)
-    [%l.debug "Freeing pointer %a" Sptr_base.pp ptr];
+    [%l.debug "Freeing pointer %a" Sptr.pp ptr];
     with_heap
       (Heap.wrap loc (Freeable_block_with_meta.wrap (Freeable_block.free ())))
 
   let zeros (ptr, _) size =
     [%l.debug
-      "Executing Zeros with pointer %a (size %a)" Sptr_base.pp ptr Typed.ppa
-        size];
+      "Executing Zeros with pointer %a (size %a)" Sptr.pp ptr Typed.ppa size];
     let@ () = with_loc_err ~trace:"Memory store (0s)" () in
     let* () = log "zeroes" ptr in
     let@ ofs = with_ptr Write ptr in
@@ -1011,9 +852,8 @@ module Make (Borrows : Tree_borrows.T) = struct
     let ptr = GlobMap.find_opt (Global g) globals in
     Rustsymex.Result.ok (ptr, globals)
 
-  let borrow ?protect (((ptr : Sptr_base.t), _) as fptr) (ty : Types.ty) =
-    [%l.debug
-      "Executing Borrow with pointer %a for %a" Sptr_base.pp ptr pp_ty ty];
+  let borrow ?protect (((ptr : Sptr.t), _) as fptr) (ty : Types.ty) =
+    [%l.debug "Executing Borrow with pointer %a for %a" Sptr.pp ptr pp_ty ty];
     let@ () = with_loc_err ~trace:"Borrow" () in
     match ptr.tag with
     | None -> Result.ok fptr
@@ -1021,9 +861,8 @@ module Make (Borrows : Tree_borrows.T) = struct
         let@ ofs = with_ptr Ghost ptr in
         Block.borrow ?protect fptr tag ty ofs
 
-  let unprotect ((ptr : Sptr_base.t), _) (ty : Types.ty) =
-    [%l.debug
-      "Executing Unprotect with pointer %a for %a" Sptr_base.pp ptr pp_ty ty];
+  let unprotect ((ptr : Sptr.t), _) (ty : Types.ty) =
+    [%l.debug "Executing Unprotect with pointer %a for %a" Sptr.pp ptr pp_ty ty];
     let@ () = with_loc_err ~trace:"Reference unprotection" () in
     match ptr.tag with
     | None -> Result.ok ()
@@ -1033,7 +872,7 @@ module Make (Borrows : Tree_borrows.T) = struct
         else
           let**^ size = Layout.size_of ty in
           let@ ofs = with_ptr Ghost ptr in
-          [%l.debug "Unprotecting pointer %a" Sptr_base.pp ptr];
+          [%l.debug "Unprotecting pointer %a" Sptr.pp ptr];
           Block.unprotect ofs tag size
 
   let with_exposed addr =
@@ -1047,7 +886,7 @@ module Make (Borrows : Tree_borrows.T) = struct
            let open Heap.SM.Syntax in
            let*^ res = DecayMap.from_exposed addr in
            match res with
-           | None -> Result.ok (Sptr_base.of_address addr, Thin)
+           | None -> Result.ok (Sptr.of_address addr, Thin)
            | Some (loc, ofs) -> (
                let ofs = addr -!@ ofs in
                let ptr = Typed.Ptr.mk loc ofs in
@@ -1061,7 +900,7 @@ module Make (Borrows : Tree_borrows.T) = struct
                      ~reason:
                        "Get a pointer from exposed with no matching allocation?"
                | Some { info = Some { size; align; _ }; _ } ->
-                   let ptr : Sptr_base.t = { ptr; tag = None; align; size } in
+                   let ptr : Sptr.t = { ptr; tag = None; align; size } in
                    Result.ok (ptr, Thin)))
 
   let leak_check () : (unit, Error.with_trace, syn list) Result.t =
@@ -1114,7 +953,7 @@ module Make (Borrows : Tree_borrows.T) = struct
     in
     match result with
     | Some loc ->
-        let ptr : Sptr_base.t =
+        let ptr : Sptr.t =
           {
             ptr = Typed.Ptr.mk loc Usize.(0s);
             tag = None;
@@ -1138,7 +977,7 @@ module Make (Borrows : Tree_borrows.T) = struct
         with_functions_sym (fun fns ->
             Rustsymex.Result.ok ((ptr, meta), FunBiMap.add loc fn_def fns))
 
-  let lookup_fn (({ ptr; _ } : Sptr_base.t), _) =
+  let lookup_fn (({ ptr; _ } : Sptr.t), _) =
     let open Rustsymex in
     let open Syntax in
     let@ () = with_loc_err ~trace:"Accessing function pointer" () in
@@ -1159,7 +998,7 @@ module Make (Borrows : Tree_borrows.T) = struct
     match Types.ConstGenericVarId.Map.find_opt id const_generics with
     | Some v -> Result.ok (v, const_generics)
     | None ->
-        let++ v = Encoder.nondet_valid ty in
+        let++ v = Value_codec.nondet_valid ty in
         (v, Types.ConstGenericVarId.Map.add id v const_generics)
 
   let register_thread_exit callback =

--- a/soteria-rust/lib/store.ml
+++ b/soteria-rust/lib/store.ml
@@ -69,29 +69,27 @@ module Binding = struct
       - Uninit: the symbol is bound to an immediate, uninitialized value.
       - Dead: the symbol is dead; it doesn't exist (e.g. after a [StorageDead]).
   *)
-  type 'a kind =
-    | Stackptr of 'a Rust_val.full_ptr
-    | Value of 'a Rust_val.t
+  type kind =
+    | Stackptr of Rust_val.full_ptr
+    | Value of Rust_val.t
     | Uninit
     | Dead
   [@@deriving show { with_path = false }]
 
-  type 'a t = { kind : 'a kind; ty : Types.ty }
+  type t = { kind : kind; ty : Types.ty }
 
   let pp ft { kind; ty } =
     match kind with
     | Stackptr ptr ->
-        Fmt.pf ft "Stackptr(%a) : %a"
-          (Rust_val.pp_full_ptr Fmt.nop)
-          ptr pp_ty ty
-    | Value v -> Fmt.pf ft "Value(%a) : %a" (Rust_val.pp Fmt.nop) v pp_ty ty
+        Fmt.pf ft "Stackptr(%a) : %a" Rust_val.pp_full_ptr ptr pp_ty ty
+    | Value v -> Fmt.pf ft "Value(%a) : %a" Rust_val.pp v pp_ty ty
     | Uninit -> Fmt.pf ft "Uninit : %a" pp_ty ty
     | Dead -> Fmt.pf ft "Dead : %a" pp_ty ty
 
   let as_value = function { kind = Value v; _ } -> Some v | _ -> None
 
-  let bind_value (f : 'a Rust_val.t -> 'a kind) :
-      'a kind option -> 'a kind option = function
+  let bind_value (f : Rust_val.t -> kind) : kind option -> kind option =
+    function
     | Some (Value v) -> Some (f v)
     | (Some Uninit | Some Dead) as v -> v
     | Some (Stackptr _) | None -> None
@@ -99,7 +97,7 @@ end
 
 open Binding
 
-type 'a t = 'a Binding.t Map.t
+type t = Binding.t Map.t
 
 let pp ft s =
   Fmt.(
@@ -121,13 +119,13 @@ let declare_ptr sym ptr t = declare sym (Stackptr ptr) t
 let declare_uninit sym t = declare sym Uninit t
 let dealloc sym t = declare sym Dead t
 let get_ty sym t = (Map.find sym t).ty
-let find local (store : 'a t) = Map.find local store
+let find local (store : t) = Map.find local store
 let empty = Map.empty
-let bindings (store : 'a t) = Map.bindings store
+let bindings (store : t) = Map.bindings store
 
 (** [try_load p s] tries loading [p] from the [s], returning [Some v] if it
     succeded, and [None] if it has to be spilled into the heap. *)
-let rec try_load (place : Place.t) (store : 'a t) : 'a Binding.kind option =
+let rec try_load (place : Place.t) (store : t) : Binding.kind option =
   match place.kind with
   | Local v -> Some (find v store).kind
   | Field (base, ProjAdt (_, Some _var), field) -> (

--- a/soteria-rust/lib/tree_borrows/concrete.ml
+++ b/soteria-rust/lib/tree_borrows/concrete.ml
@@ -8,23 +8,6 @@ module Make (Symex : Tree_borrows_intf.Rust_symex) :
   open Symex
   open Raw
 
-  module Tag = struct
-    include Tag
-
-    type syn = t [@@deriving show { with_path = false }]
-
-    let to_syn x = x
-    let fresh () = L.failwith "fresh tags not supported in concrete TB"
-    let subst _ x = x
-
-    let learn_eq syn tag =
-      if equal syn tag then Symex.Consumer.ok ()
-      else Symex.Consumer.lfail Typed.v_false
-
-    let exprs_syn _ = []
-    let nondet () = return None
-  end
-
   let[@inline] unwrap x = Option.get ~msg:"missing state in concrete TB" x
 
   module Tree = struct

--- a/soteria-rust/lib/tree_borrows/ptr_tag.ml
+++ b/soteria-rust/lib/tree_borrows/ptr_tag.ml
@@ -1,0 +1,41 @@
+type t = Tag of int [@@ocaml.boxed]
+
+let[@inline] equal (Tag t1) (Tag t2) = Int.equal t1 t2
+let pp fmt (Tag tag) = Fmt.pf fmt "‖%d‖" tag
+let show = Fmt.to_to_string pp
+let zero = Tag 0
+let tag_counter = ref 0
+
+let fresh_tag () =
+  incr tag_counter;
+  Tag !tag_counter
+
+module Key = struct
+  type nonrec t = t
+
+  let[@inline] to_int (Tag tag) = tag
+end
+
+module MapNode =
+  PatriciaTree.WeakNode
+    (struct
+      type 'k t = Key.t
+    end)
+    (PatriciaTree.WrappedHomogeneousValue)
+
+module SetNode = PatriciaTree.WeakSetNode (struct
+  type 'k t = Key.t
+end)
+
+module WeakMap = PatriciaTree.MakeCustomMap (Key) (PatriciaTree.Value) (MapNode)
+
+module WeakSet = struct
+  include Weak.Make (struct
+    type nonrec t = t
+
+    let[@inline] hash (Tag tag) = tag
+    let equal = equal
+  end)
+
+  let pp = Fmt.iter ~sep:(Fmt.any ", ") iter pp
+end

--- a/soteria-rust/lib/tree_borrows/ptr_tag.mli
+++ b/soteria-rust/lib/tree_borrows/ptr_tag.mli
@@ -1,0 +1,11 @@
+type t [@@deriving show, eq]
+
+val fresh_tag : unit -> t
+val zero : t
+
+module WeakMap : PatriciaTree.MAP with type key = t
+
+module WeakSet : sig
+  include Weak.S with type data = t
+  include Sigs.Printable with type t := t
+end

--- a/soteria-rust/lib/tree_borrows/raw.ml
+++ b/soteria-rust/lib/tree_borrows/raw.ml
@@ -3,69 +3,12 @@
 
 open Common
 
-module Tag : sig
-  type t [@@deriving show, eq]
-
-  val fresh_tag : unit -> t
-  val zero : t
-
-  module WeakMap : PatriciaTree.MAP with type key = t
-
-  module WeakSet : sig
-    include Weak.S with type data = t
-    include Sigs.Printable with type t := t
-  end
-end = struct
-  type t = Tag of int [@@ocaml.boxed]
-
-  let[@inline] equal (Tag t1) (Tag t2) = Int.equal t1 t2
-  let pp fmt (Tag tag) = Fmt.pf fmt "‖%d‖" tag
-  let show = Fmt.to_to_string pp
-  let zero = Tag 0
-  let tag_counter = ref 0
-
-  let fresh_tag () =
-    incr tag_counter;
-    Tag !tag_counter
-
-  module Key = struct
-    type nonrec t = t
-
-    let[@inline] to_int (Tag tag) = tag
-  end
-
-  module MapNode =
-    PatriciaTree.WeakNode
-      (struct
-        type 'k t = Key.t
-      end)
-      (PatriciaTree.WrappedHomogeneousValue)
-
-  module SetNode = PatriciaTree.WeakSetNode (struct
-    type 'k t = Key.t
-  end)
-
-  module WeakMap =
-    PatriciaTree.MakeCustomMap (Key) (PatriciaTree.Value) (MapNode)
-
-  module WeakSet = struct
-    include Weak.Make (struct
-      type nonrec t = t
-
-      let[@inline] hash (Tag tag) = tag
-      let equal = equal
-    end)
-
-    let pp = Fmt.iter ~sep:(Fmt.any ", ") iter pp
-  end
-end
-
 (** Whether this node has a protector (this is distinct from having the
     protector toggled!), its parents (including this node's ID!), and its
     initial state if it doesn't exist in the state. *)
 type node = {
   protector : protector option;
-  parents : Tag.WeakSet.t;
+  parents : Ptr_tag.WeakSet.t;
   initial_state : state;
 }
 [@@deriving show { with_path = false }]
@@ -133,23 +76,27 @@ let transition =
    size rather than tag count means small maps (e.g. a freshly allocated
    variable with few borrows) never pay the GC cost. *)
 let compact_threshold = 128
-let compact_map = Tag.WeakMap.filter_map_no_share (Fun.const Option.some)
+let compact_map = Ptr_tag.WeakMap.filter_map_no_share (Fun.const Option.some)
 
-type t = { tags : node Tag.WeakMap.t; known_size : int; next_compact_at : int }
+type t = {
+  tags : node Ptr_tag.WeakMap.t;
+  known_size : int;
+  next_compact_at : int;
+}
 
 let pp ft { tags; _ } =
-  Fmt.iter_bindings Tag.WeakMap.iter
-    (fun ft (tag, node) -> Fmt.pf ft "%a -> %a" Tag.pp tag pp_node node)
+  Fmt.iter_bindings Ptr_tag.WeakMap.iter
+    (fun ft (tag, node) -> Fmt.pf ft "%a -> %a" Ptr_tag.pp tag pp_node node)
     ft tags
 
 let show = Fmt.to_to_string pp
 
 let init ?(initial_state = Unique) () =
-  let tag = Tag.fresh_tag () in
-  let parents = Tag.WeakSet.create 1 in
-  Tag.WeakSet.add parents tag;
+  let tag = Ptr_tag.fresh_tag () in
+  let parents = Ptr_tag.WeakSet.create 1 in
+  Ptr_tag.WeakSet.add parents tag;
   let node = { protector = None; parents; initial_state } in
-  let tags = Tag.WeakMap.singleton tag node in
+  let tags = Ptr_tag.WeakMap.singleton tag node in
   (tag, { tags; known_size = 1; next_compact_at = compact_threshold })
 
 let ub_state = fst @@ init ~initial_state:Disabled ()
@@ -159,14 +106,14 @@ let[@inline] compact ({ tags; known_size; next_compact_at } as st : t) =
   else (
     Gc.minor ();
     let tags = compact_map tags in
-    let known_size = Tag.WeakMap.cardinal tags in
+    let known_size = Ptr_tag.WeakMap.cardinal tags in
     if known_size < next_compact_at then
       { tags; known_size; next_compact_at = compact_threshold }
     else (
       (* Tags survived minor GC — they are promoted; need a full cycle. *)
       Gc.full_major ();
       let tags = compact_map tags in
-      let known_size = Tag.WeakMap.cardinal tags in
+      let known_size = Ptr_tag.WeakMap.cardinal tags in
       (* If still large after a full GC all entries are genuinely live; back off
          exponentially so we don't retry on every subsequent borrow. *)
       let next_compact_at =
@@ -176,21 +123,21 @@ let[@inline] compact ({ tags; known_size; next_compact_at } as st : t) =
       { tags; known_size; next_compact_at }))
 
 let borrow ?protector parent ~state (st : t) =
-  let tag = Tag.fresh_tag () in
+  let tag = Ptr_tag.fresh_tag () in
   let ({ tags; known_size; _ } as st) = compact st in
-  let node_parent = Tag.WeakMap.find parent tags in
+  let node_parent = Ptr_tag.WeakMap.find parent tags in
   let parents =
-    Tag.WeakSet.create (Tag.WeakSet.count node_parent.parents + 1)
+    Ptr_tag.WeakSet.create (Ptr_tag.WeakSet.count node_parent.parents + 1)
   in
-  Tag.WeakSet.add parents tag;
-  Tag.WeakSet.iter (Tag.WeakSet.add parents) node_parent.parents;
+  Ptr_tag.WeakSet.add parents tag;
+  Ptr_tag.WeakSet.iter (Ptr_tag.WeakSet.add parents) node_parent.parents;
   let node = { protector; parents; initial_state = state } in
-  let tags = Tag.WeakMap.add tag node tags in
+  let tags = Ptr_tag.WeakMap.add tag node tags in
   (tag, { st with tags; known_size = known_size + 1 })
 
 let unprotect tag ({ tags; _ } as st) =
   let tags =
-    Tag.WeakMap.update tag
+    Ptr_tag.WeakMap.update tag
       (function
         | None -> raise Not_found | Some n -> Some { n with protector = None })
       tags
@@ -200,34 +147,34 @@ let unprotect tag ({ tags; _ } as st) =
 let strong_protector_exists { tags; _ } =
   (* Annoyingly, there is no [exists], only [for_all] *)
   not
-    (Tag.WeakMap.for_all
+    (Ptr_tag.WeakMap.for_all
        (fun _ { protector; _ } -> protector <> Some Strong)
        tags)
 
 (** [tag -> (protected * state)], [protected] indicating the tag's protector
     (managed outside [tb_state]) was toggled. *)
-type tb_state = (bool * state) Tag.WeakMap.t
+type tb_state = (bool * state) Ptr_tag.WeakMap.t
 
 (* Lets [access] walk the [root] trie (the structure, mapping tags to nodes) and
    the [tb_state] trie together in a single pass. *)
-module WeakMap_with_root = Tag.WeakMap.WithForeign (Tag.WeakMap.BaseMap)
+module WeakMap_with_root = Ptr_tag.WeakMap.WithForeign (Ptr_tag.WeakMap.BaseMap)
 
 let pp_tb_state =
-  Fmt.iter_bindings ~sep:(Fmt.any ", ") Tag.WeakMap.iter
+  Fmt.iter_bindings ~sep:(Fmt.any ", ") Ptr_tag.WeakMap.iter
     (fun ft (tag, (protected, st)) ->
-      Fmt.pf ft "%a -> %a%s" Tag.pp tag pp_state st
+      Fmt.pf ft "%a -> %a%s" Ptr_tag.pp tag pp_state st
         (if protected then " (p)" else ""))
 
-let empty_state = Tag.WeakMap.empty
-let is_empty_state = Tag.WeakMap.is_empty
+let empty_state = Ptr_tag.WeakMap.empty
+let is_empty_state = Ptr_tag.WeakMap.is_empty
 
 let equal_state =
-  Tag.WeakMap.reflexive_equal (Pair.equal Bool.equal equal_state)
+  Ptr_tag.WeakMap.reflexive_equal (Pair.equal Bool.equal equal_state)
 
 let set_protector ~protected tag ({ tags; _ } : t) =
-  Tag.WeakMap.update tag (function
+  Ptr_tag.WeakMap.update tag (function
     | None ->
-        let node = Tag.WeakMap.find tag tags in
+        let node = Ptr_tag.WeakMap.find tag tags in
         Some (protected, node.initial_state)
     | Some (_, st) -> Some (protected, st))
 
@@ -235,7 +182,7 @@ let set_protector ~protected tag ({ tags; _ } : t) =
     [state] for the tree structure [structure] with an event [e], that happened
     at [accessed]. *)
 let access accessed e ({ tags; _ } as root : t) (st : tb_state) =
-  let accessed_node = Tag.WeakMap.find accessed tags in
+  let accessed_node = Ptr_tag.WeakMap.find accessed tags in
   let parents = accessed_node.parents in
   try
     WeakMap_with_root.update_multiple_from_foreign tags
@@ -245,11 +192,14 @@ let access accessed e ({ tags; _ } as root : t) (st : tb_state) =
             let protected0, st0 =
               match old with None -> (false, initial_state) | Some ps -> ps
             in
-            let rel = if Tag.WeakSet.mem parents tag then Local else Foreign in
+            let rel =
+              if Ptr_tag.WeakSet.mem parents tag then Local else Foreign
+            in
             (* if the tag has a protector and is accessed, this toggles the
                protector! *)
             let protected =
-              (protected0 || Tag.equal tag accessed) && Option.is_some protector
+              (protected0 || Ptr_tag.equal tag accessed)
+              && Option.is_some protector
             in
             let st' = transition ~protected st0 rel e in
             if (not protected) && Common.equal_state st' initial_state then None
@@ -262,7 +212,7 @@ let access accessed e ({ tags; _ } as root : t) (st : tb_state) =
   with AliasingError ->
     [%l.debug
       "TB: Undefined behavior encountered for %a at %a in structure@.%a"
-        pp_access e Tag.pp accessed pp root];
+        pp_access e Ptr_tag.pp accessed pp root];
     Result.error `AliasingError
 
-let merge = Tag.WeakMap.idempotent_union @@ fun _ -> meet'
+let merge = Ptr_tag.WeakMap.idempotent_union @@ fun _ -> meet'

--- a/soteria-rust/lib/tree_borrows/tree_borrows.ml
+++ b/soteria-rust/lib/tree_borrows/tree_borrows.ml
@@ -4,3 +4,4 @@ include Common
 module M = Tree_borrows_intf.M
 module Concrete = Concrete
 module Raw = Raw
+module Ptr_tag = Ptr_tag

--- a/soteria-rust/lib/tree_borrows/tree_borrows_intf.ml
+++ b/soteria-rust/lib/tree_borrows/tree_borrows_intf.ml
@@ -7,30 +7,19 @@ module M (Symex : Rust_symex) = struct
   module Base = Soteria.Sym_states.Base.M (Symex)
 
   module type S = sig
-    (** {2 Pointer "tags", i.e. whatever gets stored inside pointers} *)
-
-    module Tag : sig
-      type t [@@mixins D_abstr.S_with_syn]
-
-      (** Generates a nondeterministic tag, for a nondeterministic pointer. May
-          return [None] if this tree borrows implementation doesn't support
-          symbolic tags. *)
-      val nondet : unit -> t option Symex.t
-    end
-
     module Tree : sig
       (** {2 Tree Borrows trees (the general structure)} *)
       type t [@@mixins Base.S]
 
-      val init : unit -> (Tag.t * t) Symex.t
+      val init : unit -> (Ptr_tag.t * t) Symex.t
 
       val borrow :
         ?protector:protector ->
-        Tag.t ->
+        Ptr_tag.t ->
         state:state ->
-        (Tag.t, 'e, syn list) SM.Result.t
+        (Ptr_tag.t, 'e, syn list) SM.Result.t
 
-      val unprotect : Tag.t -> (unit, 'e, syn list) SM.Result.t
+      val unprotect : Ptr_tag.t -> (unit, 'e, syn list) SM.Result.t
       val strong_protector_exists : t option -> bool
       val assert_exclusively_owned : unit -> (unit, 'e, syn list) SM.Result.t
     end
@@ -53,7 +42,7 @@ module M (Symex : Rust_symex) = struct
 
       val set_protector :
         protected:bool ->
-        Tag.t ->
+        Ptr_tag.t ->
         Tree.t option ->
         t option ->
         (t option, 'e, syn_full list) Symex.Result.t
@@ -62,7 +51,7 @@ module M (Symex : Rust_symex) = struct
           [state] for the tree rooted at [root] with an event [e], that happened
           at [accessed]. *)
       val access :
-        Tag.t ->
+        Ptr_tag.t ->
         access ->
         Tree.t option ->
         t option ->

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -95,21 +95,17 @@ let mk_box ptr allocator marker =
   let box = Tuple [ unique; allocator ] in
   box
 
-module Decoder
-    (Sptr : Sptr.S)
-    (State_tys : sig
-      module SM :
-        Soteria.Sym_states.State_monad.S
-          with type 'a Symex.t = 'a DecayMap.SM.t
-           and type 'a Symex.Value.t = 'a Typed.t
-           and type 'a Symex.Value.ty = 'a Typed.ty
-           and type Symex.Value.sbool = Typed.sbool
+module Decoder (State_tys : sig
+  module SM :
+    Soteria.Sym_states.State_monad.S
+      with type 'a Symex.t = 'a DecayMap.SM.t
+       and type 'a Symex.Value.t = 'a Typed.t
+       and type 'a Symex.Value.ty = 'a Typed.ty
+       and type Symex.Value.sbool = Typed.sbool
 
-      type fix
-    end) =
+  type fix
+end) =
 struct
-  type nonrec rust_val = Sptr.t Rust_val.t
-
   module ParserMonad = struct
     open State_tys
 
@@ -121,10 +117,10 @@ struct
 
     (* The following is just query -> (rust_val, 'err, 'fix) StateResult.t where
        StateResult = StateT (Result), but I need StateT1of3 urgh. *)
-    type handler = query -> rust_val res
+    type handler = query -> Rust_val.t res
 
     type get_all_handler =
-      get_all_query -> Typed.(rust_val * T.sint t * T.nonzero t) list res
+      get_all_query -> Typed.(Rust_val.t * T.sint t * T.nonzero t) list res
 
     (* A parser monad is an object such that, given a query handler with state
        ['state], returns a state monad-ish for that state which may fail or
@@ -336,500 +332,491 @@ struct
     | Enum _, _ -> L.failwith "decode: expected enum type for enum layout"
 end
 
-module Encoder (Sptr : Sptr.S) = struct
-  type nonrec rust_val = Sptr.t Rust_val.t
+(** [encode ?offset v ty] Converts a [Rust_val.t] of type [ty] into an iterator
+    over its sub values, along with their offset. Offsets all blocks by [offset]
+    if specified *)
+let rec encode ~offset (value : rust_val) (ty : Types.ty) :
+    ( Typed.(rust_val * T.sint t * T.nonzero t) Iter.t,
+      'e,
+      'f )
+    Rustsymex.Result.t =
+  let open Rustsymex in
+  let open Syntax in
+  let open Result in
+  let chain iter =
+    (match value with
+      | Tuple vals | Enum (_, vals) -> vals
+      | Ptr (base, VTable vt) -> [ Ptr (base, Thin); Ptr (vt, Thin) ]
+      | Ptr (base, Len len) -> [ Ptr (base, Thin); Int len ]
+      | Ptr (_, Thin) | Int _ | Float _ | PolyVal _ ->
+          L.failwith "Cannot split primitive: %a for %a" pp_rust_val value pp_ty
+            ty
+      | Union _ -> L.failwith "Cannot encode union directly")
+    |> Iter.combine_list iter
+    |> Result.fold_iter ~init:Iter.empty ~f:(fun acc ((ty, ofs), v) ->
+        let offset = offset +!!@ ofs in
+        let++ ys = encode ~offset v ty in
+        Iter.append acc ys)
+  in
+  let** ty = Layout.normalise ty in
+  let** layout = Layout.layout_of ty in
+  if%sat layout.size ==@ Usize.(0s) then ok Iter.empty
+  else
+    match (layout.fields, value) with
+    | _, Union blocks ->
+        ok
+          (Iter.of_list blocks
+          |> Iter.map (fun (v, o, s) -> (v, offset +!!@ o, s)))
+    | Primitive, _ ->
+        ok (Iter.singleton (value, offset, BV.cast_nonzero layout.size))
+    | Array _, _ | Arbitrary (_, _), _ -> chain (iter_fields layout ty)
+    | Enum (_, layouts), Enum (disc, _) -> (
+        let adt = ty_as_adt ty in
+        let* variant = variant_for_discr disc adt in
+        let variant = variant.id in
+        let++ fields = chain (iter_fields ~variant layout ty) in
+        match fst layouts.(Types.VariantId.to_int variant) with
+        | None -> fields
+        | Some (ofs, tag) ->
+            let size = BV.usizeinz (Typed.size_of_int tag / 8) in
+            let offset = ofs +!!@ offset in
+            Iter.cons (Int tag, offset, size) fields)
+    | Enum _, _ ->
+        not_impl "encode: expected enum value for enum type %a" pp_ty ty
 
-  let pp_rust_val = Rust_val.pp Sptr.pp
+(** Iterates over the validity constraints of this particular value for a given
+    type, traversing it recursively. For every requirement, this associates to
+    it the error to be raised if the requirement is not met.
 
-  (** [encode ?offset v ty] Converts a [Rust_val.t] of type [ty] into an
-      iterator over its sub values, along with their offset. Offsets all blocks
-      by [offset] if specified *)
-  let rec encode ~offset (value : rust_val) (ty : Types.ty) :
-      ( Typed.(rust_val * T.sint t * T.nonzero t) Iter.t,
-        'e,
-        'f )
-      Rustsymex.Result.t =
-    let open Rustsymex in
-    let open Syntax in
-    let open Result in
-    let chain iter =
-      (match value with
-        | Tuple vals | Enum (_, vals) -> vals
-        | Ptr (base, VTable vt) -> [ Ptr (base, Thin); Ptr (vt, Thin) ]
-        | Ptr (base, Len len) -> [ Ptr (base, Thin); Int len ]
-        | Ptr (_, Thin) | Int _ | Float _ | PolyVal _ ->
-            L.failwith "Cannot split primitive: %a for %a" pp_rust_val value
-              pp_ty ty
-        | Union _ -> L.failwith "Cannot encode union directly")
-      |> Iter.combine_list iter
-      |> Result.fold_iter ~init:Iter.empty ~f:(fun acc ((ty, ofs), v) ->
-          let offset = offset +!!@ ofs in
-          let++ ys = encode ~offset v ty in
-          Iter.append acc ys)
-    in
-    let** ty = Layout.normalise ty in
-    let** layout = Layout.layout_of ty in
-    if%sat layout.size ==@ Usize.(0s) then ok Iter.empty
-    else
-      match (layout.fields, value) with
-      | _, Union blocks ->
-          ok
-            (Iter.of_list blocks
-            |> Iter.map (fun (v, o, s) -> (v, offset +!!@ o, s)))
-      | Primitive, _ ->
-          ok (Iter.singleton (value, offset, BV.cast_nonzero layout.size))
-      | Array _, _ | Arbitrary (_, _), _ -> chain (iter_fields layout ty)
-      | Enum (_, layouts), Enum (disc, _) -> (
-          let adt = ty_as_adt ty in
-          let* variant = variant_for_discr disc adt in
-          let variant = variant.id in
-          let++ fields = chain (iter_fields ~variant layout ty) in
-          match fst layouts.(Types.VariantId.to_int variant) with
-          | None -> fields
-          | Some (ofs, tag) ->
-              let size = BV.usizeinz (Typed.size_of_int tag / 8) in
-              let offset = ofs +!!@ offset in
-              Iter.cons (Int tag, offset, size) fields)
-      | Enum _, _ ->
-          not_impl "encode: expected enum value for enum type %a" pp_ty ty
+    An optional [check_refs] function can be provided, to further check the
+    validity of references and boxes; this allows checking that references are
+    not dangling, well-aligned, and that their pointees are valid. Note that
+    this check will raise errors in the outside monad, rather than in the
+    returned list, since it is not possible to represent constraints in the
+    state in first order logic. We provide this possibility here, to avoid
+    re-implementing value traversal elsewhere.
 
-  (** Iterates over the validity constraints of this particular value for a
-      given type, traversing it recursively. For every requirement, this
-      associates to it the error to be raised if the requirement is not met.
+    Note that this function doesn't (and can't) check basic validity
+    requirements of references and boxes, even alignment, as e.g. for a
+    [&dyn Trait] the alignment cannot be known without some auxiliary state.
 
-      An optional [check_refs] function can be provided, to further check the
-      validity of references and boxes; this allows checking that references are
-      not dangling, well-aligned, and that their pointees are valid. Note that
-      this check will raise errors in the outside monad, rather than in the
-      returned list, since it is not possible to represent constraints in the
-      state in first order logic. We provide this possibility here, to avoid
-      re-implementing value traversal elsewhere.
+    This doesn't check:
+    - the fact the bytes of the value cannot be undefined, as that is checked
+      when the memory is read; once we have a [Rust_val.t], we are guaranteed
+      the data is initialised.
+    - the validity of the discriminant of an enum, as that is checked when the
+      memory is read (otherwise it would be impossible to even decode the value
+      in the first place).
 
-      Note that this function doesn't (and can't) check basic validity
-      requirements of references and boxes, even alignment, as e.g. for a
-      [&dyn Trait] the alignment cannot be known without some auxiliary state.
+    Reference:
+    https://doc.rust-lang.org/reference/behavior-considered-undefined.html#r-undefined.validity
+*)
+let rec validity ?(check_ref = fun _ _ -> Rustsymex.Result.ok ()) ty v f =
+  (* We annotate each relevant helper function or match branch with the matching
+     rule in the above-referenced document. *)
+  let open Rustsymex in
+  let open Syntax in
+  let open Result in
+  (* undefined.validity.wide *)
+  let metadata_validity ~is_raw_ptr pointee meta =
+    match (meta, Layout.dst_kind pointee) with
+    | Thin, NoneKind -> ok ()
+    | Len len, LenKind ->
+        if is_raw_ptr then ok ()
+        else f Usize.(0s <=$@ len) (`UBTransmute "Negative slice length")
+    | VTable vt, VTableKind ->
+        (* TODO: the vtable must always match the trait type of the pointee.
+           Will require a new input to this function (?) *)
+        f (Typed.not (Sptr.is_null vt)) (`UBTransmute "Null vtable pointer")
+    | _, dst_kind ->
+        let msg =
+          Fmt.str "Mismatch between metadata and DST kind; expected %a, got %a"
+            Layout.pp_meta_kind dst_kind Rust_val.pp_meta_kind meta
+        in
+        f Typed.v_false (`UBTransmute msg)
+  in
+  (* undefined.validity.reference-box *)
+  let ref_box_validity ((_, meta) as fptr) pointee =
+    let** () = metadata_validity ~is_raw_ptr:false pointee meta in
+    let** layout = Layout.layout_of pointee in
+    if layout.uninhabited then f Typed.v_false (`RefToUninhabited pointee)
+    else check_ref fptr pointee
+  in
+  (* validity of pattern types (not stabilized) *)
+  let rec pattern_valid_cond (inner_ty : Types.ty) (v : rust_val)
+      (pat : Types.type_pattern) =
+    match pat with
+    | Range (start_expr, stop_expr) ->
+        let ty = TypesUtils.ty_as_literal inner_ty in
+        let v = as_base ty v in
+        let signed = is_signed ty in
+        let lo = BV.of_constant_expr start_expr in
+        let hi = BV.of_constant_expr stop_expr in
+        if signed then lo <=$@ v &&@ (v <=$@ hi) else lo <=@ v &&@ (v <=@ hi)
+    | NotNull ->
+        let ptr, _ = as_ptr v in
+        Typed.not (Sptr.is_null ptr)
+    | OrPattern pats ->
+        List.fold_left
+          (fun acc p -> acc ||@ pattern_valid_cond inner_ty v p)
+          Typed.v_false pats
+  in
+  let** ty = Layout.normalise ty in
+  match (v, (ty : Types.ty)) with
+  (* undefined.validity.bool *)
+  | Int v, TLiteral TBool ->
+      f U8.(0s <=@ v &&@ (v <=@ 1s)) (`UBTransmute "Invalid bool value")
+  (* undefined.validity.fn-pointer *)
+  | Ptr (p, _), TFnPtr _ -> f (Typed.not (Sptr.is_null p)) `UBDanglingPointer
+  (* undefined.validity.char *)
+  | Int v, TLiteral TChar ->
+      let is_surrogate = U32.(0xD800s <=@ v &&@ (v <=@ 0xDFFFs)) in
+      let is_valid = U32.(v <=@ 0x10FFFFs) &&@ Typed.not is_surrogate in
+      f is_valid (`UBTransmute "Invalid char value")
+  (* undefined.validity.never *)
+  | _, TNever -> f Typed.v_false (`RefToUninhabited ty)
+  (* undefined.validity.scalar *)
+  | Int _, TLiteral (TInt _ | TUInt _) -> ok ()
+  | Float _, TLiteral (TFloat _) -> ok ()
+  (* undefined.validity.str *)
+  | Tuple _, TAdt { id = TBuiltin TStr; _ } -> ok ()
+  (* undefined.validity.enum *)
+  | Enum (discr, vs), TAdt adt ->
+      let* variant = variant_for_discr discr adt in
+      List.combine (field_tys variant.fields) vs
+      |> iter_list ~f:(fun (ty, v) -> validity ~check_ref ty v f)
+  (* undefined.validity.struct *)
+  | Tuple vs, TAdt adt ->
+      List.combine (Crate.as_struct_or_tuple adt) vs
+      |> iter_list ~f:(fun (ty, v) -> validity ~check_ref ty v f)
+  | Tuple vs, (TArray (ty, _) | TSlice ty) ->
+      iter_list vs ~f:(fun v -> validity ~check_ref ty v f)
+  (* undefined.validity.union *)
+  | Union _, TAdt _ -> ok ()
+  (* undefined.validity.reference-box *)
+  | Ptr ptr, TRef (_, pointee, _) -> ref_box_validity ptr pointee
+  | _, TAdt adt when adt_is_box adt ->
+      let pointee = get_pointee ty in
+      let ptr = ptr_of_box v in
+      ref_box_validity ptr pointee
+  (* undefined.validity.wide *)
+  | Ptr (_, meta), TRawPtr (pointee, _) ->
+      metadata_validity ~is_raw_ptr:true pointee meta
+  (* fndefs are ZSTs *)
+  | Tuple [], TFnDef _ -> ok ()
+  (* we assume polymorphic data has no validity requirement *)
+  | PolyVal _, TVar (Free _) -> ok ()
+  (* undefined.validity.pattern-type *)
+  | _, TPattern (inner_ty, pat) ->
+      let** () = validity ~check_ref inner_ty v f in
+      f
+        (pattern_valid_cond inner_ty v pat)
+        (`UBTransmute "Value violates pattern type constraint")
+  (* we fail loudly to avoid missing cases *)
+  | _ -> L.failwith "validity: unhandled %a / %a" pp_rust_val v pp_ty ty
 
-      This doesn't check:
-      - the fact the bytes of the value cannot be undefined, as that is checked
-        when the memory is read; once we have a [Rust_val.t], we are guaranteed
-        the data is initialised.
-      - the validity of the discriminant of an enum, as that is checked when the
-        memory is read (otherwise it would be impossible to even decode the
-        value in the first place).
-
-      Reference:
-      https://doc.rust-lang.org/reference/behavior-considered-undefined.html#r-undefined.validity
-  *)
-  let rec validity ?(check_ref = fun _ _ -> Rustsymex.Result.ok ()) ty v f =
-    (* We annotate each relevant helper function or match branch with the
-       matching rule in the above-referenced document. *)
-    let open Rustsymex in
-    let open Syntax in
-    let open Result in
-    (* undefined.validity.wide *)
-    let metadata_validity ~is_raw_ptr pointee meta =
-      match (meta, Layout.dst_kind pointee) with
-      | Thin, NoneKind -> ok ()
-      | Len len, LenKind ->
-          if is_raw_ptr then ok ()
-          else f Usize.(0s <=$@ len) (`UBTransmute "Negative slice length")
-      | VTable vt, VTableKind ->
-          (* TODO: the vtable must always match the trait type of the pointee.
-             Will require a new input to this function (?) *)
-          f (Typed.not (Sptr.is_null vt)) (`UBTransmute "Null vtable pointer")
-      | _, dst_kind ->
-          let msg =
-            Fmt.str
-              "Mismatch between metadata and DST kind; expected %a, got %a"
-              Layout.pp_meta_kind dst_kind Rust_val.pp_meta_kind meta
-          in
-          f Typed.v_false (`UBTransmute msg)
-    in
-    (* undefined.validity.reference-box *)
-    let ref_box_validity ((_, meta) as fptr) pointee =
-      let** () = metadata_validity ~is_raw_ptr:false pointee meta in
-      let** layout = Layout.layout_of pointee in
-      if layout.uninhabited then f Typed.v_false (`RefToUninhabited pointee)
-      else check_ref fptr pointee
-    in
-    (* validity of pattern types (not stabilized) *)
-    let rec pattern_valid_cond (inner_ty : Types.ty) (v : rust_val)
-        (pat : Types.type_pattern) =
-      match pat with
-      | Range (start_expr, stop_expr) ->
-          let ty = TypesUtils.ty_as_literal inner_ty in
-          let v = as_base ty v in
-          let signed = is_signed ty in
-          let lo = BV.of_constant_expr start_expr in
-          let hi = BV.of_constant_expr stop_expr in
-          if signed then lo <=$@ v &&@ (v <=$@ hi) else lo <=@ v &&@ (v <=@ hi)
-      | NotNull ->
-          let ptr, _ = as_ptr v in
-          Typed.not (Sptr.is_null ptr)
-      | OrPattern pats ->
-          List.fold_left
-            (fun acc p -> acc ||@ pattern_valid_cond inner_ty v p)
-            Typed.v_false pats
-    in
-    let** ty = Layout.normalise ty in
-    match (v, (ty : Types.ty)) with
-    (* undefined.validity.bool *)
-    | Int v, TLiteral TBool ->
-        f U8.(0s <=@ v &&@ (v <=@ 1s)) (`UBTransmute "Invalid bool value")
-    (* undefined.validity.fn-pointer *)
-    | Ptr (p, _), TFnPtr _ -> f (Typed.not (Sptr.is_null p)) `UBDanglingPointer
-    (* undefined.validity.char *)
-    | Int v, TLiteral TChar ->
-        let is_surrogate = U32.(0xD800s <=@ v &&@ (v <=@ 0xDFFFs)) in
-        let is_valid = U32.(v <=@ 0x10FFFFs) &&@ Typed.not is_surrogate in
-        f is_valid (`UBTransmute "Invalid char value")
-    (* undefined.validity.never *)
-    | _, TNever -> f Typed.v_false (`RefToUninhabited ty)
-    (* undefined.validity.scalar *)
-    | Int _, TLiteral (TInt _ | TUInt _) -> ok ()
-    | Float _, TLiteral (TFloat _) -> ok ()
-    (* undefined.validity.str *)
-    | Tuple _, TAdt { id = TBuiltin TStr; _ } -> ok ()
-    (* undefined.validity.enum *)
-    | Enum (discr, vs), TAdt adt ->
-        let* variant = variant_for_discr discr adt in
-        List.combine (field_tys variant.fields) vs
-        |> iter_list ~f:(fun (ty, v) -> validity ~check_ref ty v f)
-    (* undefined.validity.struct *)
-    | Tuple vs, TAdt adt ->
-        List.combine (Crate.as_struct_or_tuple adt) vs
-        |> iter_list ~f:(fun (ty, v) -> validity ~check_ref ty v f)
-    | Tuple vs, (TArray (ty, _) | TSlice ty) ->
-        iter_list vs ~f:(fun v -> validity ~check_ref ty v f)
-    (* undefined.validity.union *)
-    | Union _, TAdt _ -> ok ()
-    (* undefined.validity.reference-box *)
-    | Ptr ptr, TRef (_, pointee, _) -> ref_box_validity ptr pointee
-    | _, TAdt adt when adt_is_box adt ->
-        let pointee = get_pointee ty in
-        let ptr = ptr_of_box v in
-        ref_box_validity ptr pointee
-    (* undefined.validity.wide *)
-    | Ptr (_, meta), TRawPtr (pointee, _) ->
-        metadata_validity ~is_raw_ptr:true pointee meta
-    (* fndefs are ZSTs *)
-    | Tuple [], TFnDef _ -> ok ()
-    (* we assume polymorphic data has no validity requirement *)
-    | PolyVal _, TVar (Free _) -> ok ()
-    (* undefined.validity.pattern-type *)
-    | _, TPattern (inner_ty, pat) ->
-        let** () = validity ~check_ref inner_ty v f in
-        f
-          (pattern_valid_cond inner_ty v pat)
-          (`UBTransmute "Value violates pattern type constraint")
-    (* we fail loudly to avoid missing cases *)
-    | _ -> L.failwith "validity: unhandled %a / %a" pp_rust_val v pp_ty ty
-
-  (** Applies a validity check for a value, given a [check_ref] state monad
-      operation. This assumes [check_ref] is effect-free: the returned state is
-      the input state. See {!validity}. *)
-  let check_validity ~check_ref ty value st =
-    let open Rustsymex in
-    let open Syntax in
-    (* we need to "unlift" [check_ref] *)
-    let check_ref ptr ty : (unit, 'e, 'b) Rustsymex.Result.t =
-      let open Rustsymex.Syntax in
-      let+ res, _st = check_ref ptr ty st in
-      res
-    in
-    (* and then lift the result *)
-    let+ res = validity ~check_ref ty value assert_or_error in
-    (res, st)
-
-  (** Cast between literals; perform validation of the type's constraints. This
-      is different from a transmute! It doesn't simply reinterpret the bits, but
-      rather converts between types, e.g. rounding, truncating, extending, etc.
-
-      See also:
-      https://doc.rust-lang.org/stable/reference/expressions/operator-expr.html#numeric-cast
-  *)
-  let cast_literal ~(from_ty : Types.literal_type) ~(to_ty : Types.literal_type)
-      (v : Typed.([< T.cval ] t)) =
-    match (from_ty, to_ty) with
-    | _, TFloat _ when from_ty = to_ty -> Float (Typed.cast v)
-    | _, (TInt _ | TUInt _ | TBool | TChar) when from_ty = to_ty ->
-        Int (Typed.cast v)
-    | TFloat fty, ((TInt _ | TUInt _) as lit_ty) ->
-        let sv = Typed.cast_f fty v in
-        let signed = Layout.is_signed lit_ty in
-        let size = 8 * size_of_literal_ty lit_ty in
-        let sv' = BV.of_float ~rounding:Truncate ~signed ~size sv in
-        Int sv'
-    | (TInt _ | TUInt _), TFloat fp ->
-        let sv = Typed.cast_lit from_ty v in
-        let fp = float_precision fp in
-        let signed = Layout.is_signed from_ty in
-        let sv' = BV.to_float ~rounding:NearestTiesToEven ~signed ~fp sv in
-        Float sv'
-    | TFloat _, _ | _, TFloat _ ->
-        L.failwith "Unhandled float transmute: %a -> %a" pp_literal_ty from_ty
-          pp_literal_ty to_ty
-    (* here we know we're only handling scalars: bool, char, or int/uint, so we
-       can just resize the value as needed! *)
-    | (TInt _ | TUInt _ | TBool | TChar), (TInt _ | TUInt _ | TBool | TChar) ->
-        let from_bits = 8 * Layout.size_of_literal_ty from_ty in
-        let from_signed = Layout.is_signed from_ty in
-        let to_bits = 8 * Layout.size_of_literal_ty to_ty in
-        let v = Typed.cast_lit from_ty v in
-
-        if from_bits = to_bits then Int v
-        else if from_bits < to_bits then
-          Int (BV.extend ~signed:from_signed (to_bits - from_bits) v)
-        else Int (BV.extract 0 (to_bits - 1) v)
-
-  (** Converts a floating value to a bitvector, preserving it's bit
-      representation. This is a symbolic process, because SMT-Lib has no
-      operation for "float->bv" that preserves the bits, due to NaN.
-
-      See https://smt-lib.org/theories-FloatingPoint.shtml, "Conversions to
-      other sorts" *)
-  let float_to_bv_bits (f : Typed.([< T.sfloat ] t)) :
-      Typed.([> T.sint ] t) DecayMap.SM.t =
-    let fp = Typed.Float.fp_of f in
-    let size = Svalue.FloatPrecision.size fp in
-    let* bv = nondet (Typed.t_int size) in
-    let bv_f = BV.to_float_raw bv in
-    (* here we use structural equality rather than float equality; this is
-       intended. *)
-    let+ () = assume [ bv_f ==@ f ] in
-    bv
-
-  (** Transmutes a singular rust value, without splitting. This is under the
-      assumption that [size_of to_ty = size_of v], and both are primitives
-      (literal or pointer). *)
-  let rec transmute_one ~(to_ty : Types.ty) (v : rust_val) =
-    match (to_ty, v) with
-    | TLiteral (TFloat _), Float _ -> return v
-    | TLiteral (TFloat _), Int v -> return (Float (BV.to_float_raw v))
-    | TLiteral (TInt _ | TUInt _ | TBool | TChar), Int _ -> return v
-    | TLiteral (TInt _ | TUInt _ | TBool | TChar), Ptr (p, Thin) ->
-        let+ p = Sptr.decay p in
-        Int p
-    | TLiteral (TInt _ | TUInt _ | TBool | TChar), Float f ->
-        let+ v = float_to_bv_bits f in
-        Int v
-    | (TRawPtr _ | TRef _ | TFnPtr _), Ptr (_, Thin) -> return v
-    | (TRawPtr _ | TRef _ | TFnPtr _), Int v ->
-        return (Ptr (Sptr.of_address v, Thin))
-    | TPattern (inner_ty, _), v -> transmute_one ~to_ty:inner_ty v
-    | TVar (Free type_var_id), (PolyVal tid as v) ->
-        if Types.TypeVarId.equal_id type_var_id tid then return v
-        else
-          not_impl "transmute_one: mismatched type variables %a -> %a"
-            Types.pp_type_var_id type_var_id Types.pp_type_var_id tid
-    | TVar (Bound _), _ ->
-        L.failwith "transmute_one: bound type variable encountered?"
-    | TVar _, _ ->
-        L.failwith
-          "losing concrete value in %a -> %a; somewhere we lost track of \
-           generics"
-          pp_rust_val v pp_ty to_ty
-    | _ ->
-        L.failwith "unsupported transmute of value %a to type %a" pp_rust_val v
-          pp_ty to_ty
-
-  (** [nondet_raw ty] returns a nondeterministic value for [ty], by traversing
-      [ty]: the returned value will have the right structure, and any required
-      nondet variable will have been created. Importantly,
-      {b the returned value may not uphold the validity invariant of [ty]}*. To
-      ensure the value is also valid, use {!validity}, [assume]-ing the
-      constraints it returns.
-
-      * Much like in {!validity}, this function actually assumes two validity
-      invariants: the data is initialised, and the discriminant of enums
-      corresponds to that a variant. *)
-  let rec nondet_raw : Types.ty -> (rust_val, 'e, 'f) Rustsymex.Result.t =
-    let open Rustsymex in
-    let open Syntax in
-    let open Compo_res in
-    let nondets_raw tys = Rustsymex.Result.map_list tys ~f:nondet_raw in
-    function
-    | TLiteral (TFloat fp) ->
-        let+ f = nondet (Typed.t_float fp) in
-        Ok (Float f)
-    | TLiteral lit ->
-        let+ i = nondet (Typed.t_lit lit) in
-        Ok (Int (Typed.cast i))
-    | (TRef (_, pointee, _) | TRawPtr (pointee, _))
-      when not (Layout.is_dst pointee) ->
-        let++ p = Sptr.nondet pointee in
-        Ptr (p, Thin)
-    | TAdt { id = TTuple; generics = { types; _ } } ->
-        let++ fields = nondets_raw types in
-        Tuple fields
-    | TArray (ty, len) ->
-        let size = int_of_constant_expr len in
-        let++ fields = nondets_raw @@ List.init size (fun _ -> ty) in
-        Tuple fields
-    | TAdt adt as ty -> (
-        let type_decl = Crate.get_adt adt in
-        match type_decl.kind with
-        | Enum [] -> vanish ()
-        | Enum (v :: _ as variants) ->
-            let* discr = nondet (Typed.t_lit (lit_ty_of_lit v.discriminant)) in
-            let discr : Typed.(T.sint t) = Typed.cast discr in
-            let* variant =
-              match_on variants ~constr:(fun v ->
-                  BV.of_literal v.discriminant ==@ discr)
-            in
-            let* variant =
-              match variant with Some v -> return v | None -> vanish ()
-            in
-            let++ fields = nondets_raw @@ field_tys variant.fields in
-            Enum (BV.of_literal variant.discriminant, fields)
-        | Struct fields ->
-            let++ fields = nondets_raw @@ field_tys fields in
-            Tuple fields
-        | Union _ ->
-            let** size = Layout.size_of ty in
-            if%sat size ==@ Usize.(0s) then Result.ok (Union [])
-            else
-              let* sizei =
-                match BV.to_z size with
-                | Some s -> return (Z.to_int s)
-                | None -> vanish ()
-              in
-              let+ bytes = nondet (Typed.t_int (sizei * 8)) in
-              Ok (Union [ (Int bytes, Usize.(0s), BV.cast_nonzero size) ])
-        | _ ->
-            Rustsymex.not_impl
-              "cannot create a symbolic value of unsupported type %a" pp_ty ty)
-    | TPattern (inner, _) -> nondet_raw inner
-    | TVar (Free id) -> Result.ok (PolyVal id)
-    | ty ->
-        Rustsymex.not_impl
-          "cannot create a symbolic value of unsupported type %a" pp_ty ty
-
-  (** Much like {!nondet_raw}, but also assumes validity invariants for the
-      value, with {!validity}. Note this uses "stateless" validity: references
-      are not checked to be e.g. non-dangling. *)
-  let nondet_valid ty =
-    let open Rustsymex in
-    let open Syntax in
-    let** v = nondet_raw ty in
-    let++ () =
-      validity ty v (fun c _err ->
-          let+ () = assume [ c ] in
-          Compo_res.Ok ())
-    in
-    v
-
-  (** Folds over all the references and boxes in the given value and type,
-      applying [fn] to them. This is used to update nested references when
-      reborrowing. Calls [fn] with the pointer value and the pointer type (not
-      the pointee). *)
-  let rec ref_tys_in
-      (fn :
-        'acc ->
-        Types.ty ->
-        'a full_ptr ->
-        ('a full_ptr * 'acc, 'e, 'f) Rustsymex.Result.t) (init : 'acc)
-      (ty : Types.ty) (v : rust_val) :
-      (rust_val * 'acc, 'e, 'f) Rustsymex.Result.t =
-    let open Rustsymex in
-    let open Syntax in
-    let f = ref_tys_in fn in
-    let fs acc ty vs =
-      let++ vs, acc =
-        Result.fold_list vs ~init:([], acc) ~f:(fun (vs, acc) v ->
-            let++ v, acc = f acc ty v in
-            (v :: vs, acc))
-      in
-      (List.rev vs, acc)
-    in
-    let fs' acc tys vs =
-      let vs = List.combine tys vs in
-      let++ vs, acc =
-        Result.fold_list vs ~init:([], acc) ~f:(fun (vs, acc) (v, ty) ->
-            let++ v, acc = f acc v ty in
-            (v :: vs, acc))
-      in
-      (List.rev vs, acc)
-    in
-    let* ty = Poly.subst_ty ty in
-    match ty with
-    | TRef (_, _, _) | TAdt { id = TBuiltin TBox; _ } ->
-        let++ ptr, acc = fn init ty (as_ptr v) in
-        (Ptr ptr, acc)
-    | TAdt adt when adt_is_box adt ->
-        (* a box has only one non ZST, the pointer *)
-        let ptr, allocator, marker = unwrap_box v in
-        let++ ptr, acc = fn init ty ptr in
-        (mk_box (Ptr ptr) allocator marker, acc)
-    | TAdt adt when Crate.is_struct_or_tuple adt ->
-        let++ vs, acc = fs' init (Crate.as_struct_or_tuple adt) (as_tuple v) in
-        (Tuple vs, acc)
-    | TArray (ty, _) | TSlice ty ->
-        let++ vs, acc = fs init ty (as_tuple v) in
-        (Tuple vs, acc)
-    | TAdt adt when Crate.is_enum adt ->
-        let d, vs = as_enum v in
-        let* var = variant_for_discr d adt in
-        let++ vs, acc = fs' init (field_tys Types.(var.fields)) vs in
-        (Enum (d, vs), acc)
-    | TPattern (inner, _) -> f init inner v
-    | _ -> Result.ok (v, init)
-
-  (** Calculates the size and alignment of a type [t], according to the pointer
-      metadata [meta]. Receives an arbitrary state and [load] function, to
-      possibly access a heap to get VTable information. *)
-  let rec size_and_align_of_val ~load_vtable ~t ~meta =
-    let open Rustsymex in
+(** Applies a validity check for a value, given a [check_ref] state monad
+    operation. This assumes [check_ref] is effect-free: the returned state is
+    the input state. See {!validity}. *)
+let check_validity ~check_ref ty value st =
+  let open Rustsymex in
+  let open Syntax in
+  (* we need to "unlift" [check_ref] *)
+  let check_ref ptr ty : (unit, 'e, 'b) Rustsymex.Result.t =
     let open Rustsymex.Syntax in
-    (* Takes inspiration from rustc, to calculate the size and alignment of
-       DSTs.
-       https://github.com/rust-lang/rust/blob/a8664a1534913ccff491937ec2dc7ec5d973c2bd/compiler/rustc_codegen_ssa/src/size_of_val.rs *)
-    if not (Layout.is_dst t) then
-      let++ layout = Layout.layout_of t in
-      (layout.size, layout.align)
-    else
-      match (t, meta) with
-      | (TSlice _ | TAdt { id = TBuiltin TStr; _ }), (Thin | VTable _) ->
-          L.failwith "size_and_align_of_val: Invalid metadata for slice type"
-      | (TSlice _ | TAdt { id = TBuiltin TStr; _ }), Len meta ->
-          let sub_ty = Layout.dst_slice_ty t in
-          let* sub_ty =
-            of_opt_not_impl "size_of_val: missing a DST slice type" sub_ty
+    let+ res, _st = check_ref ptr ty st in
+    res
+  in
+  (* and then lift the result *)
+  let+ res = validity ~check_ref ty value assert_or_error in
+  (res, st)
+
+(** Cast between literals; perform validation of the type's constraints. This is
+    different from a transmute! It doesn't simply reinterpret the bits, but
+    rather converts between types, e.g. rounding, truncating, extending, etc.
+
+    See also:
+    https://doc.rust-lang.org/stable/reference/expressions/operator-expr.html#numeric-cast
+*)
+let cast_literal ~(from_ty : Types.literal_type) ~(to_ty : Types.literal_type)
+    (v : Typed.([< T.cval ] t)) =
+  match (from_ty, to_ty) with
+  | _, TFloat _ when from_ty = to_ty -> Float (Typed.cast v)
+  | _, (TInt _ | TUInt _ | TBool | TChar) when from_ty = to_ty ->
+      Int (Typed.cast v)
+  | TFloat fty, ((TInt _ | TUInt _) as lit_ty) ->
+      let sv = Typed.cast_f fty v in
+      let signed = Layout.is_signed lit_ty in
+      let size = 8 * size_of_literal_ty lit_ty in
+      let sv' = BV.of_float ~rounding:Truncate ~signed ~size sv in
+      Int sv'
+  | (TInt _ | TUInt _), TFloat fp ->
+      let sv = Typed.cast_lit from_ty v in
+      let fp = float_precision fp in
+      let signed = Layout.is_signed from_ty in
+      let sv' = BV.to_float ~rounding:NearestTiesToEven ~signed ~fp sv in
+      Float sv'
+  | TFloat _, _ | _, TFloat _ ->
+      L.failwith "Unhandled float transmute: %a -> %a" pp_literal_ty from_ty
+        pp_literal_ty to_ty
+  (* here we know we're only handling scalars: bool, char, or int/uint, so we
+     can just resize the value as needed! *)
+  | (TInt _ | TUInt _ | TBool | TChar), (TInt _ | TUInt _ | TBool | TChar) ->
+      let from_bits = 8 * Layout.size_of_literal_ty from_ty in
+      let from_signed = Layout.is_signed from_ty in
+      let to_bits = 8 * Layout.size_of_literal_ty to_ty in
+      let v = Typed.cast_lit from_ty v in
+
+      if from_bits = to_bits then Int v
+      else if from_bits < to_bits then
+        Int (BV.extend ~signed:from_signed (to_bits - from_bits) v)
+      else Int (BV.extract 0 (to_bits - 1) v)
+
+(** Converts a floating value to a bitvector, preserving it's bit
+    representation. This is a symbolic process, because SMT-Lib has no operation
+    for "float->bv" that preserves the bits, due to NaN.
+
+    See https://smt-lib.org/theories-FloatingPoint.shtml, "Conversions to other
+    sorts" *)
+let float_to_bv_bits (f : Typed.([< T.sfloat ] t)) :
+    Typed.([> T.sint ] t) DecayMap.SM.t =
+  let fp = Typed.Float.fp_of f in
+  let size = Svalue.FloatPrecision.size fp in
+  let* bv = nondet (Typed.t_int size) in
+  let bv_f = BV.to_float_raw bv in
+  (* here we use structural equality rather than float equality; this is
+     intended. *)
+  let+ () = assume [ bv_f ==@ f ] in
+  bv
+
+(** Transmutes a singular rust value, without splitting. This is under the
+    assumption that [size_of to_ty = size_of v], and both are primitives
+    (literal or pointer). *)
+let rec transmute_one ~(to_ty : Types.ty) (v : rust_val) =
+  match (to_ty, v) with
+  | TLiteral (TFloat _), Float _ -> return v
+  | TLiteral (TFloat _), Int v -> return (Float (BV.to_float_raw v))
+  | TLiteral (TInt _ | TUInt _ | TBool | TChar), Int _ -> return v
+  | TLiteral (TInt _ | TUInt _ | TBool | TChar), Ptr (p, Thin) ->
+      let+ p = Sptr.decay p in
+      Int p
+  | TLiteral (TInt _ | TUInt _ | TBool | TChar), Float f ->
+      let+ v = float_to_bv_bits f in
+      Int v
+  | (TRawPtr _ | TRef _ | TFnPtr _), Ptr (_, Thin) -> return v
+  | (TRawPtr _ | TRef _ | TFnPtr _), Int v ->
+      return (Ptr (Sptr.of_address v, Thin))
+  | TPattern (inner_ty, _), v -> transmute_one ~to_ty:inner_ty v
+  | TVar (Free type_var_id), (PolyVal tid as v) ->
+      if Types.TypeVarId.equal_id type_var_id tid then return v
+      else
+        not_impl "transmute_one: mismatched type variables %a -> %a"
+          Types.pp_type_var_id type_var_id Types.pp_type_var_id tid
+  | TVar (Bound _), _ ->
+      L.failwith "transmute_one: bound type variable encountered?"
+  | TVar _, _ ->
+      L.failwith
+        "losing concrete value in %a -> %a; somewhere we lost track of generics"
+        pp_rust_val v pp_ty to_ty
+  | _ ->
+      L.failwith "unsupported transmute of value %a to type %a" pp_rust_val v
+        pp_ty to_ty
+
+(** [nondet_raw ty] returns a nondeterministic value for [ty], by traversing
+    [ty]: the returned value will have the right structure, and any required
+    nondet variable will have been created. Importantly,
+    {b the returned value may not uphold the validity invariant of [ty]}*. To
+    ensure the value is also valid, use {!validity}, [assume]-ing the
+    constraints it returns.
+
+    * Much like in {!validity}, this function actually assumes two validity
+    invariants: the data is initialised, and the discriminant of enums
+    corresponds to that a variant. *)
+let rec nondet_raw : Types.ty -> (rust_val, 'e, 'f) Rustsymex.Result.t =
+  let open Rustsymex in
+  let open Syntax in
+  let open Compo_res in
+  let nondets_raw tys = Rustsymex.Result.map_list tys ~f:nondet_raw in
+  function
+  | TLiteral (TFloat fp) ->
+      let+ f = nondet (Typed.t_float fp) in
+      Ok (Float f)
+  | TLiteral lit ->
+      let+ i = nondet (Typed.t_lit lit) in
+      Ok (Int (Typed.cast i))
+  | (TRef (_, pointee, _) | TRawPtr (pointee, _))
+    when not (Layout.is_dst pointee) ->
+      let++ p = Sptr.nondet pointee in
+      Ptr (p, Thin)
+  | TAdt { id = TTuple; generics = { types; _ } } ->
+      let++ fields = nondets_raw types in
+      Tuple fields
+  | TArray (ty, len) ->
+      let size = int_of_constant_expr len in
+      let++ fields = nondets_raw @@ List.init size (fun _ -> ty) in
+      Tuple fields
+  | TAdt adt as ty -> (
+      let type_decl = Crate.get_adt adt in
+      match type_decl.kind with
+      | Enum [] -> vanish ()
+      | Enum (v :: _ as variants) ->
+          let* discr = nondet (Typed.t_lit (lit_ty_of_lit v.discriminant)) in
+          let discr : Typed.(T.sint t) = Typed.cast discr in
+          let* variant =
+            match_on variants ~constr:(fun v ->
+                BV.of_literal v.discriminant ==@ discr)
           in
-          let** layout = Layout.layout_of sub_ty in
-          let len = Typed.cast_i Usize meta in
-          let size, ovf_mul = layout.size *?@ len in
-          let++ () = assert_or_error (Typed.not ovf_mul) `Overflow in
-          (size, layout.align)
-      | TDynTrait _, (Thin | Len _) ->
-          L.failwith "size_and_align_of_val: Invalid metadata for dyn type"
-      | TDynTrait _, VTable vtable ->
-          let** size = load_vtable `Size vtable in
-          let++ align = load_vtable `Align vtable in
-          let size = as_base_i Usize size in
-          let align = as_base_i Usize align in
-          (size, Typed.cast align)
-      | TAdt { id = TTuple | TAdtId _; _ }, _ ->
-          let field_tys =
-            match t with
-            | TAdt adt -> Crate.as_struct_or_tuple adt
-            | _ -> L.failwith "impossible"
+          let* variant =
+            match variant with Some v -> return v | None -> vanish ()
           in
-          let last_field_ty = List.last field_tys in
-          let** layout = Layout.layout_of t in
-          let last_field_ofs =
-            match layout.fields with
-            | Arbitrary (_, offsets) -> offsets.(Array.length offsets - 1)
-            | _ -> L.failwith "size_and_align_of_val: Unexpected layout for ADT"
-          in
-          let++ unsized_size, unsized_align =
-            size_and_align_of_val ~load_vtable ~t:last_field_ty ~meta
-          in
-          (* TODO: we need to check if [layout] is packed, in which case
-             unsized_align is 1! See 113-125 of above function. *)
-          let align = BV.max ~signed:false unsized_align layout.align in
-          let size = last_field_ofs +!!@ unsized_size in
-          let size = Layout.size_to_fit ~size ~align in
-          (size, align)
-      | _ -> not_impl "size_and_align_of_val: Unexpected type"
-end
+          let++ fields = nondets_raw @@ field_tys variant.fields in
+          Enum (BV.of_literal variant.discriminant, fields)
+      | Struct fields ->
+          let++ fields = nondets_raw @@ field_tys fields in
+          Tuple fields
+      | Union _ ->
+          let** size = Layout.size_of ty in
+          if%sat size ==@ Usize.(0s) then Result.ok (Union [])
+          else
+            let* sizei =
+              match BV.to_z size with
+              | Some s -> return (Z.to_int s)
+              | None -> vanish ()
+            in
+            let+ bytes = nondet (Typed.t_int (sizei * 8)) in
+            Ok (Union [ (Int bytes, Usize.(0s), BV.cast_nonzero size) ])
+      | _ ->
+          Rustsymex.not_impl
+            "cannot create a symbolic value of unsupported type %a" pp_ty ty)
+  | TPattern (inner, _) -> nondet_raw inner
+  | TVar (Free id) -> Result.ok (PolyVal id)
+  | ty ->
+      Rustsymex.not_impl "cannot create a symbolic value of unsupported type %a"
+        pp_ty ty
+
+(** Much like {!nondet_raw}, but also assumes validity invariants for the value,
+    with {!validity}. Note this uses "stateless" validity: references are not
+    checked to be e.g. non-dangling. *)
+let nondet_valid ty =
+  let open Rustsymex in
+  let open Syntax in
+  let** v = nondet_raw ty in
+  let++ () =
+    validity ty v (fun c _err ->
+        let+ () = assume [ c ] in
+        Compo_res.Ok ())
+  in
+  v
+
+(** Folds over all the references and boxes in the given value and type,
+    applying [fn] to them. This is used to update nested references when
+    reborrowing. Calls [fn] with the pointer value and the pointer type (not the
+    pointee). *)
+let rec ref_tys_in
+    (fn :
+      'acc ->
+      Types.ty ->
+      full_ptr ->
+      (full_ptr * 'acc, 'e, 'f) Rustsymex.Result.t) (init : 'acc)
+    (ty : Types.ty) (v : Rust_val.t) :
+    (Rust_val.t * 'acc, 'e, 'f) Rustsymex.Result.t =
+  let open Rustsymex in
+  let open Syntax in
+  let f = ref_tys_in fn in
+  let fs acc ty vs =
+    let++ vs, acc =
+      Result.fold_list vs ~init:([], acc) ~f:(fun (vs, acc) v ->
+          let++ v, acc = f acc ty v in
+          (v :: vs, acc))
+    in
+    (List.rev vs, acc)
+  in
+  let fs' acc tys vs =
+    let vs = List.combine tys vs in
+    let++ vs, acc =
+      Result.fold_list vs ~init:([], acc) ~f:(fun (vs, acc) (v, ty) ->
+          let++ v, acc = f acc v ty in
+          (v :: vs, acc))
+    in
+    (List.rev vs, acc)
+  in
+  let* ty = Poly.subst_ty ty in
+  match ty with
+  | TRef (_, _, _) | TAdt { id = TBuiltin TBox; _ } ->
+      let++ ptr, acc = fn init ty (as_ptr v) in
+      (Ptr ptr, acc)
+  | TAdt adt when adt_is_box adt ->
+      (* a box has only one non ZST, the pointer *)
+      let ptr, allocator, marker = unwrap_box v in
+      let++ ptr, acc = fn init ty ptr in
+      (mk_box (Ptr ptr) allocator marker, acc)
+  | TAdt adt when Crate.is_struct_or_tuple adt ->
+      let++ vs, acc = fs' init (Crate.as_struct_or_tuple adt) (as_tuple v) in
+      (Tuple vs, acc)
+  | TArray (ty, _) | TSlice ty ->
+      let++ vs, acc = fs init ty (as_tuple v) in
+      (Tuple vs, acc)
+  | TAdt adt when Crate.is_enum adt ->
+      let d, vs = as_enum v in
+      let* var = variant_for_discr d adt in
+      let++ vs, acc = fs' init (field_tys Types.(var.fields)) vs in
+      (Enum (d, vs), acc)
+  | TPattern (inner, _) -> f init inner v
+  | _ -> Result.ok (v, init)
+
+(** Calculates the size and alignment of a type [t], according to the pointer
+    metadata [meta]. Receives an arbitrary state and [load] function, to
+    possibly access a heap to get VTable information. *)
+let rec size_and_align_of_val ~load_vtable ~t ~meta =
+  let open Rustsymex in
+  let open Rustsymex.Syntax in
+  (* Takes inspiration from rustc, to calculate the size and alignment of DSTs.
+     https://github.com/rust-lang/rust/blob/a8664a1534913ccff491937ec2dc7ec5d973c2bd/compiler/rustc_codegen_ssa/src/size_of_val.rs *)
+  if not (Layout.is_dst t) then
+    let++ layout = Layout.layout_of t in
+    (layout.size, layout.align)
+  else
+    match (t, meta) with
+    | (TSlice _ | TAdt { id = TBuiltin TStr; _ }), (Thin | VTable _) ->
+        L.failwith "size_and_align_of_val: Invalid metadata for slice type"
+    | (TSlice _ | TAdt { id = TBuiltin TStr; _ }), Len meta ->
+        let sub_ty = Layout.dst_slice_ty t in
+        let* sub_ty =
+          of_opt_not_impl "size_of_val: missing a DST slice type" sub_ty
+        in
+        let** layout = Layout.layout_of sub_ty in
+        let len = Typed.cast_i Usize meta in
+        let size, ovf_mul = layout.size *?@ len in
+        let++ () = assert_or_error (Typed.not ovf_mul) `Overflow in
+        (size, layout.align)
+    | TDynTrait _, (Thin | Len _) ->
+        L.failwith "size_and_align_of_val: Invalid metadata for dyn type"
+    | TDynTrait _, VTable vtable ->
+        let** size = load_vtable `Size vtable in
+        let++ align = load_vtable `Align vtable in
+        let size = as_base_i Usize size in
+        let align = as_base_i Usize align in
+        (size, Typed.cast align)
+    | TAdt { id = TTuple | TAdtId _; _ }, _ ->
+        let field_tys =
+          match t with
+          | TAdt adt -> Crate.as_struct_or_tuple adt
+          | _ -> L.failwith "impossible"
+        in
+        let last_field_ty = List.last field_tys in
+        let** layout = Layout.layout_of t in
+        let last_field_ofs =
+          match layout.fields with
+          | Arbitrary (_, offsets) -> offsets.(Array.length offsets - 1)
+          | _ -> L.failwith "size_and_align_of_val: Unexpected layout for ADT"
+        in
+        let++ unsized_size, unsized_align =
+          size_and_align_of_val ~load_vtable ~t:last_field_ty ~meta
+        in
+        (* TODO: we need to check if [layout] is packed, in which case
+           unsized_align is 1! See 113-125 of above function. *)
+        let align = BV.max ~signed:false unsized_align layout.align in
+        let size = last_field_ofs +!!@ unsized_size in
+        let size = Layout.size_to_fit ~size ~align in
+        (size, align)
+    | _ -> not_impl "size_and_align_of_val: Unexpected type"

--- a/soteria-rust/scripts/stubs.py
+++ b/soteria-rust/scripts/stubs.py
@@ -211,7 +211,7 @@ let[@inline] as_ptr (v : rust_val) =
       let v = Typed.cast_i Usize v in
       let ptr = Sptr.of_address v in
       (ptr, Thin)
-  | _ -> failwith "expected pointer"
+  | _ -> L.failwith "expected pointer"
 
 let as_base ty (v : rust_val) = Rust_val.as_base ty v
 let as_base_i ty (v : rust_val) = Rust_val.as_base_i ty v
@@ -722,7 +722,6 @@ def generate_interface(intrinsics: dict[str, FunDecl]) -> tuple[str, str, str]:
     intrinsics_info.sort(key=lambda x: x["ocaml_name"])
 
     type_utils = """
-        type rust_val := StateM.Sptr.t Rust_val.t
         type 'a ret := ('a, unit) StateM.t
         type fun_exec :=
             Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
@@ -758,11 +757,11 @@ def generate_interface(intrinsics: dict[str, FunDecl]) -> tuple[str, str, str]:
 
         open Charon
         open Common
+        open Rust_val
 
         module M (StateM : State.StateM.S) = struct
           module type Impl = sig
             {type_utils}
-            type full_ptr := StateM.Sptr.t Rust_val.full_ptr
             {interface_entries}
         end
 
@@ -794,8 +793,6 @@ def generate_interface(intrinsics: dict[str, FunDecl]) -> tuple[str, str, str]:
         module M (StateM : State.StateM.S): Intf.M(StateM).S = struct
             open StateM
             open Syntax
-
-            type rust_val = Sptr.t Rust_val.t
 
             {OCAML_HELPERS}
 
@@ -1161,14 +1158,13 @@ def generate_custom_stubs() -> None:
 
             open Charon
             open Common
+            open Rust_val
 
             module M (StateM : State.StateM.S) = struct
               open StateM
 
-              type rust_val = Sptr.t Rust_val.t
               type 'a ret = ('a, unit) StateM.t
               type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-              type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
               module type S = sig {intf_entries_str} end
             end
@@ -1191,10 +1187,8 @@ def generate_custom_stubs() -> None:
                 open StateM
                 open Syntax
 
-                type rust_val = Sptr.t Rust_val.t
                 type 'a ret = ('a, unit) StateM.t
                 type fun_exec = Fun_kind.t -> rust_val list -> (rust_val, unit) StateM.t
-                type full_ptr = StateM.Sptr.t Rust_val.full_ptr
 
                 {OCAML_HELPERS}
 


### PR DESCRIPTION
Being parametric on the pointer type was one of the most fun but also most annoying parts of the interpreter: we had to thread the pointer everywhere (for often little benefit).

Let's undo that, as part of #418 

It's just one commit! The only thing it does is:
- Move `Sptr_base` into `sptr.ml`, removing `Sptr.S` since the signature is what's exposed.
- Move `Tree_borrows.Raw.Tag` into `Tree_borrows.Ptr_tag`.

For now I've also gotten rid of all the symbolic machinery around `Ptr_tag`, because we're not using it and once a pointer tag is just a symbolic value it will be much simpler to do. Furthermore, I don't actually think we care about having pointer tags be dependent on the borrows model (for when/if we add Stacked Borrows); in both cases it's just an identifier.

**I strongly recommend reviewing the diff with whitespace changes ignored**, since `Value_codec` lost indentation, as `Value_codec.Encoder` is gone (it was a functor that received a `Sptr`