### PR TITLE
Add versioning

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -1,0 +1,121 @@
+name: Publish release
+description: >-
+  Download the per-platform soteria-c/soteria-rust packages built by build.yml,
+  zip them, generate checksums, and create (or replace) a GitHub release. Shared
+  by the nightly and versioned release workflows. The caller must pass
+  github-token and check out the repository first.
+
+inputs:
+  github-token:
+    description: >-
+      Token for the gh CLI (release create/delete). Pass ${{ github.token }}.
+      Supplied as an input because composite actions do not inherit env set on
+      the calling step.
+    required: true
+  tag:
+    description: Git tag for the release (e.g. nightly or v0.1.0).
+    required: true
+  title:
+    description: Release title.
+    required: true
+  notes-file:
+    description: Path to a file containing the release notes (Markdown).
+    required: true
+  prerelease:
+    description: Whether to mark the release as a prerelease.
+    required: false
+    default: "false"
+  delete-existing:
+    description: Delete an existing release and tag with the same name first.
+    required: false
+    default: "false"
+  asset-version:
+    description: >-
+      When non-empty, inserted into asset names as soteria-c-<version>-<platform>.zip
+      (used to version release assets). Empty for the moving nightly release.
+    required: false
+    default: ""
+  target:
+    description: >-
+      Commit-ish the tag should point at. Empty lets GitHub use the default
+      branch HEAD (the nightly behaviour).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Download soteria-c macOS package
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
+      with:
+        name: macos-arm64-soteria-c-package
+        path: release-artifacts/soteria-c-macos-arm64
+    - name: Download soteria-c Linux package
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
+      with:
+        name: linux-x86_64-soteria-c-package
+        path: release-artifacts/soteria-c-linux-x86_64
+    - name: Download soteria-rust macOS package
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
+      with:
+        name: macos-arm64-soteria-rust-package
+        path: release-artifacts/soteria-rust-macos-arm64
+    - name: Download soteria-rust Linux package
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
+      with:
+        name: linux-x86_64-soteria-rust-package
+        path: release-artifacts/soteria-rust-linux-x86_64
+
+    - name: Zip packages and compute checksums
+      shell: bash
+      env:
+        ASSET_VERSION: ${{ inputs.asset-version }}
+      run: |
+        set -euo pipefail
+        cd release-artifacts
+        infix=""
+        if [ -n "$ASSET_VERSION" ]; then
+          infix="-$ASSET_VERSION"
+        fi
+        for entry in "soteria-c macos-arm64" "soteria-c linux-x86_64" \
+                     "soteria-rust macos-arm64" "soteria-rust linux-x86_64"; do
+          # shellcheck disable=SC2086
+          set -- $entry
+          tool="$1"; platform="$2"
+          zip -r "${tool}${infix}-${platform}.zip" "${tool}-${platform}/"
+        done
+        sha256sum ./*.zip > SHA256SUMS.txt
+        cat SHA256SUMS.txt
+
+    - name: Delete existing release and tag
+      if: inputs.delete-existing == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -uo pipefail
+        gh release delete "${{ inputs.tag }}" --yes || true
+        git push --delete origin "${{ inputs.tag }}" || true
+        git tag -d "${{ inputs.tag }}" || true
+
+    - name: Create release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        prerelease_flag=""
+        if [ "${{ inputs.prerelease }}" = "true" ]; then
+          prerelease_flag="--prerelease"
+        fi
+        target_flag=""
+        if [ -n "${{ inputs.target }}" ]; then
+          target_flag="--target ${{ inputs.target }}"
+        fi
+        gh release create "${{ inputs.tag }}" \
+          --title "${{ inputs.title }}" \
+          --notes-file "${{ inputs.notes-file }}" \
+          $prerelease_flag \
+          $target_flag \
+          release-artifacts/*.zip \
+          release-artifacts/SHA256SUMS.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,15 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      version_override:
+        description: >-
+          When set, stamp this string as the build's version so `--version`
+          prints it (used by the nightly workflow to stamp nightly-<date>).
+          Empty keeps the in-repo version from scripts/versions.json.
+        type: string
+        required: false
+        default: ""
 
 env:
   # [versionsync: OCAML_VERSION=5.5.0]
@@ -29,6 +38,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
       - name: Check versions.json sync
         run: python3 scripts/versionsync.py check
+      - name: Stamp build version
+        if: inputs.version_override != ''
+        run: python3 scripts/versionsync.py set SOTERIA_VERSION "${{ inputs.version_override }}"
       - name: Setup Z3
         uses: cda-tum/setup-z3@7bfe87519f27304460db44284cb8cc59f50f5fc9 #[actionpin: v1]
         id: z3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Changelog
+
+permissions: read-all
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+# Cancel previous versions of this job that are still running.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
+      - name: Check CHANGELOG.md format
+        run: python3 scripts/changelog.py check
+      - name: Check released sections are unchanged
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        run: |
+          set -euo pipefail
+          BASE="${{ github.base_ref || github.event.merge_group.base_ref }}"
+          BASE="${BASE#refs/heads/}"
+          git fetch --depth=1 origin "$BASE"
+          git show "FETCH_HEAD:CHANGELOG.md" > base-changelog.md 2>/dev/null || : > base-changelog.md
+          python3 scripts/changelog.py check-frozen base-changelog.md

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,7 @@ jobs:
       should_run: ${{ steps.check.outputs.should_run }}
       previous_sha: ${{ steps.check.outputs.previous_sha }}
       current_sha: ${{ steps.check.outputs.current_sha }}
+      date: ${{ steps.check.outputs.date }}
     steps:
       - name: Determine whether a new nightly is needed
         id: check
@@ -31,6 +32,7 @@ jobs:
         run: |
           CURRENT_SHA="${{ github.sha }}"
           echo "current_sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
           if [ "$FORCE_NIGHTLY" = "true" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
@@ -78,6 +80,8 @@ jobs:
     needs: check-new-commits
     if: needs.check-new-commits.outputs.should_run == 'true'
     uses: ./.github/workflows/build.yml
+    with:
+      version_override: nightly-${{ needs.check-new-commits.outputs.date }}
 
   test-packages:
     needs: [check-new-commits, build]
@@ -94,47 +98,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download soteria-c macOS package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
-        with:
-          name: macos-arm64-soteria-c-package
-          path: release-artifacts/soteria-c-macos-arm64
-
-      - name: Download soteria-c Linux package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
-        with:
-          name: linux-x86_64-soteria-c-package
-          path: release-artifacts/soteria-c-linux-x86_64
-
-      - name: Download soteria-rust macOS package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
-        with:
-          name: macos-arm64-soteria-rust-package
-          path: release-artifacts/soteria-rust-macos-arm64
-
-      - name: Download soteria-rust Linux package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #[actionpin: v8]
-        with:
-          name: linux-x86_64-soteria-rust-package
-          path: release-artifacts/soteria-rust-linux-x86_64
-
-      - name: Zip packages
-        run: |
-          cd release-artifacts
-          zip -r soteria-c-macos-arm64.zip soteria-c-macos-arm64/
-          zip -r soteria-c-linux-x86_64.zip soteria-c-linux-x86_64/
-          zip -r soteria-rust-macos-arm64.zip soteria-rust-macos-arm64/
-          zip -r soteria-rust-linux-x86_64.zip soteria-rust-linux-x86_64/
-
-      - name: Delete existing nightly release and tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release delete nightly --yes || true
-          git push --delete origin nightly || true
-          git tag -d nightly || true
-
-      - name: Create nightly release
+      - name: Generate release notes
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -164,24 +128,25 @@ jobs:
             PR_LINES="- No merged pull requests found in this nightly range"
           fi
 
-          NOTES_FILE=$(mktemp)
           {
-            echo "Automated nightly build from \`main\` on $(date -u +%Y-%m-%d)."
+            echo "Automated nightly build from \`main\` on ${{ needs.check-new-commits.outputs.date }}."
             echo
             echo "Commit range: $RANGE"
             echo
             echo "Merged PRs in this release:"
             echo "$PR_LINES"
-          } > "$NOTES_FILE"
+          } > notes.md
 
-          gh release create nightly \
-            --title "Nightly $(date -u +%Y-%m-%d)" \
-            --notes-file "$NOTES_FILE" \
-            --prerelease \
-            release-artifacts/soteria-c-macos-arm64.zip \
-            release-artifacts/soteria-c-linux-x86_64.zip \
-            release-artifacts/soteria-rust-macos-arm64.zip \
-            release-artifacts/soteria-rust-linux-x86_64.zip
+      - name: Publish nightly release
+        uses: ./.github/actions/publish-release
+        with:
+          github-token: ${{ github.token }}
+          tag: nightly
+          title: Nightly ${{ needs.check-new-commits.outputs.date }}
+          notes-file: notes.md
+          prerelease: "true"
+          delete-existing: "true"
+          target: ${{ needs.check-new-commits.outputs.current_sha }}
 
   nightly-skip:
     name: Skip Nightly Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+name: Release
+
+permissions:
+  contents: write
+
+# Versioned release of the soteria library and the soteria-c / soteria-rust
+# tools, all under a single version number. The version is read from
+# scripts/versions.json (SOTERIA_VERSION); bump it, update CHANGELOG.md, and
+# merge to main *before* running this workflow. See RELEASING.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_opam:
+        description: Also open an opam-repository PR for the soteria library
+        type: boolean
+        default: false
+
+jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
+        with:
+          fetch-depth: 0
+
+      - name: Determine and validate version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION=$(python3 -c 'import json; print(json.load(open("scripts/versions.json"))["SOTERIA_VERSION"])')
+          TAG="v$VERSION"
+          echo "Releasing version $VERSION (tag $TAG)"
+
+          # Confirm version.ml is in sync with versions.json.
+          python3 scripts/versionsync.py check
+
+          # The tag must not already exist.
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::tag $TAG already exists"
+            exit 1
+          fi
+
+          # Latest existing release tag (vX.Y.Z), empty if none.
+          PREV=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
+          PREV_VERSION="${PREV#v}"
+          echo "Previous release: ${PREV:-<none>}"
+
+          python3 scripts/check_semver_bump.py "$PREV_VERSION" "$VERSION"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build
+    needs: validate
+    uses: ./.github/workflows/build.yml
+
+  test-packages:
+    name: Test Packages
+    needs: [validate, build]
+    uses: ./.github/workflows/test-packages.yml
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: [validate, build, test-packages]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          CHARON=$(python3 -c 'import json; v=json.load(open("scripts/versions.json")); print(v["CHARON_REPO"], v["CHARON_COMMIT_HASH"])')
+          OBOL=$(python3 -c 'import json; v=json.load(open("scripts/versions.json")); print(v["OBOL_REPO"], v["OBOL_COMMIT_HASH"])')
+          {
+            python3 scripts/changelog.py section "$VERSION"
+            echo
+            echo "### Frontend versions"
+            echo
+            echo "Built against:"
+            echo "- Charon \`$CHARON\`"
+            echo "- Obol \`$OBOL\`"
+          } > notes.md
+          cat notes.md
+
+      - name: Publish release
+        uses: ./.github/actions/publish-release
+        with:
+          github-token: ${{ github.token }}
+          tag: ${{ needs.validate.outputs.tag }}
+          title: ${{ needs.validate.outputs.tag }}
+          notes-file: notes.md
+          asset-version: ${{ needs.validate.outputs.tag }}
+          target: ${{ github.sha }}
+
+  opam-publish:
+    name: Publish soteria to opam-repository
+    runs-on: ubuntu-latest
+    needs: [validate, release]
+    if: ${{ inputs.publish_opam }}
+    # Only the `soteria` library is publishable to the central opam-repository:
+    # soteria-c / soteria-rust depend on Charon/Obol via git pin-depends, which
+    # the opam-repository does not accept. Requires the OPAM_PUBLISH_TOKEN secret
+    # (a PAT with access to your opam-repository fork). See RELEASING.md.
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #[actionpin: v6]
+        with:
+          fetch-depth: 0
+
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 #[actionpin: v3]
+        with:
+          ocaml-compiler: "5.4"
+
+      - name: Publish to opam-repository
+        env:
+          # opam-publish reads the GitHub PAT from this exact variable.
+          OPAM_PUBLISH_GH_TOKEN: ${{ secrets.OPAM_PUBLISH_TOKEN }}
+        run: |
+          set -euo pipefail
+          opam install -y opam-publish
+          opam publish \
+            --tag="${{ needs.validate.outputs.tag }}" \
+            -v "${{ needs.validate.outputs.version }}" \
+            --no-browser \
+            --no-confirmation \
+            "${{ github.repository }}" soteria

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Soteria, soteria-c and soteria-rust are recorded here.
+All notable changes to Soteria, Soteria Rust and Soteria Rust are recorded here.
 The three are released together under a single version number. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); see
 [RELEASING.md](./RELEASING.md) for the versioning policy and the release
@@ -15,5 +15,6 @@ This is our first release! We will be releasing regularly, under the `0.x` serie
 
 ### Added
 
-- `soteria-c --version` and `soteria-rust --version` now print the release
+- Switched to [OCaml 5.5.0](https://ocaml.org/releases/5.5.0)! 
+- `soteria-c version` and `soteria-rust version` now print the release
   version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to Soteria, soteria-c and soteria-rust are recorded here.
+The three are released together under a single version number. The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); see
+[RELEASING.md](./RELEASING.md) for the versioning policy and the release
+process.
+
+Add entries for your change under `## [Unreleased]` as part of your pull
+request.
+
+## [Unreleased]
+
+### Added
+
+- `soteria-c --version` and `soteria-rust --version` now print the release
+  version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ request.
 
 ## [Unreleased]
 
+This is our first release! We will be releasing regularly, under the `0.x` series.
+
 ### Added
 
 - `soteria-c --version` and `soteria-rust --version` now print the release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,106 @@
+# Releasing Soteria
+
+The `soteria` library and the `soteria-c` / `soteria-rust` tools are released
+together under a single version number.
+
+## Versioning policy
+
+We are in the `0.x` series. From a release `0.N.M` the only permitted bumps are:
+
+- **`0.(N+1).0`** for changes that are **breaking** (CLI, output format, or
+  library API);
+- **`0.N.(M+1)`** for **non-breaking** changes.
+
+The first release is `0.1.0`. The major version stays `0` for now. These rules
+are enforced by `scripts/check_semver_bump.py`, which the release workflow runs.
+
+## The version number lives in one place
+
+`scripts/versions.json` → `SOTERIA_VERSION` is the single source of truth. It is
+propagated to `soteria/lib/version.ml` (which backs `soteria-c --version` and
+`soteria-rust --version`) by `scripts/versionsync.py`, and CI checks they stay
+in sync. Do not edit `version.ml` by hand.
+
+## Changelog discipline
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com). Every PR
+that changes behaviour adds a bullet under `## [Unreleased]`. CI
+(`.github/workflows/changelog.yml`) only checks the file is well-formed.
+
+## Cutting a release
+
+1. **Open a release PR** that:
+   - bumps `SOTERIA_VERSION` in `scripts/versions.json`, by doing
+     `scripts/version_sync.py set SOTERIA_VERSION X.Y.Z`
+   - renames `## [Unreleased]` in `CHANGELOG.md` to
+     `## [X.Y.Z] - YYYY-MM-DD` and adds a fresh empty `## [Unreleased]` above
+     it.
+2. **Merge it to `main`** and wait for CI to go green.
+3. **Run the release workflow**: Actions → *Release* → *Run workflow* (on
+   `main`). It will:
+   - read `SOTERIA_VERSION`, verify the bump is legal and the tag is new;
+   - rebuild and re-test everything (`build.yml` + `test-packages.yml`);
+   - create the immutable tag `vX.Y.Z` at the tested commit and a GitHub
+     Release with the changelog section, the four platform zips, and
+     `SHA256SUMS.txt`.
+
+The packaging/upload logic is shared with the nightly workflow via
+`.github/actions/publish-release`.
+
+## Publishing the library to OPAM (optional)
+
+Only `soteria` can go to the central `ocaml/opam-repository`: `soteria-c` and
+`soteria-rust` depend on Charon/Obol through git `pin-depends`, which the
+opam-repository rejects. The tools are distributed as the prebuilt binaries
+attached to the release (plus `opam pin` for source installs).
+
+To publish `soteria`, tick **publish_opam** when running the release workflow.
+It runs `opam publish` (which `--no-confirmation` explicitly supports for CI),
+submitting a PR to `ocaml/opam-repository`.
+
+Prerequisites:
+
+- An `OPAM_PUBLISH_TOKEN` repository secret: a GitHub PAT belonging to an
+  account that can fork `ocaml/opam-repository`. The workflow passes it as the
+  `OPAM_PUBLISH_GH_TOKEN` variable that opam-publish reads. Note: opam-publish
+  always forks to the **token owner's personal account** (it has no option to
+  fork into an organization, so the staging fork cannot live under
+  `soteria-tools`) and opens the PR from there. The fork is only a transient
+  staging area — the contribution itself is the PR to `ocaml/opam-repository` —
+  so choose whichever account you're comfortable hosting it under.
+- Every `soteria` dependency must already be released in the official
+  opam-repository. This was verified for the current dependency set — all of
+  them resolve from the default `opam.ocaml.org` repository — but re-check if
+  you add a new dep.
+
+`soteria.opam` is generated from `dune-project` (`generate_opam_files`) and
+passes `opam lint`; the version and source `url` are filled in by `opam publish`
+from the tag, so they are intentionally absent from the checked-in file. A
+maintainer still reviews and merges the PR on the opam-repository side.
+
+## Binaries: what users still need
+
+The release zips are **not** fully self-contained: `soteria-rust` needs a
+matching **Charon** binary (and the Obol frontend) at runtime. The exact
+commits used for each release are recorded in the release notes
+("Frontend versions") for reproducibility.
+
+The binaries are **not codesigned/notarized** yet. On macOS, users may need to
+clear the quarantine attribute:
+
+```bash
+xattr -d com.apple.quarantine soteria-rust
+```
+
+Codesigning is a planned follow-up.
+
+## Website
+
+The downloads page should read GitHub Releases (the API or the
+`releases/latest` redirect) rather than hard-coding links, so it tracks
+releases automatically. API documentation is published as latest only.
+
+## One-time repository setup
+
+- **Tag protection / rulesets** so `v*` tags can't be deleted or force-moved.
+- The `OPAM_PUBLISH_TOKEN` secret, if OPAM publishing is wanted.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,7 @@
 The `soteria` library and the `soteria-c` / `soteria-rust` tools are released
 together under a single version number.
 
-## Versioning policy
+## Versions
 
 We are in the `0.x` series. From a release `0.N.M` the only permitted bumps are:
 
@@ -11,17 +11,14 @@ We are in the `0.x` series. From a release `0.N.M` the only permitted bumps are:
   library API);
 - **`0.N.(M+1)`** for **non-breaking** changes.
 
-The first release is `0.1.0`. The major version stays `0` for now. These rules
-are enforced by `scripts/check_semver_bump.py`, which the release workflow runs.
+We enforce these rules in `scripts/check_semver_bump.py`, which the release 
+workflow runs.
 
-## The version number lives in one place
+The version number is specified in entry `SOTERIA_VERSION` in
+`scripts/versions.json`. It is propagated across the repo with 
+`scripts/versionsync.py`, and CI checks they stay in sync. 
 
-`scripts/versions.json` → `SOTERIA_VERSION` is the single source of truth. It is
-propagated to `soteria/lib/version.ml` (which backs `soteria-c --version` and
-`soteria-rust --version`) by `scripts/versionsync.py`, and CI checks they stay
-in sync. Do not edit `version.ml` by hand.
-
-## Changelog discipline
+## Changelog
 
 `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com). Every PR
 that changes behaviour adds a bullet under `## [Unreleased]`. CI
@@ -35,72 +32,35 @@ that changes behaviour adds a bullet under `## [Unreleased]`. CI
    - renames `## [Unreleased]` in `CHANGELOG.md` to
      `## [X.Y.Z] - YYYY-MM-DD` and adds a fresh empty `## [Unreleased]` above
      it.
-2. **Merge it to `main`** and wait for CI to go green.
+2. **Merge it to `main`** and wait for CI to pass.
 3. **Run the release workflow**: Actions → *Release* → *Run workflow* (on
    `main`). It will:
    - read `SOTERIA_VERSION`, verify the bump is legal and the tag is new;
    - rebuild and re-test everything (`build.yml` + `test-packages.yml`);
    - create the immutable tag `vX.Y.Z` at the tested commit and a GitHub
-     Release with the changelog section, the four platform zips, and
-     `SHA256SUMS.txt`.
+     Release with the changelog section and the prebuilt binaries attached.
 
 The packaging/upload logic is shared with the nightly workflow via
 `.github/actions/publish-release`.
 
-## Publishing the library to OPAM (optional)
+## Publishing to OPAM (optional)
 
-Only `soteria` can go to the central `ocaml/opam-repository`: `soteria-c` and
-`soteria-rust` depend on Charon/Obol through git `pin-depends`, which the
-opam-repository rejects. The tools are distributed as the prebuilt binaries
-attached to the release (plus `opam pin` for source installs).
+For now we only publish `soteria` on the 
+[OPAM repository](https://github.com/ocaml/opam-repository).
 
 To publish `soteria`, tick **publish_opam** when running the release workflow.
-It runs `opam publish` (which `--no-confirmation` explicitly supports for CI),
-submitting a PR to `ocaml/opam-repository`.
+It runs `opam publish`, submitting a PR to `ocaml/opam-repository`. The current
+token is set up to use the account of [Opale](https://github.com/N1ark), so the
+PR is from her fork.
+
+In the future we may switch from `opam publish` to a custom workflow so that
+we can publish from a bot account instead of a personal one, but for now this is
+easiest.
 
 Prerequisites:
 
 - An `OPAM_PUBLISH_TOKEN` repository secret: a GitHub PAT belonging to an
-  account that can fork `ocaml/opam-repository`. The workflow passes it as the
-  `OPAM_PUBLISH_GH_TOKEN` variable that opam-publish reads. Note: opam-publish
-  always forks to the **token owner's personal account** (it has no option to
-  fork into an organization, so the staging fork cannot live under
-  `soteria-tools`) and opens the PR from there. The fork is only a transient
-  staging area — the contribution itself is the PR to `ocaml/opam-repository` —
-  so choose whichever account you're comfortable hosting it under.
-- Every `soteria` dependency must already be released in the official
-  opam-repository. This was verified for the current dependency set — all of
-  them resolve from the default `opam.ocaml.org` repository — but re-check if
-  you add a new dep.
-
-`soteria.opam` is generated from `dune-project` (`generate_opam_files`) and
-passes `opam lint`; the version and source `url` are filled in by `opam publish`
-from the tag, so they are intentionally absent from the checked-in file. A
-maintainer still reviews and merges the PR on the opam-repository side.
-
-## Binaries: what users still need
-
-The release zips are **not** fully self-contained: `soteria-rust` needs a
-matching **Charon** binary (and the Obol frontend) at runtime. The exact
-commits used for each release are recorded in the release notes
-("Frontend versions") for reproducibility.
-
-The binaries are **not codesigned/notarized** yet. On macOS, users may need to
-clear the quarantine attribute:
-
-```bash
-xattr -d com.apple.quarantine soteria-rust
-```
-
-Codesigning is a planned follow-up.
-
-## Website
-
-The downloads page should read GitHub Releases (the API or the
-`releases/latest` redirect) rather than hard-coding links, so it tracks
-releases automatically. API documentation is published as latest only.
-
-## One-time repository setup
-
-- **Tag protection / rulesets** so `v*` tags can't be deleted or force-moved.
-- The `OPAM_PUBLISH_TOKEN` secret, if OPAM publishing is wanted.
+  account that can fork `ocaml/opam-repository`. Note: opam-publish forks to
+  the **token owner's personal account** and opens the PR from there.
+- Every `soteria` dependency must already be released on OPAM; pinned
+  dependencies are not supported.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -24,6 +24,8 @@ path = [
   "dune",
   "package.json",
   "README.md",
+  "CHANGELOG.md",
+  "RELEASING.md",
   "Makefile",
   "odoc-config.sexp",
   ".github/**",

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Small helper for CHANGELOG.md.
+
+Subcommands:
+  check                  Validate the changelog format (used in CI).
+  check-frozen <file>    Fail if any already-released section changed relative
+                         to the baseline <file> (the CHANGELOG.md from the base
+                         branch). Adding a new released section is allowed.
+  section <version>      Print the body of the section for <version> (used when
+                         generating GitHub release notes).
+
+The changelog follows a trimmed-down "Keep a Changelog" layout:
+
+  # Changelog
+
+  ## [Unreleased]
+  - ...
+
+  ## [0.1.0] - 2026-06-23
+  - ...
+
+Every released section header must be `## [X.Y.Z] - YYYY-MM-DD`. The
+`## [Unreleased]` section must exist and come first. New entries are added by
+hand under `[Unreleased]`; on release that header is renamed to the version.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+CHANGELOG = Path(__file__).resolve().parent.parent / "CHANGELOG.md"
+
+VERSION_HEADER = re.compile(r"^## \[(\d+\.\d+\.\d+)\] - \d{4}-\d{2}-\d{2}\s*$")
+UNRELEASED_HEADER = re.compile(r"^## \[Unreleased\]\s*$")
+ANY_SECTION = re.compile(r"^## ")
+
+
+def read_lines() -> list[str]:
+    if not CHANGELOG.exists():
+        sys.exit(f"error: {CHANGELOG} not found")
+    return CHANGELOG.read_text().splitlines()
+
+
+def released_sections(text: str) -> dict[str, str]:
+    """Map each released version to its section text (header included).
+
+    The `[Unreleased]` section is intentionally excluded: it is the only one
+    pull requests are allowed to change.
+    """
+    lines = text.splitlines()
+    sections: dict[str, str] = {}
+    current: str | None = None
+    body: list[str] = []
+
+    def flush() -> None:
+        if current is not None:
+            sections[current] = "\n".join(body).strip("\n")
+
+    for line in lines:
+        if ANY_SECTION.match(line):
+            flush()
+            m = VERSION_HEADER.match(line)
+            current = m.group(1) if m else None
+            body = [line]
+        elif current is not None:
+            body.append(line)
+    flush()
+    return sections
+
+
+def cmd_check() -> int:
+    lines = read_lines()
+    errors: list[str] = []
+
+    non_empty = [l for l in lines if l.strip()]
+    if not non_empty or non_empty[0].strip() != "# Changelog":
+        errors.append("file must start with a '# Changelog' title")
+
+    section_headers = [
+        (i, l) for i, l in enumerate(lines) if ANY_SECTION.match(l)
+    ]
+    if not section_headers:
+        errors.append("no '## ' sections found")
+
+    seen_versions: set[str] = set()
+    unreleased_index = None
+    first_section_index = section_headers[0][0] if section_headers else None
+    for i, line in section_headers:
+        if UNRELEASED_HEADER.match(line):
+            unreleased_index = i
+            continue
+        m = VERSION_HEADER.match(line)
+        if not m:
+            errors.append(
+                f"line {i + 1}: malformed section header: {line!r}; "
+                "expected '## [Unreleased]' or '## [X.Y.Z] - YYYY-MM-DD'"
+            )
+            continue
+        if m.group(1) in seen_versions:
+            errors.append(f"line {i + 1}: duplicate version {m.group(1)}")
+        seen_versions.add(m.group(1))
+
+    if unreleased_index is None:
+        errors.append("missing '## [Unreleased]' section")
+    elif unreleased_index != first_section_index:
+        errors.append("'## [Unreleased]' must be the first section")
+
+    if errors:
+        for e in errors:
+            print(f"CHANGELOG.md: {e}", file=sys.stderr)
+        return 1
+    print("CHANGELOG.md is well-formed.")
+    return 0
+
+
+def cmd_check_frozen(baseline_path: str) -> int:
+    base = Path(baseline_path)
+    if not base.exists() or not base.read_text().strip():
+        print("no baseline changelog; skipping frozen-section check")
+        return 0
+
+    old = released_sections(base.read_text())
+    new = released_sections(CHANGELOG.read_text())
+
+    errors: list[str] = []
+    for version, text in old.items():
+        if version not in new:
+            errors.append(f"released section [{version}] was removed")
+        elif new[version] != text:
+            errors.append(
+                f"released section [{version}] was modified; released "
+                "changelog entries are immutable (only [Unreleased] may change)"
+            )
+
+    if errors:
+        for e in errors:
+            print(f"CHANGELOG.md: {e}", file=sys.stderr)
+        return 1
+    print("CHANGELOG.md: released sections are unchanged.")
+    return 0
+
+
+def cmd_section(version: str) -> int:
+    lines = read_lines()
+    start = None
+    for i, line in enumerate(lines):
+        m = VERSION_HEADER.match(line)
+        if m and m.group(1) == version:
+            start = i
+            break
+    if start is None:
+        sys.exit(
+            f"error: no '## [{version}] - YYYY-MM-DD' section found in CHANGELOG.md"
+        )
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if ANY_SECTION.match(line):
+            break
+        body.append(line)
+    print("\n".join(body).strip())
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        sys.exit("usage: changelog.py {check | section <version>}")
+    cmd = sys.argv[1]
+    if cmd == "check":
+        return cmd_check()
+    if cmd == "check-frozen":
+        if len(sys.argv) != 3:
+            sys.exit("usage: changelog.py check-frozen <baseline-file>")
+        return cmd_check_frozen(sys.argv[2])
+    if cmd == "section":
+        if len(sys.argv) != 3:
+            sys.exit("usage: changelog.py section <version>")
+        return cmd_section(sys.argv[2])
+    sys.exit(f"unknown subcommand: {cmd}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_semver_bump.py
+++ b/scripts/check_semver_bump.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Validate a Soteria release version bump.
+
+Usage: check_semver_bump.py <previous> <new>
+
+<previous> is the version of the latest existing release (without a leading
+"v"), or the empty string if there is no prior release. <new> is the version
+about to be released.
+
+While Soteria is in its 0.x series the only legal bumps from 0.N.M are:
+  - 0.(N+1).0   (breaking changes)
+  - 0.N.(M+1)   (non-breaking changes)
+
+The first ever release must be exactly 0.1.0. Exits non-zero with an
+explanation if the bump is not allowed.
+"""
+
+import re
+import sys
+
+
+def parse(label: str, value: str) -> tuple[int, int, int]:
+    m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", value)
+    if not m:
+        sys.exit(f"error: {label} version '{value}' is not of the form X.Y.Z")
+    return tuple(int(x) for x in m.groups())  # type: ignore[return-value]
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        sys.exit("usage: check_semver_bump.py <previous> <new>")
+    previous, new = sys.argv[1], sys.argv[2]
+
+    n_major, n_minor, n_patch = parse("new", new)
+    if n_major != 0:
+        sys.exit("error: major version must remain 0 during the 0.x series")
+
+    if not previous:
+        if (n_major, n_minor, n_patch) != (0, 1, 0):
+            sys.exit(f"error: first release must be 0.1.0, got {new}")
+        print(f"ok: first release {new}")
+        return
+
+    p_major, p_minor, p_patch = parse("previous", previous)
+    breaking = (n_minor, n_patch) == (p_minor + 1, 0)
+    non_breaking = (n_minor, n_patch) == (p_minor, p_patch + 1)
+    if not (breaking or non_breaking):
+        sys.exit(
+            f"error: illegal bump {previous} -> {new}; "
+            f"allowed: 0.{p_minor + 1}.0 (breaking) or "
+            f"0.{p_minor}.{p_patch + 1} (non-breaking)"
+        )
+    print(f"ok: {previous} -> {new} ({'breaking' if breaking else 'non-breaking'})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Central version configuration for Soteria. Run `scripts/versionsync.py check` to verify versions are in sync, or `scripts/versionsync.py update` to update versions everywhere.",
+  "SOTERIA_VERSION": "0.1.0",
   "CHARON_REPO": "soteria-tools/charon",
   "CHARON_COMMIT_HASH": "4986f2907dbe5899b0756ab623b5ef661ed2c58c",
   "OBOL_REPO": "soteria-tools/obol",

--- a/scripts/versionsync.py
+++ b/scripts/versionsync.py
@@ -28,6 +28,8 @@ from soteria_utils import *
 
 # Files to scan for versionsync tags
 FILES_TO_SCAN = [
+    "soteria/lib/version.ml",
+    "soteria-rust/lib/version.ml",
     ".github/workflows/build.yml",
     ".github/workflows/test-packages.yml",
     ".github/workflows/benchmarks.yml",
@@ -535,9 +537,7 @@ def pull_project(
         info(f"Running post-build command: {' '.join(cmd)}")
         run_command(cmd, target_dir)
 
-    color_print(
-        f"\n✓ {project} updated and built successfully!\n", GREEN + BOLD
-    )
+    color_print(f"\n✓ {project} updated and built successfully!\n", GREEN + BOLD)
 
 
 class ProjectPullConfig(TypedDict):

--- a/soteria-c/bin/soteria_c.ml
+++ b/soteria-c/bin/soteria_c.ml
@@ -118,8 +118,34 @@ module Capture_db = struct
       (Term.map Exit_code.to_int term)
 end
 
+module Version = struct
+  let print_version () =
+    Fmt.pr "%s@." Soteria.Version.version;
+    0
+
+  let term = Term.(const print_version $ const ())
+
+  let cmd =
+    Cmd.make
+      (Cmd.info ~exits ~doc:"Print version information"
+         ~man:
+           [
+             `S Cmdliner.Manpage.s_description;
+             `P "Print the version of Soteria C.";
+           ]
+         "version")
+      term
+end
+
 let cmd =
-  Cmd.group (Cmd.info "soteria-c")
-    [ Exec_main.cmd; Show_ail.cmd; Generate_summaries.cmd; Capture_db.cmd ]
+  Cmd.group
+    (Cmd.info ~version:Soteria.Version.version "soteria-c")
+    [
+      Exec_main.cmd;
+      Show_ail.cmd;
+      Generate_summaries.cmd;
+      Capture_db.cmd;
+      Version.cmd;
+    ]
 
 let () = exit @@ Cmd.eval' cmd

--- a/soteria-c/test/cram/cli.t/run.t
+++ b/soteria-c/test/cram/cli.t/run.t
@@ -22,11 +22,17 @@
              Parse and link the ail program and print its AST (for debugging
              purposes)
   
+         version [OPTION]…
+             Print version information
+  
   COMMON OPTIONS
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          soteria-c exits with:
@@ -169,6 +175,9 @@
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          soteria-c capture-db exits with:
@@ -400,6 +409,9 @@
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
   
+         --version
+             Show version information.
+  
   EXIT STATUS
          soteria-c exec exits with:
   
@@ -627,6 +639,9 @@
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
   
+         --version
+             Show version information.
+  
   EXIT STATUS
          soteria-c gen-summaries exits with:
   
@@ -841,6 +856,9 @@
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          soteria-c show-ail exits with:

--- a/soteria-rust/bin/dune
+++ b/soteria-rust/bin/dune
@@ -2,4 +2,4 @@
  (package soteria-rust)
  (public_name soteria-rust)
  (name soteria_rust)
- (libraries soteria_rust_lib))
+ (libraries soteria_rust_lib soteria))

--- a/soteria-rust/bin/soteria_rust.ml
+++ b/soteria-rust/bin/soteria_rust.ml
@@ -86,9 +86,32 @@ module Build_plugins = struct
       term
 end
 
+module Version = struct
+  let print_version () =
+    Fmt.pr "%s@.@.charon: %s@.charon hash: %s@.obol hash: %s@."
+      Soteria.Version.version Charon.CharonVersion.supported_charon_version
+      Soteria_rust_lib.Version.charon_commit
+      Soteria_rust_lib.Version.obol_commit
+
+  let term = Term.(const print_version $ const ())
+
+  let cmd =
+    Cmd.make
+      (Cmd.info ~exits ~doc:"Print version information"
+         ~man:
+           [
+             `S Cmdliner.Manpage.s_description;
+             `P
+               "Print the version of Soteria Rust, Charon, and the git commit \
+                hashes of the Soteria Rust and Obol repositories.";
+           ]
+         "version")
+      term
+end
+
 let cmd =
   Cmd.group
-    (Cmd.info ~exits "soteria-rust")
-    [ Exec.cmd; Compile.cmd; Build_plugins.cmd ]
+    (Cmd.info ~exits ~version:Soteria.Version.version "soteria-rust")
+    [ Exec.cmd; Compile.cmd; Build_plugins.cmd; Version.cmd ]
 
 let () = exit @@ Cmd.eval cmd

--- a/soteria-rust/lib/version.ml
+++ b/soteria-rust/lib/version.ml
@@ -1,0 +1,12 @@
+(* Kept in sync with scripts/versions.json by scripts/versionsync.py; do not
+   edit the version string by hand. *)
+
+(*
+ * [versionsync: CHARON_COMMIT_HASH=4986f2907dbe5899b0756ab623b5ef661ed2c58c]
+ *)
+let charon_commit = "4986f2907dbe5899b0756ab623b5ef661ed2c58c"
+
+(*
+ * [versionsync: OBOL_COMMIT_HASH=bdf52aa2082fbda85bb6b3bdb5a0d9c2b2c55a69]
+ *)
+let obol_commit = "bdf52aa2082fbda85bb6b3bdb5a0d9c2b2c55a69"

--- a/soteria-rust/test/cram/cli.t/run.t
+++ b/soteria-rust/test/cram/cli.t/run.t
@@ -15,11 +15,17 @@
          exec [OPTION]… PATH
              Run symbolic execution
   
+         version [OPTION]…
+             Print version information
+  
   COMMON OPTIONS
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          soteria-rust exits with:
@@ -231,6 +237,9 @@
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          soteria-rust exec exits with:
@@ -508,6 +517,9 @@
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          soteria-rust build-plugins exits with:
@@ -789,6 +801,9 @@
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          soteria-rust compile exits with:

--- a/soteria/lib/version.ml
+++ b/soteria/lib/version.ml
@@ -1,0 +1,5 @@
+(* Kept in sync with scripts/versions.json by scripts/versionsync.py; do not
+   edit the version string by hand. *)
+
+(* [versionsync: SOTERIA_VERSION=0.1.0] *)
+let version = "0.1.0"


### PR DESCRIPTION
Closes #155
Closes #411 

Add all the machinery needed for versioning:
- Added `soteria-rust version` and `soteria-c version`
- Added a `RELEASING.md` which details how to release new versions
- Added a `CHANGELOG.md` to facilitate usage of a changelog, with CI steps to make sure it's well-formatted and that we don't edit past changelogs
- Added a triggerable workflow to generate a new version
- Modified the nightly release script to override the version to `nightly-YYYY-MM-DD`, so `soteria-rust version` prints the right thing

I looked through the scripts and it looked fine; I also had Claude triple check it just in case; we'll have to just try and release to see :) If this works I believe I'll publish 0.1.0 once this is merged!