### PR TITLE
Distinguish the `test-lib` cache in CI

### DIFF
--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -39,9 +39,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #[actionpin: v5]
         with:
           path: _opam
-          key: ${{ runner.os }}-${{ runner.arch }}-opam-${{ env.OCAML_VERSION }}-${{ hashFiles('soteria/*.opam') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-opam-testlib-${{ env.OCAML_VERSION }}-${{ hashFiles('soteria/*.opam') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-opam-${{ env.OCAML_VERSION }}-
+            ${{ runner.os }}-${{ runner.arch }}-opam-testlib-${{ env.OCAML_VERSION }}-
 
       - name: Update opam
         run: opam update


### PR DESCRIPTION
so the cache for `test-lib` deps was the same as the rest of CI, despite it not actually containing the same things :p this was introduced in #341 which changed the `test-lib` workflow