### PR TITLE
Upstream fixes and minor features from the CN work

### DIFF
--- a/soteria-c/lib/driver.ml
+++ b/soteria-c/lib/driver.ml
@@ -6,6 +6,10 @@ open Soteria.Logs.Printers
 open Soteria.Terminal.Warn
 module Wpst_interp = Interp.Make (SState)
 
+(* Type-checking that the state satisfies its interface since we removed its mli
+   file. *)
+module _ : State_intf.S = SState
+
 exception Tool_error
 
 let tool_error msg =

--- a/soteria-c/lib/state.mli
+++ b/soteria-c/lib/state.mli
@@ -1,1 +1,0 @@
-include State_intf.S

--- a/soteria/lib/bv_values/analyses.ml
+++ b/soteria/lib/bv_values/analyses.ml
@@ -252,7 +252,7 @@ module Make (Typed : Typed_intf.Solver_value) = struct
       type t = st
 
       let default () = Var.Map.empty
-      let copy t = t
+      let copy = Fun.id
     end)
 
     let get n v st =

--- a/soteria/lib/bv_values/analyses.ml
+++ b/soteria/lib/bv_values/analyses.ml
@@ -251,7 +251,8 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     include Reversible.Make_mutable (struct
       type t = st
 
-      let default = Var.Map.empty
+      let default () = Var.Map.empty
+      let copy t = t
     end)
 
     let get n v st =
@@ -558,13 +559,9 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     include Reversible.Make_mutable (struct
       type t = Svalue.t UnionFind.store * Svalue.t UnionFind.rref VMap.t
 
-      let default = (UnionFind.new_store (), VMap.empty)
+      let default () = (UnionFind.new_store (), VMap.empty)
+      let copy (uf, refs) = (UnionFind.copy uf, refs)
     end)
-
-    (* override to account for UnionFind *)
-    let save d =
-      let uf, st = Dynarray.get_last d in
-      Dynarray.add_last d (UnionFind.copy uf, st)
 
     let rec cost (v : Svalue.t) : int =
       match v.node.kind with

--- a/soteria/lib/bv_values/bv_solver.ml
+++ b/soteria/lib/bv_values/bv_solver.ml
@@ -407,8 +407,8 @@ struct
     if not (Var.Set.is_empty vars) then
       Solver_state.dirty_variable solver.state vars
 
-  let memo_sat_check_tbl : Symex.Solver_result.t Hashtbl.Hint.t =
-    Hashtbl.Hint.create 1023
+  let memo_sat_check_tbl : Symex.Solver_result.t Svalue.Hashtbl.t =
+    Svalue.Hashtbl.create 1023
 
   let trivial_model_works solver to_check var_tys =
     let exception No_model in
@@ -476,11 +476,11 @@ struct
 
   let check_sat_raw_memo solver to_check =
     let to_check = Typed.untyped to_check in
-    match Hashtbl.Hint.find_opt memo_sat_check_tbl to_check.Hc.tag with
+    match Svalue.Hashtbl.find_opt memo_sat_check_tbl to_check with
     | Some result -> result
     | None ->
         let result = check_sat_raw solver to_check in
-        Hashtbl.Hint.add memo_sat_check_tbl to_check.Hc.tag result;
+        Svalue.Hashtbl.add memo_sat_check_tbl to_check result;
         result
 
   let sat solver =

--- a/soteria/lib/bv_values/bv_solver.ml
+++ b/soteria/lib/bv_values/bv_solver.ml
@@ -174,12 +174,16 @@ struct
             [%l.info "Solver returned unknown"];
             Unknown)
 
-  let as_exprs solver =
+  let as_values_iter solver =
     Iter.append
       (Solver_state.iter solver.state)
       (Analysis.encode solver.analysis)
-    |> Iter.map Typed.Expr.of_value
-    |> Iter.to_list
+
+  let pp (ft : Format.formatter) (solver : t) : unit =
+    (Fmt.Dump.iter (Fun.flip as_values_iter) Fmt.nop Typed.ppa) ft solver
+
+  let as_exprs solver =
+    as_values_iter solver |> Iter.map Typed.Expr.of_value |> Iter.to_list
 end
 
 module Make
@@ -493,12 +497,16 @@ struct
         if answer = Sat then Solver_state.mark_checked solver.state;
         answer
 
-  let as_exprs solver =
+  let as_values_iter solver =
     Iter.append
       (Solver_state.iter solver.state)
       (Analysis.encode solver.analysis)
-    |> Iter.map Typed.Expr.of_value
-    |> Iter.to_list
+
+  let pp fmt solver =
+    (Fmt.Dump.iter (Fun.flip as_values_iter) Fmt.nop Typed.ppa) fmt solver
+
+  let as_exprs solver =
+    as_values_iter solver |> Iter.map Typed.Expr.of_value |> Iter.to_list
 end
 
 module Analysis (Typed : Typed_intf.Solver_value) = struct

--- a/soteria/lib/bv_values/bv_solver.ml
+++ b/soteria/lib/bv_values/bv_solver.ml
@@ -354,8 +354,13 @@ struct
             else
               let others = fun () -> Seq.Cons (slot, others) in
               aux_checked others rest
-        | Seq.Cons ({ value = Dirty _; _ }, rest) ->
-            (* A dirty checked variable can be ignored *)
+        | Seq.Cons ({ value = Dirty vars; _ }, rest) ->
+            let vars = Fun.flip Var.Set.iter vars in
+            if relevant vars then
+              (* Variables that are together in a Dirty slot might indicate a
+                 relationship between the variables. We need to consider them
+                 connected. *)
+              add_vars vars;
             aux_checked others rest
       in
       let rec aux seq =

--- a/soteria/lib/bv_values/encoding.ml
+++ b/soteria/lib/bv_values/encoding.ml
@@ -26,7 +26,7 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     | TBitVector n -> t_bits n
     | TExtension x -> Typed.Ext.encode_ty sort_of_ty x
 
-  let memo_encode_value_tbl : sexp Hashtbl.Hint.t = Hashtbl.Hint.create 1023
+  let memo_encode_value_tbl : sexp Svalue.Hashtbl.t = Svalue.Hashtbl.create 1023
 
   let rm_to_smt : RoundingMode.t -> Smt.RoundingMode.t = function
     | NearestTiesToEven -> NearestTiesToEven
@@ -134,11 +134,11 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     | Extension x -> Typed.Ext.encode_value encode_value_memo x
 
   and encode_value_memo v =
-    match Hashtbl.Hint.find_opt memo_encode_value_tbl v.Hc.tag with
+    match Svalue.Hashtbl.find_opt memo_encode_value_tbl v with
     | Some k -> k
     | None ->
         let k = encode_value v in
-        Hashtbl.Hint.add memo_encode_value_tbl v.Hc.tag k;
+        Svalue.Hashtbl.add memo_encode_value_tbl v k;
         k
 
   let encode_value (v : Svalue.t) =

--- a/soteria/lib/bv_values/svalue.ml
+++ b/soteria/lib/bv_values/svalue.ml
@@ -514,6 +514,13 @@ module Make (V : Value_ext) () = struct
       | Extension e -> combine (combine h 12) (V.hash e)
   end)
 
+  module Hashtbl = Hashtbl.Make (struct
+    type nonrec t = t
+
+    let equal = equal
+    let hash = hash
+  end)
+
   let ( <| ) kind ty : t = Hcons.hashcons { kind; ty }
   let mk_var v ty = Var v <| ty
 

--- a/soteria/lib/bv_values/svalue.ml
+++ b/soteria/lib/bv_values/svalue.ml
@@ -532,7 +532,7 @@ module Make (V : Value_ext) () = struct
   (** We put commutative n-ary operators in some sort of normal form where
       elements are sorted by ud, to increase cache hits. If [idem] is true, will
       also remove duplicates. *)
-  let mk_commut_nop ?(idem = true) op vs =
+  let mk_commut_nop ~idem op vs =
     let sort = if idem then List.sort_uniq else List.sort in
     let vs = sort (fun l r -> Int.compare l.tag r.tag) vs in
     Nop (op, vs)
@@ -1099,6 +1099,7 @@ module Make (V : Value_ext) () = struct
           split_ands s2 f
       | _ -> f sv
 
+    (* If l is not none, it is the list represented by the sequence S *)
     let distinct_raw s ?l () =
       (* [Distinct l] when l is empty or of size 1 is always true *)
       match Seq.compare_length_with s 2 with
@@ -1117,8 +1118,9 @@ module Make (V : Value_ext) () = struct
           match (res, l) with
           | Some true, _ -> v_true
           | Some false, _ -> v_false
-          | None, Some l -> mk_commut_nop Distinct l <| TBool
-          | None, None -> mk_commut_nop Distinct (List.of_seq s) <| TBool)
+          | None, Some l -> mk_commut_nop ~idem:false Distinct l <| TBool
+          | None, None ->
+              mk_commut_nop ~idem:false Distinct (List.of_seq s) <| TBool)
 
     let distinct_seq s = distinct_raw s ()
     let distinct l = distinct_raw (List.to_seq l) ~l ()

--- a/soteria/lib/data/abstr.ml
+++ b/soteria/lib/data/abstr.ml
@@ -9,6 +9,7 @@ module M (Symex : Symex.Base) = struct
 
     type t [@@deriving show]
 
+    (* FIXME: fresh should probably not be required by default anymore. *)
     val fresh : unit -> t Symex.t
   end
 

--- a/soteria/lib/data/s_map.ml
+++ b/soteria/lib/data/s_map.ml
@@ -111,7 +111,9 @@ struct
     match M.find_opt key st with
     | Some v -> Symex.return (key, Some v)
     | None ->
-        let not_in_map = M.to_seq st |> Seq.map fst |> Key.distinct_seq in
+        let not_in_map =
+          M.to_seq st |> Seq.map fst |> Seq.cons key |> Key.distinct_seq
+        in
         B.if_not_in_map not_in_map
           ~then_:(fun () -> Symex.return (key, None))
           ~else_:(fun () -> M.to_seq st |> find_bindings)

--- a/soteria/lib/data/s_map.ml
+++ b/soteria/lib/data/s_map.ml
@@ -82,8 +82,17 @@ module Make_patricia_tree
 
 (** Sound to use when the keys of the map may depend on symbolic variables *)
 
-module Build_direct_access
+module Build_direct_or_lazy
     (Symex : Symex.Base)
+    (B : sig
+      open Symex
+
+      (** [if_not_in_map outside_map ~then_ ~else_] decides how to handle
+          branching when asking if the object is outside the map (captured by
+          the [outside_map] symbolic boolean.)*)
+      val if_not_in_map :
+        Value.(sbool t) -> then_:(unit -> 'a t) -> else_:(unit -> 'a t) -> 'a t
+    end)
     (Key : Key(Symex).S)
     (M : MapS with type key = Key.t) =
 struct
@@ -103,8 +112,58 @@ struct
     | Some v -> Symex.return (key, Some v)
     | None ->
         let not_in_map = M.to_seq st |> Seq.map fst |> Key.distinct_seq in
-        if%sat1 not_in_map then Symex.return (key, None)
-        else M.to_seq st |> find_bindings
+        B.if_not_in_map not_in_map
+          ~then_:(fun () -> Symex.return (key, None))
+          ~else_:(fun () -> M.to_seq st |> find_bindings)
+end
+
+module Build_direct_access
+    (Symex : Symex.Base)
+    (Key : Key(Symex).S)
+    (M : MapS with type key = Key.t) =
+struct
+  include
+    Build_direct_or_lazy
+      (Symex)
+      (struct
+        open Symex
+
+        (** In the direct access map, we check if it's possible that the key is
+            outside the map, and if it is, we only take that branch in UX.
+            However, we keep the information that the value is not in the map,
+            we have entirely dropped the other branch. *)
+        let if_not_in_map guard ~then_ ~else_ =
+          branch_on_take_one guard ~then_ ~else_
+      end)
+      (Key)
+      (M)
+end
+
+(** An S_map where all keys are not guaranteed to be disjoint. *)
+module Build_lazy
+    (Symex : Symex.Base)
+    (Key : Key(Symex).S)
+    (M : MapS with type key = Key.t) =
+struct
+  include
+    Build_direct_or_lazy
+      (Symex)
+      (struct
+        open Symex
+
+        (** In the lazy map, we see if we know the value is inside the map. If
+            it is, then we take that branch, knowing that fact. Otherwise, we
+            consider a new binding. This changes the interpretation of a map:
+            two different bindings are not necessarily semantically different
+            keys!
+
+            This is well modelled with the existing `if_sure` of Symex. *)
+        let if_not_in_map not_in_map ~then_ ~else_ =
+          let in_map = Value.not not_in_map in
+          if_sure in_map ~then_:else_ ~else_:then_
+      end)
+      (Key)
+      (M)
 end
 
 module Direct_access (Symex : Symex.Base) (Key : Key(Symex).S) =
@@ -114,6 +173,14 @@ module Direct_access_patricia_tree
     (Symex : Symex.Base)
     (Key : Key(Symex).S_patricia_tree) =
   Build_direct_access (Symex) (Key) (PatriciaTree.MakeMap (Key))
+
+module Lazy (Symex : Symex.Base) (Key : Key(Symex).S) =
+  Build_lazy (Symex) (Key) (Stdlib.Map.Make (Key))
+
+module Lazy_patricia_tree
+    (Symex : Symex.Base)
+    (Key : Key(Symex).S_patricia_tree) =
+  Build_lazy (Symex) (Key) (PatriciaTree.MakeMap (Key))
 
 module Concrete (Symex : Symex.Base) (Key : Key(Symex).S) = struct
   include Build (Symex) (Key) (Stdlib.Map.Make (Key))

--- a/soteria/lib/data/s_map.mli
+++ b/soteria/lib/data/s_map.mli
@@ -24,15 +24,24 @@ module Make_patricia_tree
     (Key : Key(Symex).S_patricia_tree) : S(Symex)(Key).S
 
 (** Makes a symbolic map. The algorithm for {{!S.S.find_opt}[find_opt]} will
-    first look for a syntactic match. If none is found, it will check if the
-    given key is {{!Key.S.distinct_seq}distinct} from all other existing keys
-    (in which case [None] is returned) before iterating over all entries. *)
+    first look for a syntactic match. In UX, if none is found, it will check if
+    the given key is {{!Key.S.distinct_seq}distinct} from all other existing
+    keys (in which case [None] is returned) before iterating over all entries.
+*)
 module Direct_access (Symex : Symex.Base) (Key : Key(Symex).S) : S(Symex)(Key).S
 
 (** Same as {!Direct_access}, but backed by a
     {{:https://ocaml.org/p/patricia-tree/latest/doc/index.html}Patricia Tree},
     which may offer performance benefits. *)
 module Direct_access_patricia_tree
+    (Symex : Symex.Base)
+    (Key : Key(Symex).S_patricia_tree) : S(Symex)(Key).S
+
+(** Makes a symbolic map similar to {!Direct_access}, but even in OX, if it is
+    possible that the key is outside the map, only this path will be taken. *)
+module Lazy (Symex : Symex.Base) (Key : Key(Symex).S) : S(Symex)(Key).S
+
+module Lazy_patricia_tree
     (Symex : Symex.Base)
     (Key : Key(Symex).S_patricia_tree) : S(Symex)(Key).S
 

--- a/soteria/lib/data/s_map.mli
+++ b/soteria/lib/data/s_map.mli
@@ -41,6 +41,9 @@ module Direct_access_patricia_tree
     possible that the key is outside the map, only this path will be taken. *)
 module Lazy (Symex : Symex.Base) (Key : Key(Symex).S) : S(Symex)(Key).S
 
+(** Same as {!Lazy}, but backed by a
+    {{:https://ocaml.org/p/patricia-tree/latest/doc/index.html}Patricia Tree},
+    which may offer performance benefits. *)
 module Lazy_patricia_tree
     (Symex : Symex.Base)
     (Key : Key(Symex).S_patricia_tree) : S(Symex)(Key).S

--- a/soteria/lib/data/s_map_intf.ml
+++ b/soteria/lib/data/s_map_intf.ml
@@ -48,10 +48,6 @@ struct
   module type S = sig
     type 'a t
 
-    (** Indicates whether the map has a lazy behaviour. If true, it means that:
-        - finding a hit does not mean it is the only possible hit, and
-        - not finding a hit does not mean there is no match. *)
-
     val empty : 'a t
     val is_empty : 'a t -> bool
     val syntactic_bindings : 'a t -> (Key.t * 'a) Seq.t

--- a/soteria/lib/data/s_map_intf.ml
+++ b/soteria/lib/data/s_map_intf.ml
@@ -48,6 +48,10 @@ struct
   module type S = sig
     type 'a t
 
+    (** Indicates whether the map has a lazy behaviour. If true, it means that:
+        - finding a hit does not mean it is the only possible hit, and
+        - not finding a hit does not mean there is no match. *)
+
     val empty : 'a t
     val is_empty : 'a t -> bool
     val syntactic_bindings : 'a t -> (Key.t * 'a) Seq.t

--- a/soteria/lib/soteria_std/list.ml
+++ b/soteria/lib/soteria_std/list.ml
@@ -170,6 +170,19 @@ let rec find_with_rest f l =
         | None -> None
         | Some (found, rest) -> Some (found, x :: rest))
 
+let rec take_nth n l =
+  if n < 0 then raise (Invalid_argument "take_nth: negative n");
+  let rec aux n l =
+    match (n, l) with
+    | _, [] -> None
+    | 0, x :: xs -> Some (x, xs)
+    | n, x :: xs -> (
+        match take_nth (n - 1) xs with
+        | None -> None
+        | Some (found, rest) -> Some (found, x :: rest))
+  in
+  aux n l
+
 (** [update_at i f l] updates the element at index [i] in list [l] with function
     [f]. This is more efficient than e.g. {!mapi}, as it only traverses and
     rebuilds the list up to index [i]; the list is shared after index [i].

--- a/soteria/lib/soteria_std/list.ml
+++ b/soteria/lib/soteria_std/list.ml
@@ -170,16 +170,15 @@ let rec find_with_rest f l =
         | None -> None
         | Some (found, rest) -> Some (found, x :: rest))
 
-let rec take_nth n l =
+let rec take_nth_exn n l =
   if n < 0 then raise (Invalid_argument "take_nth: negative n");
   let rec aux n l =
     match (n, l) with
-    | _, [] -> None
-    | 0, x :: xs -> Some (x, xs)
-    | n, x :: xs -> (
-        match take_nth (n - 1) xs with
-        | None -> None
-        | Some (found, rest) -> Some (found, x :: rest))
+    | _, [] -> raise (Invalid_argument "take_nth: index out of bounds")
+    | 0, x :: xs -> (x, xs)
+    | n, x :: xs ->
+        let found, rest = take_nth_exn (n - 1) xs in
+        (found, x :: rest)
   in
   aux n l
 

--- a/soteria/lib/soteria_std/reversible.ml
+++ b/soteria/lib/soteria_std/reversible.ml
@@ -17,16 +17,15 @@ module type Mutable = sig
   val reset : t -> unit
 end
 
-(** Functor to create a mutable reversible state from a default value. *)
+(** Functor to create a mutable reversible state. The content itself can be
+    mutable. *)
 module Make_mutable (M : sig
   type t
 
-  val default : t
+  val default : unit -> t
+  val copy : t -> t
 end) : sig
   include Mutable with type t = M.t Dynarray.t
-
-  (** Set the default value used when initializing new states. *)
-  val set_default : M.t -> unit
 
   (** Apply function [f] to the current state, updating it with the returned
       value. *)
@@ -37,24 +36,22 @@ end) : sig
 end = struct
   type t = M.t Dynarray.t
 
-  let default = ref M.default
-
   let init () =
     let d = Dynarray.create () in
-    Dynarray.add_last d !default;
+    Dynarray.add_last d (M.default ());
     d
-
-  let set_default v = default := v
 
   let backtrack_n d n =
     let len = Dynarray.length d in
     Dynarray.truncate d (len - n)
 
-  let save d = Dynarray.add_last d (Dynarray.get_last d)
+  let save d =
+    let copied = M.copy (Dynarray.get_last d) in
+    Dynarray.add_last d copied
 
   let reset d =
     Dynarray.clear d;
-    Dynarray.add_last d !default
+    Dynarray.add_last d (M.default ())
 
   let wrap (f : M.t -> 'a * M.t) d =
     let e = Dynarray.pop_last d in

--- a/soteria/lib/soteria_std/sigs.ml
+++ b/soteria/lib/soteria_std/sigs.ml
@@ -4,6 +4,12 @@ module type Printable = sig
   val pp : Format.formatter -> t -> unit
 end
 
+module type Eq = sig
+  type t
+
+  val equal : t -> t -> bool
+end
+
 module type String_encodable = sig
   type t
 

--- a/soteria/lib/sym_states/pmap.ml
+++ b/soteria/lib/sym_states/pmap.ml
@@ -140,6 +140,14 @@ module Make_patricia_tree
 module Direct_access (Symex : Symex.Base) (Key : Key(Symex).S) =
   Build (Symex) (Key) (S_map.Direct_access (Symex) (Key))
 
+module Lazy (Symex : Symex.Base) (Key : Key(Symex).S) =
+  Build (Symex) (Key) (S_map.Lazy (Symex) (Key))
+
+module Lazy_patricia_tree
+    (Symex : Symex.Base)
+    (Key : Key(Symex).S_patricia_tree) =
+  Build (Symex) (Key) (S_map.Lazy_patricia_tree (Symex) (Key))
+
 module Direct_access_patricia_tree
     (Symex : Symex.Base)
     (Key : Key(Symex).S_patricia_tree) =

--- a/soteria/lib/sym_states/pmap.mli
+++ b/soteria/lib/sym_states/pmap.mli
@@ -28,6 +28,18 @@ module Direct_access_patricia_tree
     (Codom : Base.M(Symex).S) :
   S(Symex)(Key).S with type codom := Codom.t and type codom_syn := Codom.syn
 
+module Lazy
+    (Symex : Symex.Base)
+    (Key : Key(Symex).S)
+    (Codom : Base.M(Symex).S) :
+  S(Symex)(Key).S with type codom := Codom.t and type codom_syn := Codom.syn
+
+module Lazy_patricia_tree
+    (Symex : Symex.Base)
+    (Key : Key(Symex).S_patricia_tree)
+    (Codom : Base.M(Symex).S) :
+  S(Symex)(Key).S with type codom := Codom.t and type codom_syn := Codom.syn
+
 module Concrete
     (Symex : Symex.Base)
     (Key : Soteria_std.Ordered_type.S)

--- a/soteria/lib/sym_states/state_monad.ml
+++ b/soteria/lib/sym_states/state_monad.ml
@@ -72,6 +72,8 @@ module Make
     module Symex = Sym
     module Value = Sym.Value
 
+    let log_solver_state ~level () = Sym.log_solver_state ~level ()
+
     type lfail = Sym.lfail [@@deriving show { with_path = false }]
     type cons_fail = Sym.cons_fail [@@deriving show { with_path = false }]
     type st = State.t

--- a/soteria/lib/symex/solver.ml
+++ b/soteria/lib/symex/solver.ml
@@ -27,6 +27,8 @@ module type Mutable_incremental = sig
   (** Converts the current solver state into the list of constraints it
       contains. These are {e syntactic} constraints, not semantic ones. *)
   val as_exprs : t -> Value.Expr.t list
+
+  val pp : Format.formatter -> t -> unit
 end
 
 (** Converts a mutable incremental solver into an effectful one. See the
@@ -43,6 +45,7 @@ module Mutable_to_effectful (M : Mutable_incremental) = struct
   let simplify x = wrap (fun st -> M.simplify st x) ()
   let fresh_var x = wrap (fun st -> M.fresh_var st x) ()
   let as_exprs () = wrap M.as_exprs ()
+  let pp fmt () = wrap (M.pp fmt) ()
 end
 
 (** Converts a mutable incremental solver into a pooled one. See the
@@ -59,4 +62,5 @@ module Mutable_to_pooled (M : Mutable_incremental) = struct
   let simplify x = wrap (fun st -> M.simplify st x) ()
   let fresh_var x = wrap (fun st -> M.fresh_var st x) ()
   let as_exprs () = wrap M.as_exprs ()
+  let pp fmt () = wrap (M.pp fmt) ()
 end

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -171,6 +171,7 @@ module type Core = sig
   (** {2 Fuel} *)
 
   val consume_fuel_steps : int -> unit t
+  val log_solver_state : level:Logs.Level.t -> unit -> unit
 end
 
 module type Base = sig
@@ -533,6 +534,9 @@ module Make_core (Sol : Solver.Mutable_incremental) = struct
     | Not_exhausted ->
         Stats.As_ctx.add_int StatKeys.steps n;
         f ()
+
+  let log_solver_state ~level () =
+    L.log ~level (fun m -> m "@[Path condition:@ %a@]" Solver.pp ())
 
   (** [Solver.simplify] throws an effect to ask the solver for simplification.
       When the value is already a concrete boolean literal, we can skip the

--- a/soteria/lib/symex/symex.ml
+++ b/soteria/lib/symex/symex.ml
@@ -171,6 +171,8 @@ module type Core = sig
   (** {2 Fuel} *)
 
   val consume_fuel_steps : int -> unit t
+
+  (** Logs the current solver state, at the given log level *)
   val log_solver_state : level:Logs.Level.t -> unit -> unit
 end
 

--- a/soteria/lib/symex/var.ml
+++ b/soteria/lib/symex/var.ml
@@ -23,7 +23,8 @@ end) =
 struct
   type nonrec t = t
 
-  let default = Start_at.start_at
+  let default () = Start_at.start_at
+  let copy i = i
   let[@inline] next i = (i, i + 1)
 end
 

--- a/soteria/lib/tiny_values/analyses.ml
+++ b/soteria/lib/tiny_values/analyses.ml
@@ -106,7 +106,7 @@ module Interval : S = struct
     type t = Range.t Var.Map.t
 
     let default () : t = Var.Map.empty
-    let copy t = t
+    let copy = Fun.id
   end)
 
   (** Union of two interval mappings, doing the union of the intervals *)

--- a/soteria/lib/tiny_values/analyses.ml
+++ b/soteria/lib/tiny_values/analyses.ml
@@ -105,7 +105,8 @@ module Interval : S = struct
   include Reversible.Make_mutable (struct
     type t = Range.t Var.Map.t
 
-    let default : t = Var.Map.empty
+    let default () : t = Var.Map.empty
+    let copy t = t
   end)
 
   (** Union of two interval mappings, doing the union of the intervals *)

--- a/soteria/lib/tiny_values/encoding.ml
+++ b/soteria/lib/tiny_values/encoding.ml
@@ -20,7 +20,7 @@ let t_ptr, mk_ptr, get_loc, get_ofs, init_commands =
     [ cmd ] )
 
 let sort_of_ty : ty -> sexp = function TBool -> t_bool | TInt -> t_int
-let memo_encode_value_tbl : sexp Hashtbl.Hint.t = Hashtbl.Hint.create 1023
+let memo_encode_value_tbl : sexp Svalue.Hashtbl.t = Svalue.Hashtbl.create 1023
 let smt_of_unop : Svalue.Unop.t -> sexp -> sexp = function Not -> bool_not
 
 let smt_of_binop : Svalue.Binop.t -> sexp -> sexp -> sexp = function
@@ -55,11 +55,11 @@ let rec encode_value (v : Svalue.t) =
       distinct vs
 
 and encode_value_memo v =
-  match Hashtbl.Hint.find_opt memo_encode_value_tbl v.Hc.tag with
+  match Svalue.Hashtbl.find_opt memo_encode_value_tbl v with
   | Some k -> k
   | None ->
       let k = encode_value v in
-      Hashtbl.Hint.add memo_encode_value_tbl v.Hc.tag k;
+      Svalue.Hashtbl.add memo_encode_value_tbl v k;
       k
 
 let encode_value (v : Svalue.t) =

--- a/soteria/lib/tiny_values/svalue.ml
+++ b/soteria/lib/tiny_values/svalue.ml
@@ -150,6 +150,13 @@ module Hcons = Hc.Make (struct
     | Ite (c, t, e) -> Hashtbl.hash (c.tag, t.tag, e.tag, hty)
 end)
 
+module Hashtbl = Hashtbl.Make (struct
+  type nonrec t = t
+
+  let equal = equal
+  let hash = hash
+end)
+
 let ( <| ) kind ty : t = Hcons.hashcons { kind; ty }
 let mk_var v ty = Var v <| ty
 

--- a/soteria/lib/tiny_values/tiny_solver.ml
+++ b/soteria/lib/tiny_values/tiny_solver.ml
@@ -121,12 +121,16 @@ struct
             [%l.info "Solver returned unknown"];
             Unknown)
 
-  let as_exprs solver =
+  let as_values_iter solver =
     Iter.append
       (Solver_state.iter solver.state)
       (Analysis.encode solver.analysis)
-    |> Iter.map Typed.Expr.of_value
-    |> Iter.to_list
+
+  let as_exprs solver =
+    as_values_iter solver |> Iter.map Typed.Expr.of_value |> Iter.to_list
+
+  let pp fmt solver =
+    (Fmt.Dump.iter (Fun.flip as_values_iter) Fmt.nop Typed.ppa) fmt solver
 end
 
 module Make
@@ -458,12 +462,16 @@ struct
         if answer = Sat then Solver_state.mark_checked solver.state;
         answer
 
-  let as_exprs solver =
+  let as_values_iter solver =
     Iter.append
       (Solver_state.iter solver.state)
       (Analysis.encode solver.analysis)
-    |> Iter.map Typed.Expr.of_value
-    |> Iter.to_list
+
+  let as_exprs solver =
+    as_values_iter solver |> Iter.map Typed.Expr.of_value |> Iter.to_list
+
+  let pp fmt solver =
+    (Fmt.Dump.iter (Fun.flip as_values_iter) Fmt.nop Typed.ppa) fmt solver
 end
 
 module Z3 = Solvers.Z3.Make (Encoding)

--- a/soteria/lib/tiny_values/tiny_solver.ml
+++ b/soteria/lib/tiny_values/tiny_solver.ml
@@ -384,8 +384,8 @@ struct
     if not (Var.Set.is_empty vars) then
       Solver_state.dirty_variable solver.state vars
 
-  let memo_sat_check_tbl : Symex.Solver_result.t Hashtbl.Hint.t =
-    Hashtbl.Hint.create 1023
+  let memo_sat_check_tbl : Symex.Solver_result.t Svalue.Hashtbl.t =
+    Svalue.Hashtbl.create 1023
 
   let trivial_model_works to_check =
     (* We try a trivial model where replacing each variable with name [|n|] with
@@ -436,11 +436,11 @@ struct
 
   let check_sat_raw_memo solver relevant_vars to_check =
     let to_check = Typed.untyped to_check in
-    match Hashtbl.Hint.find_opt memo_sat_check_tbl to_check.Hc.tag with
+    match Svalue.Hashtbl.find_opt memo_sat_check_tbl to_check with
     | Some result -> result
     | None ->
         let result = check_sat_raw solver relevant_vars to_check in
-        Hashtbl.Hint.add memo_sat_check_tbl to_check.Hc.tag result;
+        Svalue.Hashtbl.add memo_sat_check_tbl to_check result;
         result
 
   let sat solver : Symex.Solver_result.t =

--- a/soteria/tests/bv_fuzz/direct.ml
+++ b/soteria/tests/bv_fuzz/direct.ml
@@ -28,15 +28,15 @@ module Var_pool = struct
   (* We want to generate at most [max_var_per_ty] variables per type. This
      avoids generating expressions with only different variables, which cannot
      be reduced interestingly. *)
-  let var_pool : (int * ty, t) Hashtbl.t = Hashtbl.create 1024
+  let var_pool : (int * ty, t) Stdlib.Hashtbl.t = Stdlib.Hashtbl.create 1024
 
   let get_from_pool idx ty =
     let key = (idx, ty) in
-    match Hashtbl.find_opt var_pool key with
+    match Stdlib.Hashtbl.find_opt var_pool key with
     | None ->
         let name = get_next_name () in
         let v = mk_var name ty in
-        Hashtbl.replace var_pool key v;
+        Stdlib.Hashtbl.replace var_pool key v;
         v
     | Some v -> v
 end

--- a/soteria/tests/data/s_map/dune
+++ b/soteria/tests/data/s_map/dune
@@ -1,0 +1,5 @@
+(test
+ (name s_map_tests)
+ (libraries soteria alcotest fmt)
+ (preprocess
+  (pps soteria.ppx)))

--- a/soteria/tests/data/s_map/s_map_tests.ml
+++ b/soteria/tests/data/s_map/s_map_tests.ml
@@ -1,0 +1,121 @@
+module Typed = Soteria.Tiny_values.Typed
+module Tiny_solver = Soteria.Tiny_values.Tiny_solver
+module Symex = Soteria.Symex.Make (Tiny_solver.Z3_solver)
+module S_map = Soteria.Data.S_map
+
+(* A symbolic key over symbolic integers, with unit values, used to instantiate
+   the "lazy" symbolic map (the one whose [find_opt] first looks for a syntactic
+   match and otherwise branches on semantic equality with every existing
+   key). *)
+module S_int = struct
+  type t = Typed.T.sint Typed.t
+
+  let pp = Typed.ppa
+  let show = Fmt.to_to_string pp
+  let compare = Typed.compare
+  let sem_eq = Typed.sem_eq
+  let simplify = Symex.simplify
+  let distinct_seq = Typed.distinct_seq
+end
+
+module LazyMap = S_map.Lazy (Symex) (S_int)
+open Symex
+open Syntax
+open Typed.Infix
+
+(* ============================================================================
+   Test Processes
+   ============================================================================ *)
+
+(* Looking a key up in the empty map never finds a value, and hands back a key
+   usable for future syntactic operations. *)
+let empty_lookup () =
+  let* x = nondet Typed.t_int in
+  let* _key, res = LazyMap.find_opt x LazyMap.empty in
+  Alcotest.(check bool) "lookup in empty map is None" true (Option.is_none res);
+  return (Option.is_some res)
+
+(* After a syntactic insertion, looking the very same value up resolves
+   syntactically: it returns [Some] without branching at all. *)
+let syntactic_hit () =
+  let* x = nondet Typed.t_int in
+  let* key, res = LazyMap.find_opt x LazyMap.empty in
+  Alcotest.(check bool) "fresh lookup is None" true (Option.is_none res);
+  let map = LazyMap.syntactic_add key () LazyMap.empty in
+  let* key, res = LazyMap.find_opt x map in
+  Alcotest.(check bool)
+    "retrieveing syntactic hit gives the same key" true (Typed.equal key x);
+  Alcotest.(check bool) "lookup after add is Some" true (Option.is_some res);
+  return 0
+
+(* The core "lazy" behaviour: a value that is not syntactically present is
+   matched against existing keys by branching on semantic equality, and the key
+   handed back is the {i existing} key it matched, not the query itself. *)
+let lazy_matching_key () =
+  let map = LazyMap.empty in
+  let* x = nondet Typed.t_int in
+  let* y = nondet Typed.t_int in
+  let* kx, res = LazyMap.find_opt x map in
+  Alcotest.(check bool) "fresh x lookup is None" true (Option.is_none res);
+  let map = LazyMap.syntactic_add kx () map in
+  (* [y] is syntactically distinct from [x], so this lookup branches on whether
+     [y] is semantically equal to [x]; [ky] is the matched key on each
+     branch. *)
+  let* ky, _res = LazyMap.find_opt y map in
+  Alcotest.(check bool)
+    "looking up fresh y is None, even though it could equal x" true
+    (Option.is_none _res);
+  let map = LazyMap.syntactic_add ky () map in
+  if%sat x ==@ y then return 0
+  else
+    let* z = nondet Typed.t_int in
+    let* () = assume [ z ==@ x ||@ (z ==@ y) ] in
+    let* kz, _res = LazyMap.find_opt z map in
+    if Typed.equal kz kx then return 1
+    else if Typed.equal kz ky then return 2
+    else return (-1)
+
+(* ============================================================================
+   Helper
+   ============================================================================ *)
+
+let get_results process =
+  List.map fst (run ~mode:OX (process ())) |> List.sort Stdlib.compare
+
+(* ============================================================================
+   Tests
+   ============================================================================ *)
+
+let empty_lookup_test () =
+  Alcotest.(check (list bool))
+    "no value found" [ false ] (get_results empty_lookup)
+
+let syntactic_hit_test () =
+  Alcotest.(check (list int))
+    "single non-branching path" [ 0 ]
+    (get_results syntactic_hit)
+
+(* The [x = y] branch returns 0; otherwise [z] semantically matches either [x]'s
+   key (1) or [y]'s key (2). The catch-all -1 is unreachable given the
+   assumption. *)
+let lazy_matching_key_test () =
+  Alcotest.(check (list int))
+    "matched key per branch" [ 0; 1; 2 ]
+    (get_results lazy_matching_key)
+
+(* ============================================================================
+   Test Runner
+   ============================================================================ *)
+
+let () =
+  Alcotest.run "S_map.Lazy"
+    [
+      ( "lazy",
+        [
+          Alcotest.test_case "empty lookup is None" `Quick empty_lookup_test;
+          Alcotest.test_case "syntactic hit does not branch" `Quick
+            syntactic_hit_test;
+          Alcotest.test_case "lazy lookup returns matching key" `Quick
+            lazy_matching_key_test;
+        ] );
+    ]


### PR DESCRIPTION
- Removes `soteria-c/lib/state.mli`. There's no point in hiding the interface (and I added a module type-check somewhere else).
- Adds `Symex.log_solver_state ~level ()`
- Adds `Sigs.Eq`
- Fix `Dirty_vars` not being pulled in. If I have `Dirty_vars { x , y }` and I know that `x` is relevant, then I should also add `y` to my set of relevant variables (otherwise transitive equalities are lost...)
- Adds `take_nth` to `Soteria_std.List`
- Fix memoisation tables to keep the values, not just their tags 😬
- Add an implementation of the Lazy map. **Maybe look at this one in details**, I've made implementation choices :p
- Fixed union find "default" value being mutable yet copied in every fresh solver
- Fixes the S_map being very wrong when doing the member check 🤦‍♂️, and adds a few tests for the lazy map behaviour
- Fix map distinct and change the default of mk_commut_nop to be no-idempotent by default (the least risky choice)