### PR TITLE
Don't allocate ZSTs

### DIFF
--- a/soteria-rust/lib/builtins/extern/libc.ml
+++ b/soteria-rust/lib/builtins/extern/libc.ml
@@ -28,8 +28,8 @@ module M (StateM : State.StateM.S) = struct
     in
     let max_size = Typed.BitVec.usize (Layout.max_value_z (TInt Isize)) in
     let* () = assert_ (size <=@ max_size) `InvalidAlloc in
-    (* we under-approximate here: the alignment can be smaller (its min size is
-       the first power of 2 greater than or equal to the requested size) *)
+    (* UX: the alignment can be smaller (its min size is the first power of 2
+       greater than or equal to the requested size) *)
     let align = Typed.BitVec.usizeinz (2 * Crate.pointer_size ()) in
     State.alloc_untyped ~zeroed:false ~size ~align ()
 

--- a/soteria-rust/lib/builtins/optim/impl.ml
+++ b/soteria-rust/lib/builtins/optim/impl.ml
@@ -151,10 +151,10 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
        avoid path explosion. This is an under-approximation, some paths may be \
        missed."
 
-  (** Replace the real [SipHasher] with the *constant* hash: every value hashes
-      to 0. This is a valid hash function, and avoid branch explosion from
-      symbolic hashes, as e.g. hashbrown uses the lower bits of the hash to pick
-      a bucket. *)
+  (** UX: Replace the real [SipHasher] with the *constant* hash: every value
+      hashes to 0. This is a valid hash function, and avoid branch explosion
+      from symbolic hashes, as e.g. hashbrown uses the lower bits of the hash to
+      pick a bucket. *)
   let hash_one ~types:_ ~t_self:_ ~t:_ ~self:_ ~x:_ =
     if Soteria.Symex.Approx.As_ctx.is_ox () then
       Soteria.Terminal.Warn.warn_once hash_one_ux;

--- a/soteria-rust/lib/builtins/system/impl.ml
+++ b/soteria-rust/lib/builtins/system/impl.ml
@@ -12,7 +12,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
        keys, to avoid path explosion. This is an under-approximation, some \
        paths may be missed."
 
-  (* Returning *symbolic* keys makes every hash symbolic, causing branch
+  (* UX: Returning *symbolic* keys makes every hash symbolic, causing branch
      explosion; we instead stick to a concrete hash. *)
   let hashmap_random_keys ~fun_sig:_ =
     if Soteria.Symex.Approx.As_ctx.is_ox () then
@@ -30,8 +30,8 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
             NotUnicode(OsString),
         }
       ]}
-      HACK: we assume that hitting the environment never finds the variable
-      we're looking for. Under-approximating behaviour. *)
+      UX: we assume that hitting the environment never finds the variable we're
+      looking for. *)
   let inner ~(fun_sig : Types.fun_sig) ~key:_ =
     let out_res = ty_as_adt fun_sig.output in
     let var_error_ty =
@@ -51,7 +51,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
     let var_error = Typed.Adt.Checked.mk_enum var_error_ty "NotPresent" [] in
     ok @@ Typed.Adt.Checked.mk_enum out_res "Err" [ var_error ]
 
-  (** HACK: We under-approximate and always return 1. *)
+  (** UX: We under-approximate and always return 1. *)
   let available_parallelism ~(fun_sig : Types.fun_sig) =
     (* We return 1, to under-approximate the behaviour. *)
     let one = Typed.BV.usize Z.one in
@@ -72,7 +72,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).S = struct
      * // Max value of Nanoseconds is 999,999,999.
      * struct Nanoseconds(u32);
      *)
-    (* HACK: We use Unix.time for now, to be under-approximating. *)
+    (* UX: We use Unix.time for now, to be under-approximating. *)
     let now = Unix.time () in
     let sec = Int.of_float now in
     let nsec = Int.of_float ((now -. Float.of_int sec) *. 1_000_000_000.) in

--- a/soteria-rust/lib/state/rust_state_m.ml
+++ b/soteria-rust/lib/state/rust_state_m.ml
@@ -203,9 +203,6 @@ module type S = sig
     val zeros : [< sptr_f ] v -> sint v -> (unit, 'env) t
     val alloc_ty : ?span:Meta.span_data -> Types.ty -> ([> sptr_f ] v, 'env) t
 
-    val alloc_tys :
-      ?span:Meta.span_data -> Types.ty list -> ([> sptr_f ] v list, 'env) t
-
     val alloc_untyped :
       ?span:Meta.span_data ->
       zeroed:bool ->
@@ -534,7 +531,6 @@ module Make (State : State_intf.S) :
     let[@inline] store ptr ty v = ESM.lift (store ptr ty v)
     let[@inline] zeros ptr size = ESM.lift (zeros ptr size)
     let[@inline] alloc_ty ?span ty = ESM.lift (alloc_ty ?span ty)
-    let[@inline] alloc_tys ?span tys = ESM.lift (alloc_tys ?span tys)
 
     let[@inline] alloc_untyped ?span ~zeroed ~size ~align () =
       ESM.lift (alloc_untyped ?span ~zeroed ~size ~align)

--- a/soteria-rust/lib/state/state_intf.ml
+++ b/soteria-rust/lib/state/state_intf.ml
@@ -57,10 +57,6 @@ module type S = sig
     [> sptr_f ] v ret
 
   val alloc_ty : ?span:Meta.span_data -> Types.ty -> [> sptr_f ] v ret
-
-  val alloc_tys :
-    ?span:Meta.span_data -> Types.ty list -> [> sptr_f ] v list ret
-
   val free : [< sptr_f ] v -> unit ret
 
   val size_and_align_of_val :

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -784,17 +784,22 @@ module Make (Borrows : Tree_borrows.T) = struct
     [%l.debug
       "Executing Alloc of size %a (align %a)" Typed.ppa size Typed.ppa align];
     Soteria.Stats.As_ctx.incr StatKeys.allocs;
-    with_heap
-      (let open Heap.SM in
-       let open Heap.SM.Syntax in
-       let*^ block, tag =
-         Freeable_block_with_meta.make ?span ?zeroed ~align ~size ()
-       in
-       let** loc = Heap.alloc ~new_codom:block in
-       let ptr = Typed.Ptr.mk_ptr_t ~loc ~ofs:Usize.(0s) ~tag ~align ~size in
-       (* The pointer is necessarily not null *)
-       let+ () = assume [ Typed.(not (Ptr.is_null_loc loc)) ] in
-       ok (Typed.Ptr.mk_ptr_f ptr None))
+    if%sat size ==@ Usize.(0s) then
+      (* UX: we under-approximate and assume the address is align, though it can
+         in fact be any well-aligned address. *)
+      Result.ok @@ Typed.Ptr.mk_ptr_f (Typed.Ptr.of_address align) None
+    else
+      with_heap
+        (let open Heap.SM in
+         let open Heap.SM.Syntax in
+         let*^ block, tag =
+           Freeable_block_with_meta.make ?span ?zeroed ~align ~size ()
+         in
+         let** loc = Heap.alloc ~new_codom:block in
+         let ptr = Typed.Ptr.mk_ptr_t ~loc ~ofs:Usize.(0s) ~tag ~align ~size in
+         (* The pointer is necessarily not null *)
+         let+ () = assume [ Typed.(not (Ptr.is_null_loc loc)) ] in
+         ok (Typed.Ptr.mk_ptr_f ptr None))
 
   let alloc_untyped ?span ~zeroed ~size ~align = alloc ?span ~zeroed size align
 
@@ -989,9 +994,12 @@ module Make (Borrows : Tree_borrows.T) = struct
           | Real fn -> Some (Crate.get_fun fn.id).item_meta.span.data
           | Synthetic _ -> None
         in
+        (* NOTE: here we must allocate with a non-zero size, as otherwise we
+           skip creating an actual allocation and the function pointers will
+           thus have no provenance. *)
         let** ptr =
           with_alloc_kind (Function fn_def) @@ fun () ->
-          alloc_untyped ?span ~zeroed:false ~size:Usize.(0s) ~align
+          alloc_untyped ?span ~zeroed:false ~size:Usize.(1s) ~align
         in
         let ptr = Typed.Ptr.ptr_of ptr in
         let ptr = Typed.Ptr.with_tag ptr None in

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -803,26 +803,6 @@ module Make (Borrows : Tree_borrows.T) = struct
     let**^ layout = Layout.layout_of ty in
     alloc ?span layout.size layout.align
 
-  let alloc_tys ?span tys : ('a, Error.with_trace, syn list) Result.t =
-    let@ () = with_loc_err ~trace:"Allocation" () in
-    let**^ layouts = Rustsymex.Result.map_list tys ~f:Layout.layout_of in
-    let layouts = List.rev layouts in
-    with_heap
-      (Heap.allocs ~els:layouts ~fn:(fun layout loc ->
-           let open DecayMap.SM in
-           let open DecayMap.SM.Syntax in
-           (* make Tree_block *)
-           let { size; align; _ } : Layout.t = layout in
-           let* block, tag =
-             Freeable_block_with_meta.make ?span ~align ~size ()
-           in
-           (* create pointer *)
-           let* () = assume [ Typed.(not (Ptr.is_null_loc loc)) ] in
-           let ptr =
-             Typed.Ptr.mk_ptr_t ~loc ~ofs:Usize.(0s) ~tag ~align ~size
-           in
-           return (Typed.Ptr.mk_ptr_f ptr None, block)))
-
   let free (ptr : Typed.([< T.sptr_f ] t)) =
     [%l.debug "Executing Free with pointer %a" Typed.ppa ptr];
     let@ () = with_loc_err ~trace:"Freeing memory" () in

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -52,7 +52,7 @@ module Make (Borrows : Tree_borrows.T) = struct
       size : Typed.T.sint Typed.t;
       tb_root : Ptr_tag.t;
       kind : Alloc_kind.t;
-      trace : Trace.t;
+      trace : Trace.t; [@printer Trace.pp_short]
     }
     [@@deriving show { with_path = false }]
   end

--- a/soteria-rust/lib/trace.ml
+++ b/soteria-rust/lib/trace.ml
@@ -10,19 +10,19 @@ type t = {
       (** Current call stack *)
 }
 
+let pp_loc =
+  Soteria.Logs.Printers.pp_unstable ~name:"loc" Common.Charon_util.pp_span_data
+
+let pp_loc_opt : Charon.Meta.span_data option Fmt.t =
+  Fmt.option ~none:(Fmt.any "unknown location") pp_loc
+
 let pp ft t =
-  let pp_loc =
-    Soteria.Logs.Printers.pp_unstable ~name:"loc"
-      Common.Charon_util.pp_span_data
-  in
-  let pp_loc_opt : Charon.Meta.span_data option Fmt.t =
-    Fmt.option ~none:(Fmt.any "unknown location") pp_loc
-  in
   let pp_op ft = function Some op -> Fmt.pf ft " during %s" op | None -> () in
   let pp_stack = Soteria.Terminal.Call_trace.pp pp_loc in
   Fmt.pf ft "%a%a with trace@[<hov 1>@ %a@]" pp_loc_opt t.loc pp_op t.op
     pp_stack t.stack
 
+let pp_short ft t = Fmt.pf ft "%a" pp_loc_opt t.loc
 let move_to loc where = { where with loc = Some loc }
 
 let move_to_opt loc where =

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -235,7 +235,7 @@ Test exposing function pointers
   Compiling... done in <time>
   => Running expose_fn_ptr::main...
   note: expose_fn_ptr::main: done in <time>, ran 1 branch
-  PC 1: (0x0000000000000010 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffe) /\
+  PC 1: (0x0000000000000010 <=u V|1|) /\ (V|1| <=u 0x7ffffffffffffffd) /\
         (0x0 == extract[0-3](V|1|))
   
 Test thread local statics; the two warnings due to opaque functions are to be expected, as we do not run the test suite with a sysroot.

--- a/soteria/lib/logs/assets/soteria_logs.js
+++ b/soteria/lib/logs/assets/soteria_logs.js
@@ -113,7 +113,8 @@ function populateFilter() {
   const filterBox = document.getElementById("filters");
   const filterClasses = Array.from(document.querySelectorAll(".log-msg"))
     .map((msg) => msg.className.split(" "))
-    .flat();
+    .flat()
+    .filter((c) => c !== "");
   const uniqueClasses = [...new Set(filterClasses)];
   const prio = {
     SMT: 0,


### PR DESCRIPTION
Closes #313 
Enables work on #176 

Skip allocating ZSTs in `Tree_state`; this shouldn't have a massive impact since as of #374 we already return references to ZSTs without allocating, but at least now this is guaranteed!