### PR TITLE
Fix opam files

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -61,9 +61,7 @@
   (qcheck-core :with-test)
   (qcheck-alcotest :with-test)
   (dune
-   (and
-    :build
-    (>= 3.14.0)))
+   (>= 3.23))
   (ppxlib
    (>= 0.38.0))
   (ppx_mixins
@@ -72,7 +70,8 @@
    (>= 0.5))
   (yojson
    (< 3.0))
-  unionFind
+  (unionFind
+   (>= 20220109))
   ppx_deriving_yojson
   ; [versionsync: OCAMLFORMAT_VERSION=0.29.0]
   (ocamlformat
@@ -110,9 +109,7 @@
   (yojson
    (< 3.0))
   (dune
-   (and
-    :build
-    (>= 3.14.0)))
+   (>= 3.23))
   ; [versionsync: OCAMLFORMAT_VERSION=0.29.0]
   (ocamlformat
    (and
@@ -143,7 +140,8 @@
   (ppx_mixins
    (>= 0.2.0))
   fmt
-  unionFind
+  (unionFind
+   (>= 20220109))
   charon
   name_matcher_parser
   ppx_deriving_hash
@@ -152,9 +150,7 @@
   (yojson
    (< 3.0))
   (dune
-   (and
-    :build
-    (>= 3.14.0)))
+   (>= 3.23))
   ; [versionsync: OCAMLFORMAT_VERSION=0.29.0]
   (ocamlformat
    (and

--- a/soteria-c.opam
+++ b/soteria-c.opam
@@ -30,7 +30,7 @@ depends: [
   "odoc" {with-doc}
   "alcotest" {with-test}
   "yojson" {< "3.0"}
-  "dune" {>= "3.23" & build & >= "3.14.0"}
+  "dune" {>= "3.23"}
   "ocamlformat" {with-dev-setup & = "0.29.0"}
   "ocaml-lsp-server" {with-dev-setup}
 ]

--- a/soteria-c/test/cram/dune
+++ b/soteria-c/test/cram/dune
@@ -5,5 +5,6 @@
    (TERM dumb))))
 
 (cram
+ (package soteria-c)
  (deps ../../bin/soteria_c.exe exec_test.sh)
  (applies_to :whole_subtree))

--- a/soteria-rust.opam
+++ b/soteria-rust.opam
@@ -26,14 +26,14 @@ depends: [
   "ppx_subliner" {>= "0.2.1"}
   "ppx_mixins" {>= "0.2.0"}
   "fmt"
-  "unionFind"
+  "unionFind" {>= "20220109"}
   "charon"
   "name_matcher_parser"
   "ppx_deriving_hash"
   "odoc" {with-doc}
   "alcotest" {with-test}
   "yojson" {< "3.0"}
-  "dune" {>= "3.23" & build & >= "3.14.0"}
+  "dune" {>= "3.23"}
   "ocamlformat" {with-dev-setup & = "0.29.0"}
   "ocaml-lsp-server" {with-dev-setup}
 ]

--- a/soteria-rust/test/cram/dune
+++ b/soteria-rust/test/cram/dune
@@ -17,6 +17,7 @@
    (run ../../bin/soteria_rust.exe build-plugins))))
 
 (cram
+ (package soteria-rust)
  (deps
   ../../bin/soteria_rust.exe
   (alias plugins-warmup))

--- a/soteria-rust/test/ppx/dune
+++ b/soteria-rust/test/ppx/dune
@@ -4,6 +4,7 @@
  (libraries ppxlib ppx_typed_match))
 
 (cram
+ (package soteria-rust)
  (deps
   ./standalone.exe
   ./test.sh

--- a/soteria.opam
+++ b/soteria.opam
@@ -35,12 +35,12 @@ depends: [
   "alcotest" {with-test}
   "qcheck-core" {with-test}
   "qcheck-alcotest" {with-test}
-  "dune" {>= "3.23" & build & >= "3.14.0"}
+  "dune" {>= "3.23"}
   "ppxlib" {>= "0.38.0"}
   "ppx_mixins" {>= "0.2.0"}
   "hc" {>= "0.5"}
   "yojson" {< "3.0"}
-  "unionFind"
+  "unionFind" {>= "20220109"}
   "ppx_deriving_yojson"
   "ocamlformat" {with-dev-setup & = "0.29.0"}
   "ocaml-lsp-server" {with-dev-setup}


### PR DESCRIPTION
Fix our `.opam` files, that were [failing opam's CI checks](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/acaa76350133ed6eba33dcbd6cbf0c1ff0fa7765) in https://github.com/ocaml/opam-repository/pull/30150. Rather than pushing a new release just for this, I hand-edited the PR to change `soteria.opam`.

The reasons for failure:
1. we can't use a `build` rule for `dune` 
2. `unionFind` had no lower bound despite us actually needing one
3. the tests for soteria-rust and soteria-c weren't labelled for the packages soteria-rust and soteria-c so CI traied running them 

i initially had the slopper add a step to CI to check opam lints but honestly the check was not a one liner so i deemed it not worth it