### PR TITLE
Fix regression in allocator arg parsing

### DIFF
--- a/soteria-rust/lib/builtins/extern/alloc.ml
+++ b/soteria-rust/lib/builtins/extern/alloc.ml
@@ -33,8 +33,11 @@ module M (StateM : State.StateM.S) = struct
   let ptr_of_nonnull nonull = as_ptr @@ as_tuple1 nonull
 
   let align_of_enum align : [> T.nonzero ] Typed.t =
-    let align_enum = as_tuple1 align in
-    let discr = discriminant_of align_enum in
+    let discr =
+      match Rust_val.get_ty align with
+      | `Tuple -> discriminant_of (as_tuple1 align)
+      | _ -> as_any_int align
+    in
     BV.cast_nonzero @@ Typed.cast_i Usize discr
 
   let alloc ?(zeroed = false) args =

--- a/soteria-rust/lib/layout.ml
+++ b/soteria-rust/lib/layout.ml
@@ -165,7 +165,7 @@ let rec layout_of (ty : Types.ty) : (t, 'e, 'f) Rustsymex.Result.t =
          types, even if one is provided. This avoids inconsistent layouts. *)
       | [ (_triple, layout) ], _
         when (not (Config.get ()).polymorphic) || ty_is_monomorphic ty ->
-          translate_layout ty layout
+          translate_layout adt.kind ty layout
       | _ :: _ :: _, _ -> L.failwith "multiple layouts for the same ADT"
       | _, Struct fields -> compute_arbitrary_layout ty (field_tys fields)
       | _, Union fields -> compute_union_layout ty (field_tys fields)
@@ -239,7 +239,7 @@ and translate_discriminator : Types.discriminator -> Fields_shape.discriminator
       let fallback = translate_discriminator fallback in
       Branch { offset; tag_ty; children; fallback }
 
-and translate_layout ty (layout : Types.layout) =
+and translate_layout adt_kind ty (layout : Types.layout) =
   let size = compute_size ty layout.size in
   let align = compute_align ty layout.align in
   let uninhabited = layout.uninhabited in
@@ -257,17 +257,20 @@ and translate_layout ty (layout : Types.layout) =
               | [ (ofs, value) ] -> Some (BV.usizei ofs, BV.of_scalar value)
               | _ :: _ :: _ -> L.failwith "unsupported: >1 tagger values"
             in
-            (tagger, Arbitrary (Types.VariantId.of_int i, ofs)))
+            (tagger, Arbitrary ofs))
       layout.variant_layouts
   in
+  let is_enum = match adt_kind with Enum _ -> true | _ -> false in
   let fields : Fields_shape.t =
     match (discriminator, variant_layouts) with
-    (* tag layouts only exist on enum layouts *)
-    | Some (Branch _ as d), _ -> Enum (d, Array.of_list variant_layouts)
     (* no variants/invalid, so this is uninhabited; we can use primitive *)
     | _, [] | Some Invalid, _ -> Primitive
-    (* there is only one inhabited (non-Primitive) variant *)
-    | Some (Known v), _ -> snd (Types.VariantId.nth variant_layouts v)
+    (* struct/union: there is only one inhabited variant *)
+    | Some (Known v), _ when not is_enum ->
+        snd (Types.VariantId.nth variant_layouts v)
+    (* enums *)
+    | Some ((Known _ | Branch _) as d), _ ->
+        Enum (d, Array.of_list variant_layouts)
     (* we didn't translate a discriminator; we hope it's a struct-like! *)
     | None, [ (_, v) ] -> v
     | None, _ -> L.failwith "no discriminator and >1 variant layouts?"
@@ -290,8 +293,7 @@ and compute_align ty align =
       layout_warning "Inferred align=1" ty;
       BV.usizeinz 1
 
-and compute_arbitrary_layout ?fst_size ?fst_align
-    ?(variant = Types.VariantId.zero) ty members =
+and compute_arbitrary_layout ?fst_size ?fst_align ty members =
   (* Note: here we manually calculate a layout, à la [repr(C)]. We should avoid doing this,
      and make it clearer when we do. *)
   (* Calculates the offsets, size and alignment for a tuple-like type with fields of
@@ -316,9 +318,7 @@ and compute_arbitrary_layout ?fst_size ?fst_align
   let++ () = assert_or_error (Typed.not overflowed) (`InvalidLayout ty) in
   let size = size_to_fit ~size ~align in
   let layout =
-    mk ~size ~align ~uninhabited
-      ~fields:(Arbitrary (variant, Array.of_list offsets))
-      ()
+    mk ~size ~align ~uninhabited ~fields:(Arbitrary (Array.of_list offsets)) ()
   in
   Fmt.kstr layout_warning "Computed an arbitrary layout:@.%a" pp layout ty;
   layout
@@ -360,7 +360,7 @@ and compute_enum_layout ty (variants : Types.variant list) =
           ~f:(fun (size, align, variants, uninhabited) v ->
             let++ l =
               compute_arbitrary_layout ty ~fst_size:tag.size
-                ~fst_align:tag.align ~variant:v.id (field_tys v.fields)
+                ~fst_align:tag.align (field_tys v.fields)
             in
             let tagger =
               if l.uninhabited then None
@@ -391,7 +391,7 @@ and compute_union_layout ty members =
           BV.max ~signed:false align member.align ))
   in
   let fields = Array.make (List.length members) (BV.usizei 0) in
-  mk ~size ~align ~fields:(Arbitrary (Types.VariantId.zero, fields)) ()
+  mk ~size ~align ~fields:(Arbitrary fields) ()
 
 and resolve_trait_ty (tref : Types.trait_ref) assoc_ty_id args =
   match tref.kind with

--- a/soteria-rust/lib/layout_common.ml
+++ b/soteria-rust/lib/layout_common.ml
@@ -36,9 +36,8 @@ module Fields_shape = struct
 
   type t =
     | Primitive  (** No fields present *)
-    | Arbitrary of Types.variant_id * T.sint Typed.t Array.t
-        (** Arbitrary field placement (structs, unions...), with the variant
-            (e.g. enums with a single inhabited variant) *)
+    | Arbitrary of T.sint Typed.t Array.t
+        (** Arbitrary field placement (structs, tuple, unions). *)
     | Enum of discriminator * (tagger * t) Array.t
         (** Enum fields: for each variant, a possible tag with [tagger], along
             with an array of field shapes for each variant (indexed by variant
@@ -51,10 +50,8 @@ module Fields_shape = struct
 
   let rec pp ft = function
     | Primitive -> Fmt.string ft "()"
-    | Arbitrary (var, arr) ->
-        Fmt.pf ft "{%a: %a}" Types.VariantId.pp_id var
-          Fmt.(braces @@ array ~sep:comma Typed.ppa)
-          arr
+    | Arbitrary arr ->
+        Fmt.pf ft "{%a}" Fmt.(braces @@ array ~sep:comma Typed.ppa) arr
     | Enum (discriminator, shapes) ->
         Fmt.pf ft "Enum (%a, %a)" pp_discriminator discriminator
           Fmt.(brackets @@ array ~sep:comma (pair ~sep:comma pp_tagger pp))
@@ -64,12 +61,12 @@ module Fields_shape = struct
   let offset_of f = function
     | Primitive -> L.failwith "This layout has no fields"
     | Enum _ -> L.failwith "Can't get fields of enum; use `shape_for_variant`"
-    | Arbitrary (_, arr) -> arr.(f)
+    | Arbitrary arr -> arr.(f)
     | Array { stride; _ } -> BV.usizei f *!!@ stride
 
   let shape_for_variant variant = function
     | Enum (_, shapes) -> snd shapes.(Types.VariantId.to_int variant)
-    | Arbitrary (v, _) as fs when Types.VariantId.equal_id v variant -> fs
+    | Arbitrary _ as fs when Types.VariantId.(equal_id zero variant) -> fs
     | s ->
         L.failwith "Shape %a has no variant %a" pp s Types.VariantId.pp_id
           variant
@@ -97,7 +94,7 @@ module Fields_shape = struct
   let rec iter_vars fields f : unit =
     match fields with
     | Primitive -> ()
-    | Arbitrary (_, fields) -> Array.iter (fun v -> Typed.iter_vars v f) fields
+    | Arbitrary fields -> Array.iter (fun v -> Typed.iter_vars v f) fields
     | Enum (discr, layouts) ->
         iter_vars_discriminator discr f;
         Array.iter

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -67,8 +67,7 @@ let iter_fields ?variant ?meta layout (ty : Types.ty) =
   in
   match layout.fields with
   | Primitive -> Iter.singleton (ty, Usize.(0s))
-  | Array _ -> aux ?variant layout.fields ty
-  | Arbitrary (variant, _) -> aux ~variant layout.fields ty
+  | Array _ | Arbitrary _ -> aux ?variant layout.fields ty
   | Enum (_, variant_layouts) ->
       let variant = Option.get ~msg:"variant required for enum" variant in
       let _, fields = variant_layouts.(Types.VariantId.to_int variant) in
@@ -261,9 +260,9 @@ struct
     in
     let* layout = layout_of ty in
     match layout.fields with
-    | Arbitrary (vid, _) -> ok vid
     | Enum (discriminator, _) -> exec discriminator
-    | Array _ | Primitive -> L.failwith "Unexpected layout for enum"
+    | Arbitrary _ | Array _ | Primitive ->
+        L.failwith "Unexpected layout for enum"
 
   (** [decode ~meta ~offset ty] Parses a rust value of type [ty] at the given
       offset, using the provided metadata for DSTs, and returns the associated
@@ -318,16 +317,9 @@ struct
     | Array { is_ptr = false; _ }, _ ->
         let+ vs = iter (iter_fields ~meta layout ty) offset in
         mk_tuple vs
-    | Arbitrary (variant, _), _ -> (
+    | Arbitrary _, _ ->
         let+ fields = iter (iter_fields ~meta layout ty) offset in
-        match ty with
-        (* HACK: we don't want enums to be handled in arbitrary. *)
-        | TAdt adt when Crate.is_enum adt ->
-            let variants = Crate.as_enum adt in
-            let variant = Types.VariantId.nth variants variant in
-            let discr = BV.of_literal variant.discriminant in
-            mk_enum adt discr fields
-        | _ -> mk_tuple fields)
+        mk_tuple fields
     | Enum _, TAdt adt ->
         let variants = Crate.as_enum adt in
         let* variant = variant_of_enum ~offset ty in
@@ -840,7 +832,7 @@ let rec size_and_align_of_val ~load_vtable ~t ~meta =
         let** layout = Layout.layout_of t in
         let last_field_ofs =
           match layout.fields with
-          | Arbitrary (_, offsets) -> offsets.(Array.length offsets - 1)
+          | Arbitrary offsets -> offsets.(Array.length offsets - 1)
           | _ -> L.failwith "size_and_align_of_val: Unexpected layout for ADT"
         in
         let++ unsized_size, unsized_align =


### PR DESCRIPTION
#427 introduced a regression in the `align_of_enum` function for the allocator externs, which caused a big regression in conformance tests. oops!

it also introduced a regression in decoding single-variant enums due to us previously treating those as having an arbitrary layout (rather than an enum layout); i fixed the thing as a whole rather than redoing the workaround