### PR TITLE
Add `TArray` type to Soteria Rust's values

### DIFF
--- a/.claude/skills/profile-soteria/SKILL.md
+++ b/.claude/skills/profile-soteria/SKILL.md
@@ -136,7 +136,8 @@ earlier on `PATH` that logs a line then `exec`s the real one, and count
 spawns per benchmark run. Either way the goal is the same — a quantified,
 localized claim ("70% of minor allocations are in `Value.encode`",
 "we spawn Z3 N times when 1 would do"), not a feeling.
-(`references/ocaml-profiling.md` has both the OCaml and the Z3 recipes.)
+(`references/ocaml-profiling.md` has the OCaml recipes; `references/z3-solver.md`
+has the Z3-boundary recipes.)
 
 ### 4. One hypothesis, one change
 
@@ -214,9 +215,12 @@ find a profiler incantation that worked on the OCaml code, a new
 measurement trap, or a benchmark that isolates a subsystem well, add it to
 `references/` rather than keeping it in your head.
 
-- `references/ocaml-profiling.md` — concrete CPU / allocation / Z3-boundary
-  profiling for Soteria's OCaml + subprocess architecture, plus the settled
+- `references/ocaml-profiling.md` — concrete CPU / allocation profiling for
+  Soteria's OCaml engine, the realized-wins findings log, plus the settled
   flambda / `[@inline]` findings.
+- `references/z3-solver.md` — the Z3 subprocess boundary: spawn-count and
+  round-trip instrumentation, and the solver-side findings (incl. the
+  `reset` vs `push`/`pop` incrementality regression and its Z3 sources).
 - `references/tree-borrows.md` — Tree Borrows (`soteria-rust/lib/tree_borrows/`)
   specific findings: what `Raw.access`/`compact`/`borrow` actually cost, the
   realized optimizations and their benches, and the hard constraints.

--- a/.claude/skills/profile-soteria/references/ocaml-profiling.md
+++ b/.claude/skills/profile-soteria/references/ocaml-profiling.md
@@ -6,8 +6,10 @@ process over pipes, so the three things worth profiling are **OCaml CPU**,
 **OCaml allocations/GC**, and **the Z3 subprocess boundary**. Living
 document — add rows/recipes that worked.
 
-Tree-Borrows-specific findings live in `tree-borrows.md` (kept separate because
-that subsystem accreted a lot of detail).
+Tree-Borrows-specific findings live in `tree-borrows.md`, and everything about
+the **Z3 solver boundary** — spawn/round-trip instrumentation and solver-side
+findings — in `z3-solver.md` (both kept separate because those areas accreted a
+lot of detail).
 
 ## 0. First look — macOS `sample` (zero setup)
 
@@ -20,7 +22,7 @@ sample <pid> 3       -file /tmp/soteria.sample.txt
 Read the aggregated tree for the **syscall vs. compute split**:
 
 - dominated by `read`/`__read`/`waitpid`/`select` → bottleneck is the Z3
-  boundary or process lifecycle, go to §3;
+  boundary or process lifecycle, see `z3-solver.md`;
 - dominated by OCaml symbols (`caml_*`, `Soteria_*`, `camlZ3*`) → CPU/alloc
   in the engine, go to §1/§2.
 
@@ -137,43 +139,102 @@ A useful experiment: rerun the benchmark with a much larger minor heap
 (`OCAMLRUNPARAM=s=4M`). If wall-clock drops markedly, allocation pressure is
 the bottleneck and §2-style work will pay; if not, look elsewhere.
 
-## 3. The Z3 subprocess boundary
+## 3. Findings log — realized wins, levers, dead ends
 
-If §0 showed `read`/`waitpid` dominance, the cost is *waiting on Z3*, not
-solving math, and not OCaml. Quantify the boundary instead of inferring it.
+Soteria-specific results below, kept so nobody re-runs a settled experiment.
+(Z3 **solver-boundary** profiling — spawn counting, round-trip instrumentation —
+and the solver-side findings now live in `z3-solver.md`.)
 
-### Count Z3 spawns per run (wrapper shim)
+### Realized win: structural type hash, not polymorphic `Hashtbl.hash` (2026-06, soteria-rust)
 
-```sh
-#!/bin/sh
-# /tmp/z3trace.sh  — chmod +x, then put earlier on PATH or pass as solver path
-echo "z3 spawn $(date +%s.%N)" >> /tmp/z3spawns.log
-exec /absolute/path/to/real/z3 "$@"
-```
+`sample` on an array-heavy workload (a `[u32; N]` filled + RMW'd in a loop)
+showed `caml_hash` as the single hottest leaf (~25% self-time). Attribution:
+the Rust svalue extension's `hash_ty` (`soteria-rust/lib/svalue/ext.ml`) hashed
+each element type of a `TTuple` with the **polymorphic `Hashtbl.hash`** over the
+whole `Sv.ty` ADT. A large array is stored as one N-field tuple value, so every
+hash-cons of that value walked all N element types through `caml_hash`. Fix:
+expose the structural `hash_ty` the hash-cons table already uses from `Svalue`
+(`soteria/lib/bv_values/svalue.ml`, parameterised by the extension's hasher) and
+call it for embedded element types. `caml_hash` drops out of the profile;
+~1.17x on a 2048-element array bench, 1.03–1.10x on smaller aggregates, cram
+outputs unchanged. Commit `36d439217`. Lesson: any `Hashtbl.hash`/polymorphic
+`compare`/`(=)` on a Charon-or-svalue ADT in a hot path is suspect — it walks
+the whole structure in C; replace with a derived/structural function.
 
-```bash
-: > /tmp/z3spawns.log
-# point Soteria at the wrapper (PATH order, or its solver-path option),
-# run one experiment, then:
-wc -l /tmp/z3spawns.log     # spawns per analysis
-```
+### Open lever (uncommitted): `Gc` `space_overhead`
 
-This is how "3 spawns where 1 suffices" was found. A spawn count that scales
-with work units (instead of being ~1) means a pooling/lifetime bug — usually
-a bigger win than any solving micro-optimization.
+Allocation/GC churn is the dominant self-time bucket on allocation-heavy rust
+benches (`do_some_marking`/`caml_perform`/`pool_sweep`/`oldify`). A pure runtime
+knob helps a little: `OCAMLRUNPARAM=o=240` (space_overhead 120→240) gave a
+**consistent ~2–4%** (btreeset −2.9%, writealot −2–3%, heavy ~−2%) — and
+isolation showed it's **entirely `o`, not `s`** (minor-heap size `s=4M`/`16M`/`64M`
+did nothing; `s=64M` was worse). It's at the noise floor and trades heap memory
+for CPU, so it's a maintainer policy call (a `Gc.set { (Gc.get ()) with
+space_overhead = 240 }` at startup) rather than an autonomous commit. Recorded so
+the next run doesn't re-sweep it: `o` ≈ +2–4% ceiling, `s` ≈ nothing.
 
-### See the round-trips / wait time
+### Within-noise (reverted): sharing in `Range_tree.map_leaves`
 
-| Tool | Invocation | Notes |
-|---|---|---|
-| `strace -c -f` (Linux) | `strace -c -f soteria-c capture-db <db> ...` | Per-syscall counts/time; confirms write/read round-trip volume to the Z3 pipes. |
-| `dtruss` / `ktrace` (macOS) | `sudo dtruss -c soteria-c ...` | macOS equivalent; SIP may restrict — use `sample` as fallback. |
-| SMT dump | Soteria's `--dump-smt-file` (if available) | Inspect the actual command stream: redundant declares/asserts, unnecessary `reset`, unbatched commands are visible structural wins. |
+`map_leaves` (`soteria/lib/data/range_tree.ml`, used by every TB access via
+`Rtree_block.Tree.map_leaves_tb`) unconditionally rebuilt every node
+(`{t with node}` / `{t with children=Some(l,r)}`) even when `f` changed nothing.
+Adding physical-eq sharing (return `t` when `node==t.node` / `l'==l && r'==r`),
+plus making `map_leaves_tb` return the original node when `tb' == tb`, is a clean
+rebuild→share in the style of the TB `access` wins — but measured **within noise**
+on the TB sentinels (`reborrow_chain` 0.52→0.52, `reborrow_tree` 0.34→0.33,
+btreeset 2.49→2.45). Reason: in the hot path the leaves being mapped are exactly
+the accessed ones, whose `tb` state *does* change, so `tb' == tb` rarely holds and
+little gets shared. Reverted per the within-noise rule.
 
-The reusable conclusion to aim for: **N round-trips/spawns per run at ~M ms
-each**. Then the fix is one of: pool the process, pipeline fire-and-forget
-commands and only block on the answers you need (`check`/`get-model`),
-cache/dedupe encodings, or avoid a redundant `reset`.
+### Realized win: homogeneous `TArray` type for arrays (2026-06, soteria-rust)
+
+A `[T; N]` array was a `Tuple` value with a `TTuple` type carrying *one svty per
+element* — so the array's **type** was O(N) to hash/compare. Hash-consing a value
+re-hashes its type, so each element write into a large array paid an O(N) type
+hash on top of the O(N) value copy → O(N²) per pass. Fix: a dedicated
+`TArray of svty * int` (element type + length) svalue ext-type, O(1) regardless
+of length, **plus a matching first-class `Array of sv array` value** (NOT a
+re-typed `Tuple`: a value must be well-typed against its type or the SMT-LIB
+encoding in `value_codec` mismatches). This means dedicated `as_array` /
+`array_field_of` / `set_array_field` / `cast_array`, and *every generic
+aggregate site that can see an array must dispatch to them*: store `Index`
+navigation, `value_codec` encode/decode/validity/nondet/`ref_tys_in`, string
+literals (`string_to_ptr`/`parse_string`), and the SIMD lane wrapper
+(`simd_of_lanes`/`simd_lanes`/`raw_eq`). The cram suite is the gate that finds
+missed sites (each surfaces as a `cast`/`as_tuple` failure on an array value).
+`mk_array` takes the element type explicitly (callers read it off an element
+when present, else derive it structurally via `value_codec.svty_of_ty`), so even
+a length-0 array — whose element type is otherwise unobservable — stays correctly
+typed rather than carrying a placeholder. **heavy 2048-RMW bench
+4.58→~4.18s (~9%), memwrite ~7%**, cram unchanged. Commits `75e56911f` (type) +
+the first-class-value follow-up. Scaling experiment that justified it: same
+store count, halving per-store N (`N=2048,p=24` → `1024,48` → `512,96`) gave
+4.57→3.99→3.61s, i.e. the O(N)-per-update was ~⅓ of the array bench.
+
+**Next step (not yet done): tree-ify the array *value*.** The win above removes
+only the O(N) *type* hash; the value copy + value hash are still O(N) per write.
+Representing a large array as a balanced tree of hash-consed sub-arrays would
+make updates O(log N) (rebuild only the path; root hash folds child tags). The
+homogeneity of `TArray` already removes the type-nesting/distinguishability
+blockers that sink a chunked-*tuple* (genuine nested tuples are
+indistinguishable from chunk-trees; `impl.ml` SIMD matches exact tuple shapes).
+Sound by construction as long as nodes are built immutably (never mutate a
+shared node — the rule that sank the old `tb_state` array change). It's the
+natural substrate for issue #383's "level 2".
+
+### Dead end: guarding the logging closure allocation (PR #405, CLOSED)
+
+Tempting and *almost* worth it, but already tried and rejected — do not
+re-explore. `[%l.debug "fmt" args]` expands (see `soteria/ppx/logs.ml`) to
+`L.debug (fun m -> m "fmt" args)`, allocating a closure on every call even when
+the level is off (flambda is **off**, so it isn't sunk). PR #405 changed the ppx
+to emit `if L.<level>_enabled () then L.debug (fun m -> ...)`. Microbenchmark:
+4 words → 0, −40% CPU *on the closure in isolation*. But the real per-file
+benches **regressed +0.8% to +2.3% across the board** (write-a-lot, ctpop,
+btreeset, array_init, reborrow chain/tree): a minor-heap closure that's never
+promoted is nearly free, while the `should_log` branch + `Config.get`
+(`Write_once`) deref is a real cost paid on every hot-path log site even when
+off. Net negative; the PR was approved-but-closed.
 
 ## What we already tried: compiler-level levers (flambda, `[@inline]`/`[@cold]`)
 

--- a/.claude/skills/profile-soteria/references/z3-solver.md
+++ b/.claude/skills/profile-soteria/references/z3-solver.md
@@ -1,0 +1,115 @@
+# Profiling the Z3 solver boundary
+
+Soteria (`soteria-rust` and `soteria-c`) drives an external **Z3 process** over
+pipes through `Bv_solver.Z3_solver` (`soteria/lib/bv_values/bv_solver.ml`) — a
+*stateless, caching* solver. Whether a given benchmark is Z3-bound or
+OCaml-bound varies wildly per benchmark, so let a `sample`/`perf` profile decide
+*before* spending time here (see `ocaml-profiling.md` §0 for the first-look
+`sample` recipe and the syscall-vs-compute split).
+
+**You are in the right file when** the profile is dominated by
+`read`/`__read`/`waitpid`/`select`: the cost is *waiting on Z3*, not solving
+math and not OCaml. Quantify the boundary instead of inferring it. (If instead
+OCaml symbols — `caml_*`, `Soteria_*`, GC — dominate, Z3 instrumentation tells
+you nothing; go back to `ocaml-profiling.md` §1/§2.)
+
+## Count Z3 spawns per run (wrapper shim)
+
+```sh
+#!/bin/sh
+# /tmp/z3trace.sh  — chmod +x, then put earlier on PATH or pass as solver path
+echo "z3 spawn $(date +%s.%N)" >> /tmp/z3spawns.log
+exec /absolute/path/to/real/z3 "$@"
+```
+
+```bash
+: > /tmp/z3spawns.log
+# point Soteria at the wrapper (PATH order, or its solver-path option),
+# run one experiment, then:
+wc -l /tmp/z3spawns.log     # spawns per analysis
+```
+
+This is how "3 spawns where 1 suffices" was found. A spawn count that scales
+with work units (instead of being ~1) means a pooling/lifetime bug — usually
+a bigger win than any solving micro-optimization.
+
+## See the round-trips / wait time
+
+| Tool | Invocation | Notes |
+|---|---|---|
+| `strace -c -f` (Linux) | `strace -c -f soteria-c capture-db <db> ...` | Per-syscall counts/time; confirms write/read round-trip volume to the Z3 pipes. |
+| `dtruss` / `ktrace` (macOS) | `sudo dtruss -c soteria-c ...` | macOS equivalent; SIP may restrict — use `sample` as fallback. |
+| SMT dump | Soteria's `--dump-smt-file` (if available) | Inspect the actual command stream: redundant declares/asserts, unnecessary `reset`, unbatched commands are visible structural wins. |
+
+The reusable conclusion to aim for: **N round-trips/spawns per run at ~M ms
+each**. Then the fix is one of: pool the process, pipeline fire-and-forget
+commands and only block on the answers you need (`check`/`get-model`),
+cache/dedupe encodings, or avoid a redundant `reset`.
+
+But **`reset` is not free overhead** — read the next finding before "optimising"
+it away.
+
+## Finding (reverted, regression): `(reset)` per query → scoped `push`/`pop` (2026-06, soteria-rust)
+
+**Tried and reverted — do not retry without solving the incrementality problem
+below.** `check_sat_raw` issued a `(reset)` before **every** non-cached query,
+then re-declared the query's vars, asserted the full constraint, and checked. On
+`ctpop.rs` the SMT dump (`--dump-smt=...`) showed one `(reset)` per `(check-sat)`
+(995 of each) and `sample` showed ~95% of wall-clock blocked in `read`, i.e.
+Z3-bound; the cost there wasn't *solving* (one 8-bit var) but Z3 re-initialising
+its solver object on each `(reset)`. Swapping `(reset)` for an `Intf.push z3 1` …
+`Intf.pop z3 1` pair around the per-query declares+assert cut that re-init:
+**ctpop 4.93 s → 0.52 s** locally.
+
+**Why it was reverted:** that local benchmark was misleading. `(reset)` lets Z3
+run its **non-incremental** tactic pipeline (aggressive bit-blasting /
+preprocessing); `push`/`pop` forces Z3's **incremental** online SMT core, which
+is dramatically slower for the hard goals these benchmarks actually hit —
+bit-blasted floating-point (FPA) and bitvector-heavy queries. CI on the full PR
+exposed it: **Collections-C `capture-db` 9.96 s → 44.39 s (+346%, ≈4.4×)** and
+**6 kani FP-intrinsic tests (`trunc`/`floor`/`ceil`/`round`/`round_ties_even`/
+FastMath `mul`) went `pass → timeout`** (3 s limit). A minimal A/B confirmed it
+in isolation: a symbolic `f64` through `trunc`/`floor`/`ceil` took **4.65 s with
+push/pop vs 0.28 s with reset** — a ~16× regression from this one hunk. The
+trivial-query win (ctpop) does not come close to paying for the FP/bitvector
+timeouts.
+
+Transferable lesson: **`reset` vs `push`/`pop` is not a free re-init
+optimisation — it changes Z3's solving mode.** A per-query `(reset)`/full
+re-declare looks wasteful in an SMT dump, but for FPA/bitvector goals the
+non-incremental tactic path it enables is often the reason Z3 terminates at all.
+Before touching it, gate on a *solver-heavy* and an *FP-heavy* benchmark (e.g.
+Collections-C + the kani rounding intrinsics), not just a re-init-bound one like
+ctpop. (Separately: `(set-option :produce-models true)` is sent on every init
+but `get_model` is never called outside `tests/bv_fuzz`; dropping it shaved ~3%
+on ctpop but was left in to avoid a latent `None`-model footgun.)
+
+Confirmed by Z3 maintainers — this is documented Z3 behaviour, not a
+soteria-specific quirk:
+
+- **Why incremental is a different, weaker solver.** Christoph Wintersteiger:
+  *"The 'one-shot' solver translates everything into bit-vectors, bit-blasts,
+  then runs a specialized SAT-only solver. The incremental version uses a
+  completely different (SMT) solver which supports theory combination, supports
+  incrementality, and which is lazy in terms of float-to-bv conversion and
+  bit-blasting, and uses different heuristics."*
+  ([Z3 #1459](https://github.com/Z3Prover/z3/issues/1459)) — same issue reports
+  push/pop turning *instant* into 14 s, and 2 s into >6 min, on small QF_FP
+  goals.
+- **The lost preprocessing is variable elimination.** Nikolaj Bjørner:
+  *"It is solved mainly due to pre-processing that eliminates variables from
+  equations. This is not available in incremental mode for this version … the
+  more common shortcoming of incremental mode that it doesn't include useful
+  variable elimination."* His recommendation is literally what `reset` does:
+  *"instead of using incremental mode, create a solver for every new query."*
+  ([Z3 #7441](https://github.com/Z3Prover/z3/issues/7441))
+- **The tactic dispatch.** For `QF_BV`, Z3's `qfbv` tactic picks the fast
+  one-shot `sat` solver or the slow fully-featured `smt` solver based on
+  features; *"If you don't specify any logic, Z3 will often run the slowest
+  possible solver because it has to expect anything."*
+  ([Z3 #248](https://github.com/Z3Prover/z3/issues/248))
+- **The "throw it away periodically" pattern** (relevant if a future re-init
+  optimisation is attempted): some users *"push/pop for some time, but after
+  some number of queries they throw it all away and re-build all the
+  assertions"* — i.e. amortise re-init without staying incremental forever
+  ([Z3 #1459](https://github.com/Z3Prover/z3/issues/1459)).

--- a/soteria-c/lib/abductor.ml
+++ b/soteria-c/lib/abductor.ml
@@ -29,7 +29,7 @@ let generate_summaries_for (fundef : fundef) =
   in
   let process =
     let open Csymex.Syntax in
-    let* args = Csymex.all Layout.nondet_c_ty_aggregate arg_tys in
+    let* args = Csymex.map_list ~f:Layout.nondet_c_ty_aggregate arg_tys in
     let* result, state = Bi_interp.exec_fun fundef ~args Bi_state.empty in
     match result with
     | Ok ret -> Csymex.return (args, Ok ret, state)

--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -187,7 +187,7 @@ let parse_and_link_ail ~includes files =
   | files ->
       let* parsed =
         if (Config.current ()).no_ignore_parse_failures then
-          Monad.ResultM.all parse_and_signal files
+          Monad.ResultM.map_list ~f:parse_and_signal files
         else
           let parsed =
             List.filter_map

--- a/soteria-rust/bin/soteria_rust.ml
+++ b/soteria-rust/bin/soteria_rust.ml
@@ -114,4 +114,7 @@ let cmd =
     (Cmd.info ~exits ~version:Soteria.Version.version "soteria-rust")
     [ Exec.cmd; Compile.cmd; Build_plugins.cmd; Version.cmd ]
 
-let () = exit @@ Cmd.eval cmd
+let () =
+  (* Trade extra memory for better performance (~2% across benchmarks) *)
+  Gc.set { (Gc.get ()) with space_overhead = 240 };
+  exit @@ Cmd.eval cmd

--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -2,6 +2,7 @@
     share them here for convenience. *)
 
 open Charon
+open Common.Charon_util
 open Svalue
 open Typed
 open Typed.Syntax
@@ -208,9 +209,9 @@ module M (StateM : State.StateM.S) = struct
         { id = TBuiltin TStr; generics = Charon.TypesUtils.empty_generic_args }
     in
     let+ str_data = State.load ptr str_ty in
-    Typed.Adt.as_tuple @@ Typed.cast_tuple str_data
-    |> ( Monad.OptionM.map_list @@ fun b ->
-         Typed.BitVec.to_z @@ Typed.cast_i U8 b )
+    Typed.Adt.as_array @@ Typed.cast_array str_data
+    |> Monad.OptionM.map_list ~f:(fun b ->
+        Typed.BitVec.to_z @@ Typed.cast_i U8 b)
     |> Option.map (fun cs ->
         let cs = List.map (fun z -> Char.chr (Z.to_int z)) cs in
         let str = String.of_seq @@ List.to_seq cs in
@@ -233,9 +234,9 @@ module M (StateM : State.StateM.S) = struct
           |> Bytes.fold_left (fun l c -> BV.u8i (Char.code c) :: l) []
           |> List.rev
         in
-        let char_arr = Typed.Adt.mk_tuple chars in
+        let char_arr = Typed.Adt.mk_array u8_ty chars in
         let str_ty : Types.ty =
-          Common.Charon_util.mk_array_ty (TLiteral (TUInt U8)) (Z.of_int len)
+          Common.Charon_util.mk_array_ty u8_ty (Z.of_int len)
         in
         let@ () = with_alloc_kind ~kind:StaticString in
         let* ptr = State.alloc_ty str_ty in

--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -209,7 +209,8 @@ module M (StateM : State.StateM.S) = struct
     in
     let+ str_data = State.load ptr str_ty in
     Typed.Adt.as_tuple @@ Typed.cast_tuple str_data
-    |> (Monad.OptionM.all @@ fun b -> Typed.BitVec.to_z @@ Typed.cast_i U8 b)
+    |> ( Monad.OptionM.map_list @@ fun b ->
+         Typed.BitVec.to_z @@ Typed.cast_i U8 b )
     |> Option.map (fun cs ->
         let cs = List.map (fun z -> Char.chr (Z.to_int z)) cs in
         let str = String.of_seq @@ List.to_seq cs in

--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -210,8 +210,9 @@ module M (StateM : State.StateM.S) = struct
     in
     let+ str_data = State.load ptr str_ty in
     Typed.Adt.as_array @@ Typed.cast_array str_data
-    |> Monad.OptionM.map_list ~f:(fun b ->
-        Typed.BitVec.to_z @@ Typed.cast_i U8 b)
+    |> Monad.OptionM.map_m
+         (module Iarray)
+         ~f:(fun b -> Typed.BitVec.to_z @@ Typed.cast_i U8 b)
     |> Option.map (fun cs ->
         let cs = List.map (fun z -> Char.chr (Z.to_int z)) cs in
         let str = String.of_seq @@ List.to_seq cs in
@@ -229,10 +230,9 @@ module M (StateM : State.StateM.S) = struct
     | Some ptr -> ok ptr
     | None ->
         let len = String.length str in
+        let bytes = Bytes.of_string str in
         let chars =
-          String.to_bytes str
-          |> Bytes.fold_left (fun l c -> BV.u8i (Char.code c) :: l) []
-          |> List.rev
+          Iarray.init len (fun i -> BV.u8i (Bytes.get_uint8 bytes i))
         in
         let char_arr = Typed.Adt.mk_array u8_ty chars in
         let str_ty : Types.ty =

--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -892,7 +892,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let* r = State.load b bytes in
     let l = Typed.cast_array l in
     let r = Typed.cast_array r in
-    Iter.of_list_combine (Typed.Adt.as_array l) (Typed.Adt.as_array r)
+    Iter.of_iarray2 (Typed.Adt.as_array l) (Typed.Adt.as_array r)
     |> Iter.fold
          (fun acc (l, r) ->
            Typed.and_lazy acc (fun () ->
@@ -1075,7 +1075,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     | TExtension (TTuple [ TExtension (TArray _) ]) ->
         let wrapper = Typed.Adt.as_tuple1 @@ lanes in
         let elems = Typed.Adt.as_array @@ Typed.cast_array wrapper in
-        ok (List.map (Typed.cast_lit elem_ty) elems)
+        ok (Iarray.map (Typed.cast_lit elem_ty) elems)
     | _ ->
         not_impl
           "unsupported SIMD type definition, expected a struct wrapping a [T; \
@@ -1115,7 +1115,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let lane a b = Typed.ite (cmp a b) ones zeros in
     let* x = simd_lanes lit x in
     let+ y = simd_lanes lit y in
-    simd_of_lanes lit (List.map2 lane x y)
+    simd_of_lanes lit (Iarray.map2 lane x y)
 
   let simd_eq ~t:_ ~u ~x ~y = simd_cmp Typed.sem_eq ~u ~x ~y
   let simd_ne ~t:_ ~u ~x ~y = simd_cmp (fun a b -> Typed.not (a ==@ b)) ~u ~x ~y
@@ -1135,7 +1135,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let lane a b = op a b in
     let* x = simd_lanes lit x in
     let+ y = simd_lanes lit y in
-    simd_of_lanes lit (List.map2 lane x y)
+    simd_of_lanes lit (Iarray.map2 lane x y)
 
   let simd_and ~t ~x ~y = simd_binop t BV.and_ x y
   let simd_or ~t ~x ~y = simd_binop t BV.or_ x y
@@ -1153,7 +1153,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
   let simd_unop t op x =
     let lit = simd_elem_lit t in
     let+ x = simd_lanes lit x in
-    simd_of_lanes lit (List.map (fun a -> op a) x)
+    simd_of_lanes lit (Iarray.map op x)
 
   let simd_neg ~t ~x = simd_unop t ( ~-! ) x
 
@@ -1163,10 +1163,10 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     in
     let lit = TypesUtils.ty_as_literal u in
     let+ x = simd_lanes lit x in
-    List.nth x (Z.to_int idx)
+    Iarray.get x (Z.to_int idx)
 
   let simd_splat ~t ~u ~value =
     let ty = TypesUtils.ty_as_literal u in
     let+ len = simd_len t in
-    simd_of_lanes ty (List.init len (fun _ -> value))
+    simd_of_lanes ty (Iarray.init len (fun _ -> value))
 end

--- a/soteria-rust/lib/builtins/intrinsics/impl.ml
+++ b/soteria-rust/lib/builtins/intrinsics/impl.ml
@@ -520,14 +520,13 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let r = Typed.Ptr.ptr_of right in
     let zero = Usize.(0s) in
     let one = Usize.(1s) in
-    let byte = Types.TLiteral (TUInt U8) in
     let rec aux ?res ?(inc = one) l r len =
       if%sat len ==@ zero then ok @@ Option.value res ~default:U32.(0s)
       else
         let* l = Sptr.offset inc l in
         let* r = Sptr.offset inc r in
-        let* bl = State.load (Typed.Ptr.mk_ptr_f l None) byte in
-        let* br = State.load (Typed.Ptr.mk_ptr_f r None) byte in
+        let* bl = State.load (Typed.Ptr.mk_ptr_f l None) u8_ty in
+        let* br = State.load (Typed.Ptr.mk_ptr_f r None) u8_ty in
         (* compare_bytes reads all bytes and mustn't short-circuit, so we must
            keep reading; here we only modify the result if we haven't reached a
            conclusion yet *)
@@ -885,15 +884,15 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let* size =
       of_opt_not_impl "raw_eq with nondet size" @@ BV.to_z layout.size
     in
-    let bytes = mk_array_ty (TLiteral (TUInt U8)) size in
+    let bytes = mk_array_ty u8_ty size in
     (* TODO: figure out if for these two reads we should ignore the modified
        state, as its leaves may be split in bytes which will require ugly
        transmutations to be read from again later. *)
     let* l = State.load a bytes in
     let* r = State.load b bytes in
-    let l = Typed.cast_tuple l in
-    let r = Typed.cast_tuple r in
-    Iter.of_list_combine (Typed.Adt.as_tuple l) (Typed.Adt.as_tuple r)
+    let l = Typed.cast_array l in
+    let r = Typed.cast_array r in
+    Iter.of_list_combine (Typed.Adt.as_array l) (Typed.Adt.as_array r)
     |> Iter.fold
          (fun acc (l, r) ->
            Typed.and_lazy acc (fun () ->
@@ -1056,7 +1055,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
         ~f:(fun i ->
           let off = BV.usizei i in
           let* ptr = Sptr.offset ~check_signed:true off ptr in
-          State.store (Typed.Ptr.mk_ptr_f ptr None) (TLiteral (TUInt U8)) val_)
+          State.store (Typed.Ptr.mk_ptr_f ptr None) u8_ty val_)
 
   let volatile_load ~t ~src = State.load src t
   let volatile_set_memory = write_bytes
@@ -1073,16 +1072,17 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
      value is [Tuple [ Tuple lanes ]]. *)
   let simd_lanes elem_ty (lanes : Typed.([< T.any ] t)) =
     match%ty lanes with
-    | TExtension (TTuple [ TExtension (TTuple _) ]) ->
+    | TExtension (TTuple [ TExtension (TArray _) ]) ->
         let wrapper = Typed.Adt.as_tuple1 @@ lanes in
-        let elems = Typed.Adt.as_tuple @@ Typed.cast_tuple wrapper in
+        let elems = Typed.Adt.as_array @@ Typed.cast_array wrapper in
         ok (List.map (Typed.cast_lit elem_ty) elems)
     | _ ->
         not_impl
           "unsupported SIMD type definition, expected a struct wrapping a [T; \
            N] array"
 
-  let simd_of_lanes lanes = Typed.Adt.mk_tuple [ Typed.Adt.mk_tuple lanes ]
+  let simd_of_lanes ty lanes =
+    Typed.Adt.mk_tuple [ Typed.Adt.mk_array (TLiteral ty) lanes ]
 
   (* The element type of a SIMD vector, i.e. the [T] in its `[T; N]` field. *)
   let simd_elem_lit (ty : Types.ty) : Types.literal_type =
@@ -1115,7 +1115,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let lane a b = Typed.ite (cmp a b) ones zeros in
     let* x = simd_lanes lit x in
     let+ y = simd_lanes lit y in
-    simd_of_lanes (List.map2 lane x y)
+    simd_of_lanes lit (List.map2 lane x y)
 
   let simd_eq ~t:_ ~u ~x ~y = simd_cmp Typed.sem_eq ~u ~x ~y
   let simd_ne ~t:_ ~u ~x ~y = simd_cmp (fun a b -> Typed.not (a ==@ b)) ~u ~x ~y
@@ -1135,7 +1135,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let lane a b = op a b in
     let* x = simd_lanes lit x in
     let+ y = simd_lanes lit y in
-    simd_of_lanes (List.map2 lane x y)
+    simd_of_lanes lit (List.map2 lane x y)
 
   let simd_and ~t ~x ~y = simd_binop t BV.and_ x y
   let simd_or ~t ~x ~y = simd_binop t BV.or_ x y
@@ -1153,7 +1153,7 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
   let simd_unop t op x =
     let lit = simd_elem_lit t in
     let+ x = simd_lanes lit x in
-    simd_of_lanes (List.map (fun a -> op a) x)
+    simd_of_lanes lit (List.map (fun a -> op a) x)
 
   let simd_neg ~t ~x = simd_unop t ( ~-! ) x
 
@@ -1165,7 +1165,8 @@ module M (StateM : State.StateM.S) : Intf.M(StateM).Impl = struct
     let+ x = simd_lanes lit x in
     List.nth x (Z.to_int idx)
 
-  let simd_splat ~t ~u:_ ~value =
+  let simd_splat ~t ~u ~value =
+    let ty = TypesUtils.ty_as_literal u in
     let+ len = simd_len t in
-    simd_of_lanes (List.init len (fun _ -> value))
+    simd_of_lanes ty (List.init len (fun _ -> value))
 end

--- a/soteria-rust/lib/common/charon_util.ml
+++ b/soteria-rust/lib/common/charon_util.ml
@@ -198,12 +198,15 @@ let meta_get_attr (meta : Types.item_meta) attr =
 let decl_get_attr (decl : GAst.fun_decl) attr =
   meta_get_attr decl.item_meta attr
 
-let adt_is_box (adt : Types.type_decl_ref) =
+let adt_is_lang_item lang_item (adt : Types.type_decl_ref) =
   match adt.id with
   | TAdtId id ->
       let adt = Crate.get_adt_raw id in
-      adt.item_meta.lang_item = Some "owned_box"
+      Option.is_some_and (String.equal lang_item) adt.item_meta.lang_item
   | _ -> false
+
+let adt_is_box = adt_is_lang_item "owned_box"
+let adt_is_unsafe_cell = adt_is_lang_item "unsafe_cell"
 
 let rec get_pointee : Types.ty -> Types.ty = function
   | TRef (_, ty, _)

--- a/soteria-rust/lib/common/charon_util.ml
+++ b/soteria-rust/lib/common/charon_util.ml
@@ -182,7 +182,11 @@ let mk_tuple_ty types : Types.ty =
 (** The type [*const ()] *)
 let unit_ptr = Types.TRawPtr (TypesUtils.mk_unit_ty, RShared)
 
+(** The type [&()] *)
 let unit_ref = Types.TRef (RErased, TypesUtils.mk_unit_ty, RShared)
+
+(** The type [u8] *)
+let u8_ty = Types.TLiteral (TUInt U8)
 
 let decl_has_attr (decl : GAst.fun_decl) attr =
   List.exists

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -170,7 +170,7 @@ module Make (StateImpl : State.S) = struct
     | CArray cs ->
         let+ vals = map_list cs ~f:resolve_constant in
         let elem_ty = Layout.index_ty const.ty in
-        Typed.Adt.mk_array elem_ty vals
+        Typed.Adt.mk_array elem_ty (Iarray.of_list vals)
     | CAdt (None, fields) ->
         let+ vals = map_list fields ~f:resolve_constant in
         Typed.Adt.mk_tuple vals
@@ -934,7 +934,7 @@ module Make (StateImpl : State.S) = struct
     (* Array aggregate *)
     | Aggregate (AggregatedArray (ty, _size), operands) ->
         let+ values = eval_operand_list operands in
-        Typed.Adt.mk_array ty values
+        Typed.Adt.mk_array ty (Iarray.of_list values)
     (* Raw pointer construction *)
     | Aggregate (AggregatedRawPtr (_, _), operands) ->
         let* values = eval_operand_list operands in
@@ -970,7 +970,7 @@ module Make (StateImpl : State.S) = struct
         let+ value = eval_operand value in
         let len = int_of_constant_expr len in
         (* FIXME: this is horrible for large arrays! *)
-        let els = List.init len (fun _ -> value) in
+        let els = Iarray.init len (fun _ -> value) in
         Typed.Adt.mk_array ty els
     (* Length of a &[T;N] or &[T] *)
     | Len (place, _, size_opt) -> (

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -169,7 +169,8 @@ module Make (StateImpl : State.S) = struct
     | CPtrNoProvenance v -> ok (Typed.Ptr.of_address_f (BV.usize v))
     | CArray cs ->
         let+ vals = map_list cs ~f:resolve_constant in
-        Typed.Adt.mk_tuple vals
+        let elem_ty = Layout.index_ty const.ty in
+        Typed.Adt.mk_array elem_ty vals
     | CAdt (None, fields) ->
         let+ vals = map_list fields ~f:resolve_constant in
         Typed.Adt.mk_tuple vals
@@ -759,11 +760,8 @@ module Make (StateImpl : State.S) = struct
                   Typed.Ptr.mk_ptr_f v (Some meta)
               | idx :: rest ->
                   let v = Typed.cast_tuple v in
-                  let fs = Typed.Adt.as_tuple v in
-                  let before, target, after = List.split_around fs idx in
-                  let+ target = with_ptr_meta target rest in
-                  let fs = before @ (target :: after) in
-                  Typed.Adt.mk_tuple fs
+                  let+ target = with_ptr_meta (Typed.Adt.field_of idx v) rest in
+                  Typed.Adt.set_field idx target v
             in
             let* unsize_path = Layout.unsize_path from_ty in
             match unsize_path with
@@ -934,9 +932,9 @@ module Make (StateImpl : State.S) = struct
     | Aggregate (AggregatedAdt (_, Some _, Some _), _) ->
         L.failwith "Invalid ADT aggregate kind"
     (* Array aggregate *)
-    | Aggregate (AggregatedArray (_ty, _size), operands) ->
+    | Aggregate (AggregatedArray (ty, _size), operands) ->
         let+ values = eval_operand_list operands in
-        Typed.Adt.mk_tuple values
+        Typed.Adt.mk_array ty values
     (* Raw pointer construction *)
     | Aggregate (AggregatedRawPtr (_, _), operands) ->
         let* values = eval_operand_list operands in
@@ -968,12 +966,12 @@ module Make (StateImpl : State.S) = struct
         in
         Typed.Ptr.mk_ptr_f ptr meta
     (* Array repetition *)
-    | Repeat (value, _, len) ->
+    | Repeat (value, ty, len) ->
         let+ value = eval_operand value in
         let len = int_of_constant_expr len in
         (* FIXME: this is horrible for large arrays! *)
         let els = List.init len (fun _ -> value) in
-        Typed.Adt.mk_tuple els
+        Typed.Adt.mk_array ty els
     (* Length of a &[T;N] or &[T] *)
     | Len (place, _, size_opt) -> (
         let* ptr = resolve_place place in

--- a/soteria-rust/lib/layout.ml
+++ b/soteria-rust/lib/layout.ml
@@ -71,15 +71,22 @@ let rec dst_kind : Types.ty -> meta_kind = function
   | _ -> NoneKind
 
 (** If this is a DST type with a slice tail, return the type of the slice's
-    element. *)
-let rec dst_slice_ty : Types.ty -> Types.ty option = function
-  | TAdt { id = TBuiltin TStr; _ } -> Some (TLiteral (TUInt U8))
-  | TSlice sub_ty -> Some sub_ty
+    element. Errors otherwise. *)
+let rec dst_slice_ty : Types.ty -> Types.ty = function
+  | TAdt { id = TBuiltin TStr; _ } -> TLiteral (TUInt U8)
+  | TSlice sub_ty -> sub_ty
   | TAdt adt when Crate.is_struct adt -> (
       match List.last_opt (Crate.as_struct adt) with
-      | None -> None
+      | None -> L.failwith "dst_slice_ty: unexpected type"
       | Some last -> dst_slice_ty Types.(last.field_ty))
-  | _ -> None
+  | ty -> L.failwith "dst_slice_ty: unexpected type: %a" pp_ty ty
+
+(** Returns the resulting type obtained when indexing into the given type. Only
+    valid for arrays, slices and [str]. *)
+let index_ty : Types.ty -> Types.ty = function
+  | TAdt { id = TBuiltin TStr; _ } -> TLiteral (TUInt U8)
+  | TSlice ty | TArray (ty, _) -> ty
+  | ty -> L.failwith "slice_ty: unexpected type: %a" pp_ty ty
 
 (** If this is a dynamically sized type (requiring a fat pointer) *)
 let is_dst ty = dst_kind ty <> NoneKind

--- a/soteria-rust/lib/layout.ml
+++ b/soteria-rust/lib/layout.ml
@@ -465,10 +465,9 @@ let rec is_unsafe_cell : Types.ty -> bool = function
       List.exists is_unsafe_cell types
   | TAdt { id = TBuiltin _; _ } -> false
   | TAdt adt -> (
-      let adt = Crate.get_adt adt in
-      if adt.item_meta.lang_item = Some "unsafe_cell" then true
+      if adt_is_unsafe_cell adt then true
       else
-        match adt.kind with
+        match (Crate.get_adt adt).kind with
         | Struct fs | Union fs -> List.exists is_unsafe_cell (field_tys fs)
         | Enum vs ->
             Iter.exists is_unsafe_cell

--- a/soteria-rust/lib/rustsymex.ml
+++ b/soteria-rust/lib/rustsymex.ml
@@ -114,9 +114,12 @@ module Poly = struct
       (res, { st with subst = prev_subst })
 
   let subst f x =
-    let* { subst; _ } = get_state () in
-    try return (f subst x)
-    with Not_found -> give_up "Substitution failed -- wrong poly environment"
+    if not (Config.get ()).polymorphic then return x
+    else
+      let* { subst; _ } = get_state () in
+      try return (f subst x)
+      with Not_found ->
+        give_up "Substitution failed -- wrong poly environment"
 
   let subst_ty = subst ty_substitute
   let subst_tys = subst (fun subst -> List.map (ty_substitute subst))

--- a/soteria-rust/lib/store.ml
+++ b/soteria-rust/lib/store.ml
@@ -52,7 +52,7 @@ module Place = struct
           v
     | Index (base, idx) ->
         update_val base
-          ~f:(fun v -> Typed.Adt.update_field idx f (Typed.cast_tuple v))
+          ~f:(fun v -> Typed.Adt.update_array_field idx f (Typed.cast_array v))
           v
     (* metadata isn't navigable for in-place writes; spill to the heap *)
     | Metadata _ -> None
@@ -147,7 +147,7 @@ let rec try_load (place : Place.t) (store : t) : Binding.kind option =
   | Index (base, idx) ->
       try_load base store
       |> bind_value @@ fun v ->
-         Value (Typed.Adt.field_of idx (Typed.cast_tuple v))
+         Value (Typed.Adt.array_field_of idx (Typed.cast_array v))
   | Metadata base -> (
       try_load base store
       |> bind_value @@ fun v ->

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -26,8 +26,9 @@ and 'ghost ext_ty =
       (** the type decl ref of an {b enum} *)
   | TUnion of (Types.type_decl_ref[@printer Crate.pp_type_decl_ref])
       (** the type decl ref of a {b union} *)
-  | TTuple of 'ghost svty list
-      (** structs, tuples and arrays (ordered fields) *)
+  | TTuple of 'ghost svty list  (** structs and tuples (ordered fields) *)
+  | TArray of 'ghost svty * Z.t
+      (** arrays (all elements share the same type) *)
   | TThinPtr
   | TFullPtr
   | TPolyType
@@ -37,7 +38,8 @@ and 'ghost ext_t =
   | ThinPtr of 'ghost ptr
       (** thin pointer, without metadata but with extra info on the pointer *)
   | Enum of 'ghost sv * 'ghost sv list  (** discriminant * values *)
-  | Tuple of 'ghost sv list  (** contains ordered values *)
+  | Tuple of 'ghost sv list  (** structs and tuples: ordered values *)
+  | Array of 'ghost sv list  (** arrays: ordered values, all of the same type *)
   | Union of ('ghost sv * 'ghost sv * 'ghost sv) list
       (** list of blocks in the union, with their offset and size *)
   | PolyVal of Charon.Types.type_var_id
@@ -49,6 +51,7 @@ let rec pp_ext_ty ft : 'ghost ext_ty -> unit = function
   | TEnum ty -> Crate.pp_type_decl_ref ft ty
   | TUnion ty -> Crate.pp_type_decl_ref ft ty
   | TTuple tys -> Fmt.(brackets (list ~sep:semi pp_svty)) ft tys
+  | TArray (ty, n) -> Fmt.pf ft "[%a; %a]" pp_svty ty Z.pp n
   | TThinPtr -> Fmt.string ft "TThinPtr"
   | TFullPtr -> Fmt.string ft "TFullPtr"
   | TPolyType -> Fmt.string ft "TPolyType"
@@ -79,6 +82,7 @@ module Rust_ext :
     | Enum (disc, vals) ->
         Fmt.pf ft "Enum(%a: %a)" pp disc (Fmt.list ~sep:(Fmt.any ", ") pp) vals
     | Tuple vals -> Fmt.pf ft "(%a)" (Fmt.list ~sep:(Fmt.any ", ") pp) vals
+    | Array vals -> Fmt.pf ft "[%a]" (Fmt.list ~sep:(Fmt.any ", ") pp) vals
     | Union vs ->
         let pp_block ft (v, ofs, size) =
           Fmt.pf ft "(%a: %a-%a)" pp ofs pp v pp size
@@ -101,7 +105,7 @@ module Rust_ext :
     | Enum (disc, vals) ->
         iter_vars disc;
         List.iter iter_vars vals
-    | Tuple vals -> List.iter iter_vars vals
+    | Tuple vals | Array vals -> List.iter iter_vars vals
     | Union vs ->
         List.iter
           (fun (v, ofs, size) ->
@@ -122,6 +126,7 @@ module Rust_ext :
     | TThinPtr -> 3
     | TFullPtr -> 4
     | TPolyType -> 5
+    | TArray (ty, n) -> combine (combine 6 (Sv.hash_ty hash_ty ty)) (Z.hash n)
 
   (* TODO: so derivable *)
   let hash = function
@@ -137,6 +142,8 @@ module Rust_ext :
           (combine disc.tag 4) vals
     | Tuple vals ->
         List.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 5 vals
+    | Array vals ->
+        List.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 8 vals
     | Union vs ->
         List.fold_left
           (fun acc ((v : _ sv), (ofs : _ sv), (size : _ sv)) ->
@@ -157,6 +164,22 @@ module Rust_ext :
         let v, s = apply ~missing_var s v in
         let vs, s = apply_list apply ~missing_var s vs in
         (v :: vs, s)
+
+  let apply_iarray apply ~missing_var s arr =
+    let n = Iarray.length arr in
+    if n = 0 then (arr, s)
+    else begin
+      let s = ref s in
+      let out =
+        Iarray.map
+          (fun prev ->
+            let v, s' = apply ~missing_var !s prev in
+            s := s';
+            v)
+          arr
+      in
+      (out, !s)
+    end
 
   let apply_subst_ptr apply ~missing_var s { ptr; size; align; tag } =
     let ptr, s = apply ~missing_var s ptr in
@@ -183,6 +206,9 @@ module Rust_ext :
     | Tuple vs ->
         let vs, s = apply_list apply ~missing_var s vs in
         (Tuple vs, s)
+    | Array vs ->
+        let vs, s = apply_list apply ~missing_var s vs in
+        (Array vs, s)
     | Union vs ->
         let apply ~missing_var s (v, ofs, size) =
           let v, s = apply ~missing_var s v in

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -37,8 +37,8 @@ and 'ghost ext_t =
   | Ptr of 'ghost sv * 'ghost sv option  (** pointer, with optional meta *)
   | ThinPtr of 'ghost ptr
       (** thin pointer, without metadata but with extra info on the pointer *)
-  | Enum of 'ghost sv * 'ghost sv Iarray.t  (** discriminant * values *)
-  | Tuple of 'ghost sv Iarray.t  (** structs and tuples: ordered values *)
+  | Enum of 'ghost sv * 'ghost sv list  (** discriminant * values *)
+  | Tuple of 'ghost sv list  (** structs and tuples: ordered values *)
   | Array of 'ghost sv Iarray.t
       (** arrays: ordered values, all of the same type *)
   | Union of ('ghost sv * 'ghost sv * 'ghost sv) list
@@ -81,8 +81,8 @@ module Rust_ext :
           Fmt.(option ~none:(any "*") Ptr_tag.pp)
           ptr.tag
     | Enum (disc, vals) ->
-        Fmt.pf ft "Enum(%a: %a)" pp disc (Iarray.pp ~sep:(Fmt.any ", ") pp) vals
-    | Tuple vals -> Fmt.pf ft "(%a)" (Iarray.pp ~sep:(Fmt.any ", ") pp) vals
+        Fmt.pf ft "Enum(%a: %a)" pp disc (Fmt.list ~sep:(Fmt.any ", ") pp) vals
+    | Tuple vals -> Fmt.pf ft "(%a)" (Fmt.list ~sep:(Fmt.any ", ") pp) vals
     | Array vals -> Fmt.pf ft "[%a]" (Iarray.pp ~sep:(Fmt.any ", ") pp) vals
     | Union vs ->
         let pp_block ft (v, ofs, size) =
@@ -105,8 +105,9 @@ module Rust_ext :
     | ThinPtr ptr -> iter_vars_ptr iter_vars ptr
     | Enum (disc, vals) ->
         iter_vars disc;
-        Iarray.iter iter_vars vals
-    | Tuple vals | Array vals -> Iarray.iter iter_vars vals
+        List.iter iter_vars vals
+    | Tuple vals -> List.iter iter_vars vals
+    | Array vals -> Iarray.iter iter_vars vals
     | Union vs ->
         List.iter
           (fun (v, ofs, size) ->
@@ -138,11 +139,11 @@ module Rust_ext :
           (combine (combine (combine ptr.tag 3) size.tag) align.tag)
           (Option.fold ~none:(-1) ~some:Ptr_tag.hash tag)
     | Enum (disc, vals) ->
-        Iarray.fold_left
+        List.fold_left
           (fun acc (v : _ sv) -> combine acc v.tag)
           (combine disc.tag 4) vals
     | Tuple vals ->
-        Iarray.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 5 vals
+        List.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 5 vals
     | Array vals ->
         Iarray.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 8 vals
     | Union vs ->
@@ -202,10 +203,10 @@ module Rust_ext :
         (ThinPtr ptr, s)
     | Enum (discr, vs) ->
         let discr, s = apply ~missing_var s discr in
-        let vs, s = apply_iarray apply ~missing_var s vs in
+        let vs, s = apply_list apply ~missing_var s vs in
         (Enum (discr, vs), s)
     | Tuple vs ->
-        let vs, s = apply_iarray apply ~missing_var s vs in
+        let vs, s = apply_list apply ~missing_var s vs in
         (Tuple vs, s)
     | Array vs ->
         let vs, s = apply_iarray apply ~missing_var s vs in

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -114,11 +114,11 @@ module Rust_ext :
   (* Allocation-free structural hash *)
   let[@inline] combine h x = (h * 65599) + x
 
-  let hash_ty : 'ghost ty -> int = function
+  let rec hash_ty : 'ghost ty -> int = function
     | TEnum ty -> combine 0 (Hashtbl.hash ty)
     | TUnion ty -> combine 1 (Hashtbl.hash ty)
     | TTuple tys ->
-        List.fold_left (fun acc ty -> combine acc (Hashtbl.hash ty)) 2 tys
+        List.fold_left (fun acc ty -> combine acc (Sv.hash_ty hash_ty ty)) 2 tys
     | TThinPtr -> 3
     | TFullPtr -> 4
     | TPolyType -> 5

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -37,9 +37,10 @@ and 'ghost ext_t =
   | Ptr of 'ghost sv * 'ghost sv option  (** pointer, with optional meta *)
   | ThinPtr of 'ghost ptr
       (** thin pointer, without metadata but with extra info on the pointer *)
-  | Enum of 'ghost sv * 'ghost sv list  (** discriminant * values *)
-  | Tuple of 'ghost sv list  (** structs and tuples: ordered values *)
-  | Array of 'ghost sv list  (** arrays: ordered values, all of the same type *)
+  | Enum of 'ghost sv * 'ghost sv Iarray.t  (** discriminant * values *)
+  | Tuple of 'ghost sv Iarray.t  (** structs and tuples: ordered values *)
+  | Array of 'ghost sv Iarray.t
+      (** arrays: ordered values, all of the same type *)
   | Union of ('ghost sv * 'ghost sv * 'ghost sv) list
       (** list of blocks in the union, with their offset and size *)
   | PolyVal of Charon.Types.type_var_id
@@ -80,9 +81,9 @@ module Rust_ext :
           Fmt.(option ~none:(any "*") Ptr_tag.pp)
           ptr.tag
     | Enum (disc, vals) ->
-        Fmt.pf ft "Enum(%a: %a)" pp disc (Fmt.list ~sep:(Fmt.any ", ") pp) vals
-    | Tuple vals -> Fmt.pf ft "(%a)" (Fmt.list ~sep:(Fmt.any ", ") pp) vals
-    | Array vals -> Fmt.pf ft "[%a]" (Fmt.list ~sep:(Fmt.any ", ") pp) vals
+        Fmt.pf ft "Enum(%a: %a)" pp disc (Iarray.pp ~sep:(Fmt.any ", ") pp) vals
+    | Tuple vals -> Fmt.pf ft "(%a)" (Iarray.pp ~sep:(Fmt.any ", ") pp) vals
+    | Array vals -> Fmt.pf ft "[%a]" (Iarray.pp ~sep:(Fmt.any ", ") pp) vals
     | Union vs ->
         let pp_block ft (v, ofs, size) =
           Fmt.pf ft "(%a: %a-%a)" pp ofs pp v pp size
@@ -104,8 +105,8 @@ module Rust_ext :
     | ThinPtr ptr -> iter_vars_ptr iter_vars ptr
     | Enum (disc, vals) ->
         iter_vars disc;
-        List.iter iter_vars vals
-    | Tuple vals | Array vals -> List.iter iter_vars vals
+        Iarray.iter iter_vars vals
+    | Tuple vals | Array vals -> Iarray.iter iter_vars vals
     | Union vs ->
         List.iter
           (fun (v, ofs, size) ->
@@ -137,13 +138,13 @@ module Rust_ext :
           (combine (combine (combine ptr.tag 3) size.tag) align.tag)
           (Option.fold ~none:(-1) ~some:Ptr_tag.hash tag)
     | Enum (disc, vals) ->
-        List.fold_left
+        Iarray.fold_left
           (fun acc (v : _ sv) -> combine acc v.tag)
           (combine disc.tag 4) vals
     | Tuple vals ->
-        List.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 5 vals
+        Iarray.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 5 vals
     | Array vals ->
-        List.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 8 vals
+        Iarray.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 8 vals
     | Union vs ->
         List.fold_left
           (fun acc ((v : _ sv), (ofs : _ sv), (size : _ sv)) ->
@@ -201,13 +202,13 @@ module Rust_ext :
         (ThinPtr ptr, s)
     | Enum (discr, vs) ->
         let discr, s = apply ~missing_var s discr in
-        let vs, s = apply_list apply ~missing_var s vs in
+        let vs, s = apply_iarray apply ~missing_var s vs in
         (Enum (discr, vs), s)
     | Tuple vs ->
-        let vs, s = apply_list apply ~missing_var s vs in
+        let vs, s = apply_iarray apply ~missing_var s vs in
         (Tuple vs, s)
     | Array vs ->
-        let vs, s = apply_list apply ~missing_var s vs in
+        let vs, s = apply_iarray apply ~missing_var s vs in
         (Array vs, s)
     | Union vs ->
         let apply ~missing_var s (v, ofs, size) =

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -341,15 +341,21 @@ module Ptr = struct
 end
 
 module Adt = struct
-  let unit = Extension (Tuple []) <| t_tuple []
-  let mk_tuple vs = Extension (Tuple vs) <| t_tuple (List.map get_ty vs)
+  let unit = Extension (Tuple [||]) <| t_unit
 
-  let mk_array elem_ty vs =
-    let len = List.length vs in
-    let elem_ty = if len = 0 then ty_of_rust elem_ty else get_ty (List.hd vs) in
-    Extension (Array vs) <| t_array elem_ty (Z.of_int len)
+  let mk_tuple vs =
+    let tuple_ty = t_tuple @@ List.map get_ty vs in
+    let vs = Iarray.of_list vs in
+    Extension (Tuple vs) <| tuple_ty
 
-  let mk_enum adt discr vs = Extension (Enum (discr, vs)) <| t_enum adt
+  let mk_array elem_ty arr =
+    let len = Iarray.length arr in
+    let elem_ty = if len = 0 then ty_of_rust elem_ty else get_ty arr.%(0) in
+    Extension (Array arr) <| t_array elem_ty (Z.of_int len)
+
+  let mk_enum adt discr vs =
+    Extension (Enum (discr, Iarray.of_list vs)) <| t_enum adt
+
   let mk_union adt blocks = Extension (Union blocks) <| t_union adt
   let mk_poly ty_id = Extension (PolyVal ty_id) <| t_poly ()
 
@@ -379,16 +385,18 @@ module Adt = struct
     | _ -> todo_migration "as_enum_of_variant unop"
 
   let as_tuple1 v =
-    match as_tuple v with [ a ] -> a | _ -> cast_error v (t_tuple [ t_int 1 ])
+    match as_tuple v with
+    | [| a |] -> a
+    | _ -> cast_error v (t_tuple [ t_int 1 ])
 
   let as_tuple2 v =
     match as_tuple v with
-    | [ a; b ] -> (a, b)
+    | [| a; b |] -> (a, b)
     | _ -> cast_error v (t_tuple [ t_int 2 ])
 
   let as_tuple3 v =
     match as_tuple v with
-    | [ a; b; c ] -> (a, b, c)
+    | [| a; b; c |] -> (a, b, c)
     | _ -> cast_error v (t_tuple [ t_int 3 ])
 
   let as_type_var v =
@@ -404,7 +412,7 @@ module Adt = struct
   let field_of idx v =
     match kind v with
     | Extension (Tuple vs) -> (
-        try List.nth vs idx
+        try vs.%(idx)
         with Invalid_argument _ ->
           L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "field_of op"
@@ -412,7 +420,7 @@ module Adt = struct
   let array_field_of idx v =
     match kind v with
     | Extension (Array vs) -> (
-        try List.nth vs idx
+        try vs.%(idx)
         with Invalid_argument _ ->
           L.failwith "Array index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "array_field_of op"
@@ -421,7 +429,7 @@ module Adt = struct
     (* TODO: assert the variant? *)
     match kind v with
     | Extension (Enum (_, vs)) -> (
-        try List.nth vs idx
+        try vs.%(idx)
         with Invalid_argument _ ->
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "field_of_variant op"
@@ -429,7 +437,7 @@ module Adt = struct
   let set_field idx f v =
     match kind v with
     | Extension (Tuple vs) -> (
-        try Extension (Tuple (List.set_nth idx f vs)) <| v.node.ty
+        try Extension (Tuple (Iarray.copy_and_set idx f vs)) <| v.node.ty
         with Invalid_argument _ ->
           L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_field op"
@@ -438,7 +446,7 @@ module Adt = struct
     (* TODO: assert the variant *)
     match kind v with
     | Extension (Enum (discr, vs)) -> (
-        try Extension (Enum (discr, List.set_nth idx f vs)) <| v.node.ty
+        try Extension (Enum (discr, Iarray.copy_and_set idx f vs)) <| v.node.ty
         with Invalid_argument _ ->
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_field_of_variant op"
@@ -446,7 +454,7 @@ module Adt = struct
   let set_array_field idx x v =
     match kind v with
     | Extension (Array vs) -> (
-        try Extension (Array (List.set_nth idx x vs)) <| v.node.ty
+        try Extension (Array (Iarray.copy_and_set idx x vs)) <| v.node.ty
         with Invalid_argument _ ->
           L.failwith "Array index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_array_field op"

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -341,21 +341,15 @@ module Ptr = struct
 end
 
 module Adt = struct
-  let unit = Extension (Tuple [||]) <| t_unit
-
-  let mk_tuple vs =
-    let tuple_ty = t_tuple @@ List.map get_ty vs in
-    let vs = Iarray.of_list vs in
-    Extension (Tuple vs) <| tuple_ty
+  let unit = Extension (Tuple []) <| t_tuple []
+  let mk_tuple vs = Extension (Tuple vs) <| t_tuple (List.map get_ty vs)
 
   let mk_array elem_ty arr =
     let len = Iarray.length arr in
     let elem_ty = if len = 0 then ty_of_rust elem_ty else get_ty arr.%(0) in
     Extension (Array arr) <| t_array elem_ty (Z.of_int len)
 
-  let mk_enum adt discr vs =
-    Extension (Enum (discr, Iarray.of_list vs)) <| t_enum adt
-
+  let mk_enum adt discr vs = Extension (Enum (discr, vs)) <| t_enum adt
   let mk_union adt blocks = Extension (Union blocks) <| t_union adt
   let mk_poly ty_id = Extension (PolyVal ty_id) <| t_poly ()
 
@@ -385,18 +379,16 @@ module Adt = struct
     | _ -> todo_migration "as_enum_of_variant unop"
 
   let as_tuple1 v =
-    match as_tuple v with
-    | [| a |] -> a
-    | _ -> cast_error v (t_tuple [ t_int 1 ])
+    match as_tuple v with [ a ] -> a | _ -> cast_error v (t_tuple [ t_int 1 ])
 
   let as_tuple2 v =
     match as_tuple v with
-    | [| a; b |] -> (a, b)
+    | [ a; b ] -> (a, b)
     | _ -> cast_error v (t_tuple [ t_int 2 ])
 
   let as_tuple3 v =
     match as_tuple v with
-    | [| a; b; c |] -> (a, b, c)
+    | [ a; b; c ] -> (a, b, c)
     | _ -> cast_error v (t_tuple [ t_int 3 ])
 
   let as_type_var v =
@@ -412,7 +404,7 @@ module Adt = struct
   let field_of idx v =
     match kind v with
     | Extension (Tuple vs) -> (
-        try vs.%(idx)
+        try List.nth vs idx
         with Invalid_argument _ ->
           L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "field_of op"
@@ -429,7 +421,7 @@ module Adt = struct
     (* TODO: assert the variant? *)
     match kind v with
     | Extension (Enum (_, vs)) -> (
-        try vs.%(idx)
+        try List.nth vs idx
         with Invalid_argument _ ->
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "field_of_variant op"
@@ -437,7 +429,7 @@ module Adt = struct
   let set_field idx f v =
     match kind v with
     | Extension (Tuple vs) -> (
-        try Extension (Tuple (Iarray.copy_and_set idx f vs)) <| v.node.ty
+        try Extension (Tuple (List.set_nth idx f vs)) <| v.node.ty
         with Invalid_argument _ ->
           L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_field op"
@@ -446,7 +438,7 @@ module Adt = struct
     (* TODO: assert the variant *)
     match kind v with
     | Extension (Enum (discr, vs)) -> (
-        try Extension (Enum (discr, Iarray.copy_and_set idx f vs)) <| v.node.ty
+        try Extension (Enum (discr, List.set_nth idx f vs)) <| v.node.ty
         with Invalid_argument _ ->
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_field_of_variant op"

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -1,3 +1,4 @@
+open Iarray.Infix
 open Charon
 open Common.Charon_util
 open Soteria.Bv_values.Svalue
@@ -55,13 +56,6 @@ let float_precision :
   | F64 -> F64
   | F128 -> F128
 
-type ptr = {
-  ptr : T.sptr t;
-  size : T.sint t;
-  align : T.nonzero t;
-  tag : Ptr_tag.t option;
-}
-
 (* The raw pointer type; only used to materialise a fully-symbolic nondet
    pointer in [Value_codec] (see {!Ptr.of_raw}). *)
 let t_ptr () = t_ptr (8 * size_of_uint_ty Usize)
@@ -77,7 +71,9 @@ let t_lit : Types.literal_type -> [> T.sint ] ty = function
 let t_float (ty : Types.float_type) : [< T.sfloat ] ty =
   t_float (float_precision ty)
 
+let t_unit : [> T.tuple ] ty = TExtension (TTuple [])
 let t_tuple tys : [> T.tuple ] ty = TExtension (TTuple tys)
+let t_array ty n : [> T.tuple ] ty = TExtension (TArray (ty, n))
 
 let t_enum adt : [> T.enum ] ty =
   assert (Common.Charon_util.tyref_is_substituted adt);
@@ -88,6 +84,29 @@ let t_union adt : [> T.union ] ty =
   TExtension (TUnion adt)
 
 let t_poly () : [> T.poly ] ty = TExtension TPolyType
+
+let rec ty_of_rust : Types.ty -> _ ty = function
+  | TLiteral (TFloat ft) -> t_float ft
+  | TLiteral lit -> t_lit lit
+  | TRef _ | TRawPtr _ | TFnPtr _ -> t_ptr_f ()
+  | TNever | TFnDef _ -> t_unit
+  | TVar _ -> t_poly ()
+  | TPattern (ty, _) -> ty_of_rust ty
+  | TArray (ty, n) -> t_array (ty_of_rust ty) (z_of_constant_expr n)
+  | TAdt { id = TTuple; generics = { types; _ } } ->
+      t_tuple (List.map ty_of_rust types)
+  | TAdt ({ id = TAdtId _; _ } as adt) -> (
+      match (Crate.get_adt adt).kind with
+      | Struct fs ->
+          t_tuple (List.map (fun (f : Types.field) -> ty_of_rust f.field_ty) fs)
+      | Enum _ -> t_enum adt
+      | Union _ -> t_union adt
+      | kind ->
+          L.failwith "ty_of_rust unexpected adt kind %a" Types.pp_type_decl_kind
+            kind)
+  | ( TError _ | TPtrMetadata _ | TTraitType _ | TDynTrait _ | TSlice _
+    | TAdt { id = TBuiltin _; _ } ) as ty ->
+      L.failwith "ty_of_rust unexpected type %a" Common.Charon_util.pp_ty ty
 
 let cast_checked ~ty v =
   match cast_checked v ty with Some v -> v | None -> cast_error v ty
@@ -112,6 +131,11 @@ let cast_tuple v =
   match get_ty v with
   | TExtension (TTuple _) -> v
   | _ -> cast_error v (t_tuple [])
+
+let cast_array v =
+  match get_ty v with
+  | TExtension (TArray _) -> v
+  | _ -> cast_error v (t_array (t_int 1) Z.zero)
 
 (* The [adt] ref, when given, additionally checks the value is that precise
    enum/union; callers that only know the kind (e.g. the generic store
@@ -319,6 +343,12 @@ end
 module Adt = struct
   let unit = Extension (Tuple []) <| t_tuple []
   let mk_tuple vs = Extension (Tuple vs) <| t_tuple (List.map get_ty vs)
+
+  let mk_array elem_ty vs =
+    let len = List.length vs in
+    let elem_ty = if len = 0 then ty_of_rust elem_ty else get_ty (List.hd vs) in
+    Extension (Array vs) <| t_array elem_ty (Z.of_int len)
+
   let mk_enum adt discr vs = Extension (Enum (discr, vs)) <| t_enum adt
   let mk_union adt blocks = Extension (Union blocks) <| t_union adt
   let mk_poly ty_id = Extension (PolyVal ty_id) <| t_poly ()
@@ -338,7 +368,12 @@ module Adt = struct
     | Extension (Tuple vs) -> vs
     | _ -> todo_migration "as_tuple unop"
 
-  let as_enum_of_variant var_id v =
+  let as_array v =
+    match kind v with
+    | Extension (Array vs) -> vs
+    | _ -> todo_migration "as_array unop"
+
+  let as_enum_of_variant _var_id v =
     match kind v with
     | Extension (Enum (_, vs)) -> vs
     | _ -> todo_migration "as_enum_of_variant unop"
@@ -370,16 +405,24 @@ module Adt = struct
     match kind v with
     | Extension (Tuple vs) -> (
         try List.nth vs idx
-        with Failure _ ->
+        with Invalid_argument _ ->
           L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "field_of op"
+
+  let array_field_of idx v =
+    match kind v with
+    | Extension (Array vs) -> (
+        try List.nth vs idx
+        with Invalid_argument _ ->
+          L.failwith "Array index %d out of bounds for value %a" idx ppa v)
+    | _ -> todo_migration "array_field_of op"
 
   let field_of_variant _var_id idx v =
     (* TODO: assert the variant? *)
     match kind v with
     | Extension (Enum (_, vs)) -> (
         try List.nth vs idx
-        with Failure _ ->
+        with Invalid_argument _ ->
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "field_of_variant op"
 
@@ -387,7 +430,7 @@ module Adt = struct
     match kind v with
     | Extension (Tuple vs) -> (
         try Extension (Tuple (List.set_nth idx f vs)) <| v.node.ty
-        with Failure _ ->
+        with Invalid_argument _ ->
           L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_field op"
 
@@ -396,11 +439,22 @@ module Adt = struct
     match kind v with
     | Extension (Enum (discr, vs)) -> (
         try Extension (Enum (discr, List.set_nth idx f vs)) <| v.node.ty
-        with Failure _ ->
+        with Invalid_argument _ ->
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_field_of_variant op"
 
+  let set_array_field idx x v =
+    match kind v with
+    | Extension (Array vs) -> (
+        try Extension (Array (List.set_nth idx x vs)) <| v.node.ty
+        with Invalid_argument _ ->
+          L.failwith "Array index %d out of bounds for value %a" idx ppa v)
+    | _ -> todo_migration "set_array_field op"
+
   let update_field idx f v = set_field idx (f (field_of idx v)) v
+
+  let update_array_field idx f v =
+    set_array_field idx (f (array_field_of idx v)) v
 
   let update_field_of_variant var idx f v =
     set_field_of_variant var idx (f (field_of_variant var idx v)) v

--- a/soteria-rust/lib/svalue/typed.mli
+++ b/soteria-rust/lib/svalue/typed.mli
@@ -171,7 +171,7 @@ module Adt : sig
   val mk_tuple : [< T.any ] t list -> [> T.tuple ] t
 
   (** Creates an array value with the given element type and elements. *)
-  val mk_array : Types.ty -> [< T.any ] t list -> [> T.tuple ] t
+  val mk_array : Types.ty -> [< T.any ] t iarray -> [> T.tuple ] t
 
   (** Creates an enum value with the given discriminant and fields. *)
   val mk_enum :
@@ -194,11 +194,11 @@ module Adt : sig
   val as_union :
     [< T.union ] t -> ([> T.any ] t * [> T.sint ] t * [> T.nonzero ] t) list
 
-  val as_tuple : [< T.tuple ] t -> [> T.any ] t list
-  val as_array : [< T.tuple ] t -> [> T.any ] t list
+  val as_tuple : [< T.tuple ] t -> [> T.any ] t iarray
+  val as_array : [< T.tuple ] t -> [> T.any ] t iarray
 
   val as_enum_of_variant :
-    Types.variant_id -> [< T.enum ] t -> [> T.any ] t list
+    Types.variant_id -> [< T.enum ] t -> [> T.any ] t iarray
 
   (** Like {!as_tuple}, but casts to a fixed-arity tuple, failing if the tuple
       does not have exactly that many fields. Avoids partial list pattern

--- a/soteria-rust/lib/svalue/typed.mli
+++ b/soteria-rust/lib/svalue/typed.mli
@@ -194,11 +194,11 @@ module Adt : sig
   val as_union :
     [< T.union ] t -> ([> T.any ] t * [> T.sint ] t * [> T.nonzero ] t) list
 
-  val as_tuple : [< T.tuple ] t -> [> T.any ] t iarray
+  val as_tuple : [< T.tuple ] t -> [> T.any ] t list
   val as_array : [< T.tuple ] t -> [> T.any ] t iarray
 
   val as_enum_of_variant :
-    Types.variant_id -> [< T.enum ] t -> [> T.any ] t iarray
+    Types.variant_id -> [< T.enum ] t -> [> T.any ] t list
 
   (** Like {!as_tuple}, but casts to a fixed-arity tuple, failing if the tuple
       does not have exactly that many fields. Avoids partial list pattern

--- a/soteria-rust/lib/svalue/typed.mli
+++ b/soteria-rust/lib/svalue/typed.mli
@@ -57,6 +57,7 @@ val cast_lit : Types.literal_type -> _ t -> [> T.sint ] t
 val cast_ptr_f : _ t -> [< T.sptr_f ] t
 val cast_ptr_t : _ t -> [< T.sptr_t ] t
 val cast_tuple : _ t -> [> T.tuple ] t
+val cast_array : _ t -> [> T.tuple ] t
 val cast_enum : ?adt:Types.type_decl_ref -> _ t -> [> T.enum ] t
 val cast_union : ?adt:Types.type_decl_ref -> _ t -> [> T.union ] t
 
@@ -169,6 +170,9 @@ module Adt : sig
       or tuple. *)
   val mk_tuple : [< T.any ] t list -> [> T.tuple ] t
 
+  (** Creates an array value with the given element type and elements. *)
+  val mk_array : Types.ty -> [< T.any ] t list -> [> T.tuple ] t
+
   (** Creates an enum value with the given discriminant and fields. *)
   val mk_enum :
     Types.type_decl_ref -> [< T.sint ] t -> [< T.any ] t list -> [> T.enum ] t
@@ -191,6 +195,7 @@ module Adt : sig
     [< T.union ] t -> ([> T.any ] t * [> T.sint ] t * [> T.nonzero ] t) list
 
   val as_tuple : [< T.tuple ] t -> [> T.any ] t list
+  val as_array : [< T.tuple ] t -> [> T.any ] t list
 
   val as_enum_of_variant :
     Types.variant_id -> [< T.enum ] t -> [> T.any ] t list
@@ -205,10 +210,13 @@ module Adt : sig
   val as_type_var : [< T.poly ] t -> Types.type_var_id
   val discriminant_of : [< T.enum ] t -> [> T.sint ] t
 
-  (* Field access is split by kind: tuples/structs/arrays and enum variants
-     store their fields differently (an enum also keeps its discriminant). *)
+  (** Get the field of a tuple *)
   val field_of : int -> [< T.tuple ] t -> [> T.any ] t
 
+  (** Get the field of an array *)
+  val array_field_of : int -> [< T.tuple ] t -> [> T.any ] t
+
+  (** Get the field of a enum with the given variant *)
   val field_of_variant :
     Types.variant_id -> int -> [< T.enum ] t -> [> T.any ] t
 
@@ -218,6 +226,11 @@ module Adt : sig
     Types.variant_id -> int -> [< T.any ] t -> [< T.enum ] t -> [> T.enum ] t
 
   val update_field :
+    int -> ([< T.any ] t -> [> T.any ] t) -> [< T.tuple ] t -> [> T.tuple ] t
+
+  val set_array_field : int -> [< T.any ] t -> [< T.tuple ] t -> [> T.tuple ] t
+
+  val update_array_field :
     int -> ([< T.any ] t -> [> T.any ] t) -> [< T.tuple ] t -> [> T.tuple ] t
 
   val update_field_of_variant :

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -329,7 +329,7 @@ struct
         Typed.Ptr.mk_ptr_f ptr (Some meta)
     | Array { is_ptr = false; _ }, _ ->
         let+ vs = iter (iter_fields ?meta layout ty) offset in
-        Typed.Adt.mk_tuple vs
+        Typed.Adt.mk_array (index_ty ty) vs
     | Arbitrary _, _ ->
         let+ fields = iter (iter_fields ?meta layout ty) offset in
         Typed.Adt.mk_tuple fields
@@ -378,7 +378,7 @@ let rec encode ~offset (value : Typed.(T.any t)) (ty : Types.ty) :
           let fields = Typed.Adt.as_tuple (Typed.cast_tuple value) in
           chain fields (iter_fields layout ty)
     | Array { is_ptr = false; _ } ->
-        let fields = Typed.Adt.as_tuple (Typed.cast_tuple value) in
+        let fields = Typed.Adt.as_array (Typed.cast_array value) in
         chain fields (iter_fields layout ty)
     | Array { is_ptr = true; _ } ->
         let ptr, meta = Typed.Ptr.split (Typed.cast_ptr_f value) in
@@ -540,8 +540,8 @@ let rec validity ?(check_ref = fun _ _ -> Rustsymex.Result.ok ()) ty v f =
       |> Iter.mapi (fun i ty -> (ty, Typed.Adt.field_of i v))
       |> iter_iter ~f:(fun (ty, v) -> validity ~check_ref ty v f)
   | TArray (ty, _) | TSlice ty ->
-      let vs = Typed.Adt.as_tuple (Typed.cast_tuple v) in
-      iter_list vs ~f:(fun v -> validity ~check_ref ty v f)
+      Typed.Adt.as_array (Typed.cast_array v)
+      |> iter_list ~f:(fun v -> validity ~check_ref ty v f)
   (* undefined.validity.union *)
   | TAdt adt when Crate.is_union adt -> ok ()
   (* fndefs are ZSTs *)
@@ -698,7 +698,7 @@ let rec nondet_raw :
   | TArray (ty, len) ->
       let size = int_of_constant_expr len in
       let++ fields = nondets_raw @@ List.init size (fun _ -> ty) in
-      Typed.Adt.mk_tuple fields
+      Typed.Adt.mk_array ty fields
   | TAdt adt as ty -> (
       let type_decl = Crate.get_adt adt in
       match type_decl.kind with
@@ -802,9 +802,9 @@ let rec ref_tys_in
       in
       (Typed.Adt.mk_tuple vs, acc)
   | TArray (ty, _) | TSlice ty ->
-      let v = Typed.cast_tuple v in
-      let++ vs, acc = fs init ty (Typed.Adt.as_tuple v) in
-      (Typed.Adt.mk_tuple vs, acc)
+      let v = Typed.cast_array v in
+      let++ vs, acc = fs init ty (Typed.Adt.as_array v) in
+      (Typed.Adt.mk_array ty vs, acc)
   | TAdt adt when Crate.is_enum adt ->
       let v = Typed.cast_enum ~adt v in
       let discr = Typed.Adt.discriminant_of v in
@@ -831,9 +831,6 @@ let rec size_and_align_of_val ~load_vtable ~t
     match t with
     | TSlice _ | TAdt { id = TBuiltin TStr; _ } ->
         let sub_ty = Layout.dst_slice_ty t in
-        let* sub_ty =
-          of_opt_not_impl "size_of_val: missing a DST slice type" sub_ty
-        in
         let** layout = Layout.layout_of sub_ty in
         let meta = Option.get ~msg:"size_of_val: missing slice meta" meta in
         let len = Typed.cast_i Usize meta in

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -352,9 +352,9 @@ let rec encode ~offset (value : Typed.(T.any t)) (ty : Types.ty) :
   let open Rustsymex in
   let open Syntax in
   let open Result in
-  let chain fields iter =
+  let chain combine fields iter =
     fields
-    |> Iter.combine_iarray iter
+    |> combine iter
     |> Result.fold_iter ~init:Iter.empty ~f:(fun acc ((ty, ofs), v) ->
         let offset = offset +!!@ ofs in
         let++ ys = encode ~offset v ty in
@@ -376,10 +376,10 @@ let rec encode ~offset (value : Typed.(T.any t)) (ty : Types.ty) :
             |> Iter.map (fun (v, o, s) -> (v, offset +!!@ o, s)))
         else
           let fields = Typed.Adt.as_tuple (Typed.cast_tuple value) in
-          chain fields (iter_fields layout ty)
+          chain Iter.combine_list fields (iter_fields layout ty)
     | Array { is_ptr = false; _ } ->
         let fields = Typed.Adt.as_array (Typed.cast_array value) in
-        chain fields (iter_fields layout ty)
+        chain Iter.combine_iarray fields (iter_fields layout ty)
     | Array { is_ptr = true; _ } ->
         let ptr, meta = Typed.Ptr.split (Typed.cast_ptr_f value) in
         let ptr = Typed.Ptr.mk_ptr_f ptr None in
@@ -390,7 +390,7 @@ let rec encode ~offset (value : Typed.(T.any t)) (ty : Types.ty) :
           | TExtension TThinPtr -> Typed.Ptr.mk_ptr_f meta None
           | _ -> L.failwith "invalid meta"
         in
-        chain (Iarray.of_list [ ptr; meta ]) (iter_fields layout ty)
+        chain Iter.combine_list [ ptr; meta ] (iter_fields layout ty)
     | Enum (_, layouts) -> (
         let adt = ty_as_adt ty in
         let value = Typed.cast_enum ~adt value in
@@ -398,7 +398,9 @@ let rec encode ~offset (value : Typed.(T.any t)) (ty : Types.ty) :
         let* variant = variant_for_discr discr adt in
         let variant = variant.id in
         let fields = Typed.Adt.as_enum_of_variant variant value in
-        let++ fields = chain fields (iter_fields ~variant layout ty) in
+        let++ fields =
+          chain Iter.combine_list fields (iter_fields ~variant layout ty)
+        in
         match fst layouts.(Types.VariantId.to_int variant) with
         | None -> fields
         | Some (ofs, tag) ->
@@ -780,7 +782,7 @@ let rec ref_tys_in
   in
   let fs' acc tys vs =
     let++ vs, acc =
-      Iter.combine_iarray (Iter.of_list tys) vs
+      Iter.of_list_combine tys vs
       |> Result.fold_iter ~init:([], acc) ~f:(fun (vs, acc) (v, ty) ->
           let++ v, acc = f acc v ty in
           (v :: vs, acc))

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -329,7 +329,7 @@ struct
         Typed.Ptr.mk_ptr_f ptr (Some meta)
     | Array { is_ptr = false; _ }, _ ->
         let+ vs = iter (iter_fields ?meta layout ty) offset in
-        Typed.Adt.mk_array (index_ty ty) vs
+        Typed.Adt.mk_array (index_ty ty) (Iarray.of_list vs)
     | Arbitrary _, _ ->
         let+ fields = iter (iter_fields ?meta layout ty) offset in
         Typed.Adt.mk_tuple fields
@@ -354,7 +354,7 @@ let rec encode ~offset (value : Typed.(T.any t)) (ty : Types.ty) :
   let open Result in
   let chain fields iter =
     fields
-    |> Iter.combine_list iter
+    |> Iter.combine_iarray iter
     |> Result.fold_iter ~init:Iter.empty ~f:(fun acc ((ty, ofs), v) ->
         let offset = offset +!!@ ofs in
         let++ ys = encode ~offset v ty in
@@ -390,7 +390,7 @@ let rec encode ~offset (value : Typed.(T.any t)) (ty : Types.ty) :
           | TExtension TThinPtr -> Typed.Ptr.mk_ptr_f meta None
           | _ -> L.failwith "invalid meta"
         in
-        chain [ ptr; meta ] (iter_fields layout ty)
+        chain (Iarray.of_list [ ptr; meta ]) (iter_fields layout ty)
     | Enum (_, layouts) -> (
         let adt = ty_as_adt ty in
         let value = Typed.cast_enum ~adt value in
@@ -541,7 +541,7 @@ let rec validity ?(check_ref = fun _ _ -> Rustsymex.Result.ok ()) ty v f =
       |> iter_iter ~f:(fun (ty, v) -> validity ~check_ref ty v f)
   | TArray (ty, _) | TSlice ty ->
       Typed.Adt.as_array (Typed.cast_array v)
-      |> iter_list ~f:(fun v -> validity ~check_ref ty v f)
+      |> iter (module Iarray) ~f:(fun v -> validity ~check_ref ty v f)
   (* undefined.validity.union *)
   | TAdt adt when Crate.is_union adt -> ok ()
   (* fndefs are ZSTs *)
@@ -698,7 +698,7 @@ let rec nondet_raw :
   | TArray (ty, len) ->
       let size = int_of_constant_expr len in
       let++ fields = nondets_raw @@ List.init size (fun _ -> ty) in
-      Typed.Adt.mk_array ty fields
+      Typed.Adt.mk_array ty (Iarray.of_list fields)
   | TAdt adt as ty -> (
       let type_decl = Crate.get_adt adt in
       match type_decl.kind with
@@ -769,7 +769,10 @@ let rec ref_tys_in
   let f = ref_tys_in fn in
   let fs acc ty vs =
     let++ vs, acc =
-      Result.fold_list vs ~init:([], acc) ~f:(fun (vs, acc) v ->
+      Result.fold
+        (module Iarray)
+        vs ~init:([], acc)
+        ~f:(fun (vs, acc) v ->
           let++ v, acc = f acc ty v in
           (v :: vs, acc))
     in
@@ -777,7 +780,7 @@ let rec ref_tys_in
   in
   let fs' acc tys vs =
     let++ vs, acc =
-      Iter.of_list_combine tys vs
+      Iter.combine_iarray (Iter.of_list tys) vs
       |> Result.fold_iter ~init:([], acc) ~f:(fun (vs, acc) (v, ty) ->
           let++ v, acc = f acc v ty in
           (v :: vs, acc))
@@ -804,7 +807,7 @@ let rec ref_tys_in
   | TArray (ty, _) | TSlice ty ->
       let v = Typed.cast_array v in
       let++ vs, acc = fs init ty (Typed.Adt.as_array v) in
-      (Typed.Adt.mk_array ty vs, acc)
+      (Typed.Adt.mk_array ty (Iarray.of_list vs), acc)
   | TAdt adt when Crate.is_enum adt ->
       let v = Typed.cast_enum ~adt v in
       let discr = Typed.Adt.discriminant_of v in

--- a/soteria/lib/bv_values/svalue.ml
+++ b/soteria/lib/bv_values/svalue.ml
@@ -203,6 +203,17 @@ type 'ty ty =
   | TExtension of 'ty
 [@@deriving eq, show { with_path = false }, ord]
 
+let[@inline] hash_combine h x = (h * 65599) + x
+
+let rec hash_ty hash_ext = function
+  | TBool -> 1
+  | TFloat p -> hash_combine 2 (FloatPrecision.size p)
+  | TLoc n -> hash_combine 3 n
+  | TPointer n -> hash_combine 4 n
+  | TSeq ty -> hash_combine 5 (hash_ty hash_ext ty)
+  | TBitVector n -> hash_combine 6 n
+  | TExtension e -> hash_combine 7 (hash_ext e)
+
 let pp_hash_consed pp_node ft t = pp_node ft t.node
 let equal_hash_consed _ t1 t2 = Int.equal t1.tag t2.tag
 let compare_hash_consed _ t1 t2 = Int.compare t1.tag t2.tag
@@ -472,18 +483,8 @@ module Make (V : Value_ext) () = struct
     type t = t_node
 
     let equal = equal_t_node
-
-    (* Allocation-free structural hash *)
-    let[@inline] combine h x = (h * 65599) + x
-
-    let rec hash_ty = function
-      | TBool -> 1
-      | TFloat p -> combine 2 (FloatPrecision.size p)
-      | TLoc n -> combine 3 n
-      | TPointer n -> combine 4 n
-      | TSeq ty -> combine 5 (hash_ty ty)
-      | TBitVector n -> combine 6 n
-      | TExtension e -> combine 7 (V.hash_ty e)
+    let combine = hash_combine
+    let hash_ty ty = hash_ty V.hash_ty ty
 
     let hash { kind; ty } =
       let h = hash_ty ty in

--- a/soteria/lib/soteria_std/compo_res.ml
+++ b/soteria/lib/soteria_std/compo_res.ml
@@ -147,13 +147,15 @@ module type S = sig
   val iter_iter :
     'elem Iter.t -> f:('elem -> (unit, 'b, 'c) t) -> (unit, 'b, 'c) t
 
+  val map_m :
+    (module M : Sigs.Foldable) ->
+    'elem M.t -> f:('elem -> ('a, 'b, 'c) t) -> ('a list, 'b, 'c) t
+
   val map_list :
     'elem list -> f:('elem -> ('a, 'b, 'c) t) -> ('a list, 'b, 'c) t
 
   val map_iter :
     'elem Iter.t -> f:('elem -> ('a, 'b, 'c) t) -> ('a list, 'b, 'c) t
-
-  val all : ('a -> ('b, 'c, 'd) t) -> 'a list -> ('b list, 'c, 'd) t
 end
 
 (** {2 Functors} *)
@@ -174,13 +176,11 @@ module Extend (M : Base) :
   let[@inline] iter_list xs ~f = iter (module List) xs ~f
   let[@inline] iter_iter xs ~f = iter (module Iter) xs ~f
 
-  let[@inline] map_list xs ~f =
-    Monad.mapM (module List) ~return:ok ~bind ~map ~f xs
+  let[@inline] map_m (module M : Sigs.Foldable) xs ~f =
+    Monad.mapM (module M) ~return:ok ~bind ~map ~f xs
 
-  let[@inline] map_iter xs ~f =
-    Monad.mapM (module Iter) ~return:ok ~bind ~map ~f xs
-
-  let[@inline] all f xs = Monad.all ~return:ok ~bind f xs
+  let[@inline] map_list xs ~f = map_m (module List) ~f xs
+  let[@inline] map_iter xs ~f = map_m (module Iter) ~f xs
 end
 
 module Make_syntax (M : Base) :

--- a/soteria/lib/soteria_std/dynarray.ml
+++ b/soteria/lib/soteria_std/dynarray.ml
@@ -17,6 +17,6 @@ let to_yojson (elem_to_yojson : 'a -> Yojson.Safe.t) t =
 let of_yojson (elem_of_yojson : Yojson.Safe.t -> ('a, string) Result.t) :
     Yojson.Safe.t -> ('a t, string) Result.t = function
   | `List l ->
-      let l = Monad.ResultM.all elem_of_yojson l in
+      let l = Monad.ResultM.map_list ~f:elem_of_yojson l in
       Result.map of_list l
   | _ -> Error "Expected a list for Dynarray.of_yojson"

--- a/soteria/lib/soteria_std/iarray.ml
+++ b/soteria/lib/soteria_std/iarray.ml
@@ -3,3 +3,16 @@ include Stdlib.Iarray
 module Infix = struct
   let ( .%() ) = get
 end
+
+(* copied from stdlib, unsafe! *)
+external unsafe_of_array : 'a array -> 'a iarray = "%opaque"
+
+let fold = fold_left
+
+let copy_and_update f vs =
+  let vs = to_array vs in
+  f vs;
+  unsafe_of_array vs
+
+let copy_and_set idx x vs = copy_and_update (fun vs -> vs.(idx) <- x) vs
+let pp ?sep pp_elt = Fmt.iter ?sep iter pp_elt

--- a/soteria/lib/soteria_std/iarray.mli
+++ b/soteria/lib/soteria_std/iarray.mli
@@ -1,0 +1,29 @@
+include module type of Stdlib.Iarray
+
+(** Equivalent to {!fold_left}; we re-export is as [fold] for compatibility with
+    {!Sigs.Foldable}. *)
+val fold : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+
+(** Creates a copy of this array, with the given function applied to a mutable
+    copy of the underlying array, before making it immutable.
+
+    This is more efficient than {!mapi}, as only the strictly necessary work is
+    performed by [f], rather than an entire iteration. It is also more
+    performant than a {!to_array} + {!of_array} roundtrip, as it only copies the
+    array once. *)
+val copy_and_update : ('a array -> unit) -> 'a t -> 'a t
+
+(** Creates a copy of this array, with the given index set to the given value.
+*)
+val copy_and_set : int -> 'a -> 'a t -> 'a t
+
+val pp :
+  ?sep:(Format.formatter -> unit -> unit) ->
+  (Format.formatter -> 'a -> unit) ->
+  Format.formatter ->
+  'a t ->
+  unit
+
+module Infix : sig
+  val ( .%() ) : 'a t -> int -> 'a
+end

--- a/soteria/lib/soteria_std/iter_soteria.ml
+++ b/soteria/lib/soteria_std/iter_soteria.ml
@@ -36,6 +36,32 @@ let[@inline] combine_list (i : 'a t) (l : 'b list) k =
           l := b;
           k (x, a))
 
+(** Iterates over the elements of an immutable array. *)
+let[@inline] of_iarray a k = Iarray.iter k a
+
+(** Iterates over the elements of two immutable arrays in parallel.
+
+    @raise Invalid_argument if the arrays are not of the same length. *)
+let[@inline] of_iarray2 a1 a2 k =
+  let n = Iarray.length a1 in
+  if n <> Iarray.length a2 then invalid_arg "Iter.of_iarray2";
+  for i = 0 to n - 1 do
+    k (Iarray.unsafe_get a1 i, Iarray.unsafe_get a2 i)
+  done
+
+(** Like {!combine_list}, but combines the iterator [i] with an immutable array
+    [a] element-wise.
+
+    @raise Invalid_argument if [a] is smaller than [i]. *)
+let[@inline] combine_iarray (i : 'a t) (a : 'b Iarray.t) k =
+  let n = Iarray.length a in
+  let idx = ref 0 in
+  i (fun x ->
+      if !idx >= n then invalid_arg "Iter.combine_iarray";
+      let v = Iarray.unsafe_get a !idx in
+      incr idx;
+      k (x, v))
+
 let[@inline] repeati n x k =
   let i = ref 0 in
   while !i < n do

--- a/soteria/lib/soteria_std/monad.ml
+++ b/soteria/lib/soteria_std/monad.ml
@@ -38,9 +38,12 @@ module type Extension = sig
 
   val iter_list : 'elem list -> f:('elem -> unit t) -> unit t
   val iter_iter : 'elem Iter.t -> f:('elem -> unit t) -> unit t
+
+  val map_m :
+    (module M : Sigs.Foldable) -> 'elem M.t -> f:('elem -> 'a t) -> 'a list t
+
   val map_list : 'elem list -> f:('elem -> 'a t) -> 'a list t
   val map_iter : 'elem Iter.t -> f:('elem -> 'a t) -> 'a list t
-  val all : ('a -> 'b t) -> 'a list -> 'b list t
 end
 
 module type S = sig
@@ -96,9 +99,13 @@ module type Extension2 = sig
 
   val iter_list : 'elem list -> f:('elem -> (unit, 'b) t) -> (unit, 'b) t
   val iter_iter : 'elem Iter.t -> f:('elem -> (unit, 'b) t) -> (unit, 'b) t
+
+  val map_m :
+    (module M : Sigs.Foldable) ->
+    'elem M.t -> f:('elem -> ('a, 'b) t) -> ('a list, 'b) t
+
   val map_list : 'elem list -> f:('elem -> ('a, 'b) t) -> ('a list, 'b) t
   val map_iter : 'elem Iter.t -> f:('elem -> ('a, 'b) t) -> ('a list, 'b) t
-  val all : ('a -> ('b, 'c) t) -> 'a list -> ('b list, 'c) t
 end
 
 module type S2 = sig
@@ -125,15 +132,6 @@ let[@inline] mapM (module M : Sigs.Foldable) ~return ~bind ~map xs ~f =
     ~f:(fun acc x -> map (fun y -> y :: acc) (f x))
   |> bind (fun l -> return (List.rev l))
 
-(** Generic monadic map function that collects results. *)
-let all ~return ~bind fn xs =
-  let rec aux acc rs =
-    match rs with
-    | [] -> return (List.rev acc)
-    | r :: rs -> bind (fun x -> aux (x :: acc) rs) (fn r)
-  in
-  aux [] xs
-
 module Make_extension (Base : Base) : Extension with type 'a t := 'a Base.t =
 struct
   (** Functor to create generic monadic operations for a basic monad. *)
@@ -150,13 +148,11 @@ struct
   let[@inline] iter_list xs ~f = iter (module List) xs ~f
   let[@inline] iter_iter xs ~f = iter (module Iter) xs ~f
 
-  let[@inline] map_list xs ~f =
-    mapM (module List) ~return:Base.return ~bind:Base.bind ~map:Base.map xs ~f
+  let[@inline] map_m (module M : Sigs.Foldable) xs ~f =
+    mapM (module M) ~return:Base.return ~bind:Base.bind ~map:Base.map xs ~f
 
-  let[@inline] map_iter xs ~f =
-    mapM (module Iter) ~return:Base.return ~bind:Base.bind ~map:Base.map xs ~f
-
-  let[@inline] all fn xs = all ~return:Base.return ~bind:Base.bind fn xs
+  let[@inline] map_list xs ~f = map_m (module List) xs ~f
+  let[@inline] map_iter xs ~f = map_m (module Iter) xs ~f
 end
 
 module Make_syntax (Base : Base) : Syntax with type 'a t = 'a Base.t = struct
@@ -199,13 +195,11 @@ end) : Extension2 with type ('a, 'b) t := ('a, 'b) Base.t = struct
   let[@inline] iter_list xs ~f = iter (module List) xs ~f
   let[@inline] iter_iter xs ~f = iter (module Iter) xs ~f
 
-  let[@inline] map_list xs ~f =
-    mapM (module List) ~return:Base.ok ~bind:Base.bind ~map:Base.map xs ~f
+  let[@inline] map_m (module M : Sigs.Foldable) xs ~f =
+    mapM (module M) ~return:Base.ok ~bind:Base.bind ~map:Base.map xs ~f
 
-  let[@inline] map_iter xs ~f =
-    mapM (module Iter) ~return:Base.ok ~bind:Base.bind ~map:Base.map xs ~f
-
-  let[@inline] all fn xs = all ~return:Base.ok ~bind:Base.bind fn xs
+  let[@inline] map_list xs ~f = map_m (module List) xs ~f
+  let[@inline] map_iter xs ~f = map_m (module Iter) xs ~f
 end
 
 module Make_syntax2 (Base : Base2) :


### PR DESCRIPTION
Some perf improvements I did over the weekend

## Main changes

- Add an `Array` value and `TArray` type to Rust's extension, to represent arrays/slices which have only one element type. This avoids a significant perf cost on stuff like `[u8; 128]` where we would need to hash 128 times the `u8` type to get the hash of the type. 

  It also makes more sense semantically, and gives the opportunity in the future to support stuff like `ArrayRepeat` without concretising the repetition, or to have symbolic polymorphic arrays of unknown size!

- Make Rust's ~~`Tuple`~~, `Array`, ~~`Enum`~~ values be `Iarray` backed; this avoids O(N) access on fields. For this, added some helpers to `Iarray`.

## Minor
- remove the `Hashtbl.hash` call in Soteria Rust's extension
- make Soteria Rust's GC use more memory (tweaking `space_overhead`), this seemed to improve perf on everything, and its not like we eat massive amounts of memory
- Refactor `adt_is_box` and remove the polymorphic equal, using instead `Option.is_some_and (String.equal _)`
- Remove `Monad.all` -- I realised that the `Monad.map_list` I had added is exactly the same thing :P 