### PR TITLE
Faster CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,8 @@ jobs:
         uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 #[actionpin: v3]
         with:
           ocaml-compiler: ${{ env.OCAML_VERSION }}
-          dune-cache: true
+          # Disabled: we get dune from the opam cache already
+          dune-cache: false
           opam-pin: false
       - name: Restore opam cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #[actionpin: v5]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Build JSON documentation
         run: make doc-json
-        if: runner.os == 'linux'
+        if: runner.os == 'linux' && github.ref == 'refs/heads/main'
 
       - name: Upload JSON documentation artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #[actionpin: v7]
@@ -202,7 +202,7 @@ jobs:
           name: odoc-json
           path: _build/default/_doc/_html
           if-no-files-found: error
-        if: runner.os == 'linux'
+        if: runner.os == 'linux' && github.ref == 'refs/heads/main'
 
       - name: Opam Cleanup
         run: opam clean -a -r

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        operating-system: [macos-latest, ubuntu-latest]
+        operating-system: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["macos-latest", "ubuntu-latest"]') }}
     runs-on: ${{ matrix.operating-system }}
     steps:
       # Setup steps: checkout, z3,  ocaml and opam
@@ -180,6 +180,7 @@ jobs:
 
       - name: Build API documentation
         run: make doc
+        if: runner.os == 'Linux'
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #[actionpin: v7]

--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 #[actionpin: v3]
         with:
           ocaml-compiler: ${{ env.OCAML_VERSION }}
-          dune-cache: true
+          dune-cache: false
           opam-pin: false
 
       - name: Restore opam cache

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test soteria-c Package
     strategy:
       matrix:
-        operating-system: [macos-latest, ubuntu-latest]
+        operating-system: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["macos-latest", "ubuntu-latest"]') }}
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Set platform artifact name
@@ -87,7 +87,7 @@ jobs:
     name: Test soteria-rust Package
     strategy:
       matrix:
-        operating-system: [macos-latest, ubuntu-latest]
+        operating-system: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["macos-latest", "ubuntu-latest"]') }}
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Set platform artifact name

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -123,11 +123,10 @@ def bench_rust(entry: dict, kind: str) -> dict:
     soteria_rust = os.environ.get("SOTERIA_RUST", SOTERIA_RUST)
     target = resolve(entry["path"])
     args = entry.get("args", [])
-    base = [soteria_rust, "exec", str(target), *args]
 
     # Compile once (untimed); analysis may exit non-zero on a found bug.
     log(f"pre-compiling {kind}: {target}")
-    run(base)
+    run([soteria_rust, "compile", str(target), *args])
 
     cmd = [soteria_rust, "exec", str(target), "--no-compile", *args]
     stats = measure(cmd, entry.get("no_hyperfine", False))


### PR DESCRIPTION


Small things I did while not knowing what to do

Disabled `dune-cache` for the `setup-ocaml` jobs, because we install `dune` and keep it in the opam cache anyways, so having it just added ~50s of Dune installation for no reason

Disabled `macos-latest` on PRs, while still running it in the merge queue, on main and for releases. MacOS runners are quite a bit slower and honestly not really needed; it basically never has a different outcome to the ubuntu build.

Skip building JSON docs outside main