### PR TITLE
Fix hack in decoding values

### DIFF
--- a/soteria-rust/lib/layout.ml
+++ b/soteria-rust/lib/layout.ml
@@ -442,6 +442,15 @@ let[@inline] is_zst ty =
   let++ layout = layout_of ty in
   layout.size ==@ Usize.(0s)
 
+(** If the given type is an enum with a single variant, return the variant's ID.
+    Otherwise, return None. Fails if the type is not an enum. *)
+let enum_single_variant (ty : Types.ty) =
+  let++ layout = layout_of ty in
+  match layout.fields with
+  | Enum (Known v, _) -> Some v
+  | Enum _ -> None
+  | _ -> L.failwith "enum_single_variant: not an enum type: %a" pp_ty ty
+
 let min_value_z : Types.literal_type -> Z.t = function
   | TUInt _ -> Z.zero
   | TInt Isize -> Z.neg (Z.shift_left Z.one ((8 * Crate.pointer_size ()) - 1))

--- a/soteria-rust/lib/state/rtree_block.ml
+++ b/soteria-rust/lib/state/rtree_block.ml
@@ -599,6 +599,29 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) = struct
     let+ tb_st = Borrows.State.init () in
     alloc (Leaf (st, Some tb_st)) size
 
+  module Decoder = Value_codec.Decoder (struct
+    module SM = SM
+
+    type nonrec syn = syn
+  end)
+
+  (** Applies the given parser. [on_access] is called at the start of any actual
+      access to memory (which means it may not be called, e.g. with ZSTs that
+      don't need any accesses to be parsed). *)
+  let apply_parser (type a) ?(on_access = DecayMap.SM.Result.ok) ~ignore_borrow
+      tag tb (parser : a Decoder.ParserMonad.t) :
+      (a, Error.t, syn list) SM.Result.t =
+    let open SM.Syntax in
+    let handler (ty, ofs) =
+      let**^ () = on_access () in
+      load ~ignore_borrow ofs ty tag tb
+    in
+    let get_all (size, ofs) =
+      let**^ () = on_access () in
+      get_init_leaves ofs size
+    in
+    Decoder.ParserMonad.parse ~handler ~get_all parser
+
   (* Tree borrow updates *)
 
   let with_tb_access (ofs : Typed.([< T.sint ] t))

--- a/soteria-rust/lib/state/rtree_block.ml
+++ b/soteria-rust/lib/state/rtree_block.ml
@@ -612,11 +612,11 @@ module Make (Borrows : Tree_borrows.M(DecayMap.SM).S) = struct
       tag tb (parser : a Decoder.ParserMonad.t) :
       (a, Error.t, syn list) SM.Result.t =
     let open SM.Syntax in
-    let handler (ty, ofs) =
+    let handler ty ofs =
       let**^ () = on_access () in
       load ~ignore_borrow ofs ty tag tb
     in
-    let get_all (size, ofs) =
+    let get_all size ofs =
       let**^ () = on_access () in
       get_init_leaves ofs size
     in

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -324,6 +324,16 @@ module Make (Borrows : Tree_borrows.T) = struct
         (Fmt.Dump.option (pp_pretty ~ignore_freed:true))
         st]
 
+  let ignore_state x =
+    DecayMap.SM.map
+      (function
+        | Ok (value, _block) -> Ok value
+        | Error (e, _block) -> Error e
+        (* HACK: we add this because we can't lift misses for a part of state
+           that doesn't exist (and misses can't happen here anyways) *)
+        | Missing _ -> L.failwith "impossible : miss")
+      x
+
   let[@inline] with_alloc_kind kind (f : unit -> 'a t) : 'a t =
    fun st -> with_alloc_kind kind (f () st)
 
@@ -378,10 +388,14 @@ module Make (Borrows : Tree_borrows.T) = struct
     in
     lift @@ Value_codec.size_and_align_of_val ~load_vtable ~t ~meta
 
+  (** Checks the given pointer is well-aligned for the given type, possibly
+      reading in the heap to know what the alignment is (e.g. for [&dyn Trait]).
+      Returns the size of the type for that pointer (i.e. taking into account
+      metadata). *)
   and check_ptr_align (ptr : Typed.([< T.sptr_f ] t)) (ty : Types.ty) =
     (* The expected alignment of a dyn pointer is stored inside the VTable *)
     let ptr, meta = Typed.Ptr.split ptr in
-    let** _, exp_align = size_and_align_of_val ty meta in
+    let** size, exp_align = size_and_align_of_val ty meta in
     [%l.debug
       "Checking pointer alignment of %a: expect %a for %a" Sptr.pp ptr Typed.ppa
         exp_align pp_ty ty];
@@ -403,9 +417,9 @@ module Make (Borrows : Tree_borrows.T) = struct
          always be aligned; what matters most is whether it is guaranteed to be
          aligned. *)
       let* address = with_pointers_sym @@ Sptr.decay ptr in
-      if%sure address %@ exp_align ==@ Usize.(0s) then Result.ok ()
+      if%sure address %@ exp_align ==@ Usize.(0s) then Result.ok size
       else Result.error (`MisalignedPointer (exp_align, align, ofs))
-    else Result.ok ()
+    else Result.ok size
 
   and check_non_dangling_untyped (ptr : Typed.([< T.sptr_t ] t)) size =
     let check (ptr : Typed.([< T.sptr_t ] t)) size =
@@ -430,7 +444,7 @@ module Make (Borrows : Tree_borrows.T) = struct
 
   and check_validity ~check_refs ty value =
     let default_check ptr ty =
-      let** () = check_ptr_align ptr ty in
+      let** _size = check_ptr_align ptr ty in
       check_non_dangling ptr ty
     in
     let check_ref =
@@ -450,18 +464,32 @@ module Make (Borrows : Tree_borrows.T) = struct
       Types.ty ->
       (Typed.([> T.any ] t), Error.t, syn list) Result.t =
    fun ?ignore_borrow ?(check_refs = true) ptr ty ->
-    let** () = check_ptr_align ptr ty in
+    let** size = check_ptr_align ptr ty in
     let ptr, meta = Typed.Ptr.split ptr in
     let parser ~offset = Tree_block.Decoder.decode ~meta ~offset ty in
-    let** value = apply_parser ?ignore_borrow ptr parser in
+    let** value =
+      if%sat size ==@ Usize.(0s) then
+        with_pointers
+          (Tree_block.SM.Result.run_with_state ~state:None
+             (Tree_block.apply_parser ~ignore_borrow:true None None
+                (parser ~offset:Usize.(0s)))
+          |> ignore_state)
+      else apply_parser ?ignore_borrow ptr parser
+    in
     [%l.debug "Finished reading rust value %a" Typed.ppa value];
     let++ () = check_validity ~check_refs ty value in
     Typed.as_any value
 
   and load_discriminant (ptr : Typed.([< T.sptr_f ] t)) ty =
-    let** () = check_ptr_align ptr ty in
-    let parser ~offset = Tree_block.Decoder.variant_of_enum ty ~offset in
-    let++ variant_id = apply_parser (Typed.Ptr.ptr_of ptr) parser in
+    let** _size = check_ptr_align ptr ty in
+    let**^ known_variant = Layout.enum_single_variant ty in
+    let++ variant_id =
+      match known_variant with
+      | Some variant -> Result.ok variant
+      | None ->
+          let parser ~offset = Tree_block.Decoder.variant_of_enum ty ~offset in
+          apply_parser (Typed.Ptr.ptr_of ptr) parser
+    in
     let adt = Charon_util.ty_as_adt ty in
     let variants = Crate.as_enum adt in
     let variant = Types.VariantId.nth variants variant_id in
@@ -536,13 +564,12 @@ module Make (Borrows : Tree_borrows.T) = struct
     in
     if Iter.is_empty parts then Result.ok ()
     else
-      let** () = check_ptr_align ptr ty in
+      let** size = check_ptr_align ptr ty in
       (* [%l.debug
        *   "Parsed to parts [%a]"
        *   Fmt.(list ~sep:comma Encoder.pp_cval_info)
        *   parts]; *)
       let* () = log "store" ptr in
-      let**^ size = Layout.size_of ty in
       let ptr = Typed.Ptr.ptr_of ptr in
       let tag = Typed.Ptr.tag_of ptr in
       let@ ofs = with_ptr Write ptr in
@@ -575,12 +602,7 @@ module Make (Borrows : Tree_borrows.T) = struct
             (* next, we read *)
             Tree_block.apply_parser ~ignore_borrow:true None None
             @@ Tree_block.Decoder.decode ~meta:None ~offset:Usize.(0s) to_)
-         |> map (function
-           | Ok (value, _block) -> Ok value
-           | Error (e, _block) -> Error e
-           (* HACK: we add this because we can't lift misses for a part of state
-              that doesn't exist (and misses can't happen here anyways) *)
-           | Missing _ -> L.failwith "impossible : miss"))
+         |> ignore_state)
     in
     let++ () = check_validity ~check_refs:true to_ value in
     (value : Typed.T.any Typed.t :> Typed.([> T.any ] t))
@@ -647,7 +669,7 @@ module Make (Borrows : Tree_borrows.T) = struct
 
     let check_aligned ptr ty =
       let@ () = with_loc_err ~trace:"Requires well-aligned pointer" () in
-      check_ptr_align ptr ty
+      SM.Result.map ignore @@ check_ptr_align ptr ty
 
     let check_non_dangling_untyped (ptr : Typed.([< T.sptr_t ] t)) size =
       let@ () = with_loc_err ~trace:"Dangling check" () in

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -227,30 +227,24 @@ module Make (Borrows : Tree_borrows.T) = struct
       let open SM.Syntax in
       let* () = print_access access ptr in
       let** () =
-        assert_or_error Typed.(not (Typed.Ptr.is_null ptr)) `NullDereference
+        assert_or_error Typed.(not (Ptr.is_null ptr)) `NullDereference
+      in
+      let** () =
+        assert_or_error Typed.(Ptr.has_provenance ptr) `UBDanglingPointer
       in
       let loc, ofs = Typed.Ptr.decompose ptr in
-      let* res =
-        wrap loc
-          (let open Freeable_block_with_meta in
-           let open SM.Syntax in
-           let* block = SM.get_state () in
-           match (alloc_kind block, access) with
-           | Some (Function _), (Read | Write) ->
-               SM.Result.error `AccessedFnPointer
-           | Some ((Const _ | AnonConst | StaticString) as k), Write ->
-               let*^ cur_kind = DecayMap.SM.lift @@ get_alloc_kind () in
-               if cur_kind <> k then SM.Result.error `WriteToReadOnly
-               else Freeable_block_with_meta.wrap @@ Freeable_block.wrap (f ofs)
-           | _ -> Freeable_block_with_meta.wrap @@ Freeable_block.wrap (f ofs))
-      in
-      match (res, Config.get_mode ()) with
-      | (Missing _ as miss), Whole_program ->
-          (* HACK: a miss in WPST means there is a dangling pointer. *)
-          if%sat Typed.not (Typed.Ptr.has_provenance ptr) then
-            Result.error `UBDanglingPointer
-          else return miss
-      | ok_or_err, _ -> return ok_or_err
+      wrap loc
+        (let open Freeable_block_with_meta in
+         let open SM.Syntax in
+         let* block = SM.get_state () in
+         match (alloc_kind block, access) with
+         | Some (Function _), (Read | Write) ->
+             SM.Result.error `AccessedFnPointer
+         | Some ((Const _ | AnonConst | StaticString) as k), Write ->
+             let*^ cur_kind = DecayMap.SM.lift @@ get_alloc_kind () in
+             if cur_kind <> k then SM.Result.error `WriteToReadOnly
+             else wrap @@ Freeable_block.wrap (f ofs)
+         | _ -> wrap @@ Freeable_block.wrap (f ofs))
 
     let is_freed loc =
       wrap loc

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -444,8 +444,8 @@ module Make (Borrows : Tree_borrows.T) = struct
 
   and check_validity ~check_refs ty value =
     let default_check ptr ty =
-      let** _size = check_ptr_align ptr ty in
-      check_non_dangling ptr ty
+      let** size = check_ptr_align ptr ty in
+      check_non_dangling_untyped (Typed.Ptr.ptr_of ptr) size
     in
     let check_ref =
       if (Config.get ()).recursive_validity <> Allow && check_refs then

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -220,17 +220,23 @@ module Make (Borrows : Tree_borrows.T) = struct
         "%a access to the state at pointer %a" pp_access access Typed.ppa ptr];
       [%l.trace "STATE:@\n%a" (Fmt.Dump.option pp) st]
 
-    let with_ptr (access : access) (ptr : Typed.([< T.sptr_t ] t))
+    let check_ptr_deref (ptr : Typed.([< T.sptr_t ] t)) =
+      let open DecayMap.SM in
+      let open Syntax in
+      let** () =
+        assert_or_error Typed.(not (Ptr.is_null ptr)) `NullDereference
+      in
+      assert_or_error Typed.(Ptr.has_provenance ptr) `UBDanglingPointer
+
+    let with_ptr ?(check_ptr = true) (access : access)
+        (ptr : Typed.([< T.sptr_t ] t))
         (f : [< T.sint ] Typed.t -> ('a, 'err, 'fix list) Block.SM.Result.t) :
         ('a, 'err, syn list) SM.Result.t =
       let open SM in
       let open SM.Syntax in
       let* () = print_access access ptr in
-      let** () =
-        assert_or_error Typed.(not (Ptr.is_null ptr)) `NullDereference
-      in
-      let** () =
-        assert_or_error Typed.(Ptr.has_provenance ptr) `UBDanglingPointer
+      let**^ () =
+        if check_ptr then check_ptr_deref ptr else DecayMap.SM.Result.ok ()
       in
       let loc, ofs = Typed.Ptr.decompose ptr in
       wrap loc
@@ -254,12 +260,6 @@ module Make (Borrows : Tree_borrows.T) = struct
          match block with
          | Some { node = Freed; _ } -> SM.Result.ok true
          | _ -> SM.Result.ok false)
-
-    module Decoder = Value_codec.Decoder (struct
-      module SM = SM
-
-      type fix = syn list
-    end)
   end
 
   type t = {
@@ -338,23 +338,19 @@ module Make (Borrows : Tree_borrows.T) = struct
     Error.log_at trace err;
     Error (Error.decorate trace err)
 
+  module Decoder = Value_codec.Decoder (Block)
+
   let apply_parser (type a) ?(ignore_borrow = false) ptr
-      (parser : offset:T.sint Typed.t -> a Heap.Decoder.ParserMonad.t) :
+      (parser : offset:T.sint Typed.t -> a Tree_block.Decoder.ParserMonad.t) :
       (a, Error.t, syn list) Result.t =
     let* () = log "load" ptr in
+    let open Block.SM.Syntax in
     let tag = Typed.Ptr.tag_of ptr in
-    let handler (ty, ofs) =
-      let@ _ofs = Heap.with_ptr Read ptr in
-      Block.with_block_read_tb (Tree_block.load ~ignore_borrow ofs ty tag)
-    in
-    let get_all (size, ofs) =
-      let@ _ofs = Heap.with_ptr Read ptr in
-      Block.with_block (Tree_block.get_init_leaves ofs size)
-    in
-    let offset = Typed.Ptr.ofs ptr in
-    with_heap
-    @@ Heap.Decoder.ParserMonad.parse ~handler ~get_all
-    @@ parser ~offset
+    let@@ () = with_heap in
+    let@ offset = Heap.with_ptr ~check_ptr:false Read ptr in
+    let@ tb = Block.with_block_read_tb in
+    let on_access () = Heap.check_ptr_deref ptr in
+    Tree_block.apply_parser ~on_access ~ignore_borrow tag tb @@ parser ~offset
 
   let with_ptr access ptr f = with_heap @@ Heap.with_ptr access ptr f
 
@@ -456,7 +452,7 @@ module Make (Borrows : Tree_borrows.T) = struct
    fun ?ignore_borrow ?(check_refs = true) ptr ty ->
     let** () = check_ptr_align ptr ty in
     let ptr, meta = Typed.Ptr.split ptr in
-    let parser ~offset = Heap.Decoder.decode ~meta ~offset ty in
+    let parser ~offset = Tree_block.Decoder.decode ~meta ~offset ty in
     let** value = apply_parser ?ignore_borrow ptr parser in
     [%l.debug "Finished reading rust value %a" Typed.ppa value];
     let++ () = check_validity ~check_refs ty value in
@@ -464,7 +460,7 @@ module Make (Borrows : Tree_borrows.T) = struct
 
   and load_discriminant (ptr : Typed.([< T.sptr_f ] t)) ty =
     let** () = check_ptr_align ptr ty in
-    let parser ~offset = Heap.Decoder.variant_of_enum ty ~offset in
+    let parser ~offset = Tree_block.Decoder.variant_of_enum ty ~offset in
     let++ variant_id = apply_parser (Typed.Ptr.ptr_of ptr) parser in
     let adt = Charon_util.ty_as_adt ty in
     let variants = Crate.as_enum adt in
@@ -559,15 +555,6 @@ module Make (Borrows : Tree_borrows.T) = struct
           Result.iter_iter parts ~f:(fun (value, offset, size) ->
               Tree_block.store (offset +!!@ ofs) size value tag tb))
 
-  (** We can't use {!Heap.Decoder} for [transmute], since the transmute happens
-      regardless of the heap's state, so we need to re-instantiate it for tree
-      block instead *)
-  module Tree_block_decoder = Value_codec.Decoder (struct
-    module SM = Tree_block.SM
-
-    type fix = Tree_block.syn list
-  end)
-
   let transmute_raw_inner ~to_ ~size blocks =
     (* a transmute is just a write of one type with a read of another type; we
        provide a function to do it that avoids allocating, checking alignment
@@ -580,19 +567,14 @@ module Make (Borrows : Tree_borrows.T) = struct
          Tree_block.SM.Result.run_with_state ~state:(Some block)
            (let open Tree_block.SM in
             let open Syntax in
-            let open Tree_block_decoder in
             (* first, we write *)
             let** () =
               Result.iter_iter blocks ~f:(fun (value, offset, size) ->
                   Tree_block.store offset size value None None)
             in
             (* next, we read *)
-            let handler (ty, ofs) =
-              Tree_block.load ~ignore_borrow:true ofs ty None None
-            in
-            let get_all (size, ofs) = Tree_block.get_init_leaves ofs size in
-            ParserMonad.parse ~handler ~get_all
-            @@ decode ~meta:None ~offset:Usize.(0s) to_)
+            Tree_block.apply_parser ~ignore_borrow:true None None
+            @@ Tree_block.Decoder.decode ~meta:None ~offset:Usize.(0s) to_)
          |> map (function
            | Ok (value, _block) -> Ok value
            | Error (e, _block) -> Error e

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -121,18 +121,17 @@ struct
   module ParserMonad = struct
     open State_tys
 
-    type query = Types.ty * Typed.(T.sint t)
     type 'a res = ('a, Error.t, syn list) SM.Result.t
 
-    (* size * offset *)
-    type get_all_query = Typed.(T.nonzero t) * Typed.(T.sint t)
-
-    (* The following is just query -> (rust_val, 'err, 'fix) StateResult.t where
-       StateResult = StateT (Result), but I need StateT1of3 urgh. *)
-    type handler = query -> Typed.T.any Typed.t res
+    (* The following is just [ty -> offset -> (rust_val, 'err, 'fix)
+       StateResult.t] where StateResult = StateT (Result), but I need StateT1of3
+       urgh. *)
+    type handler = Types.ty -> Typed.(T.sint t) -> Typed.T.any Typed.t res
 
     type get_all_handler =
-      get_all_query -> Typed.(T.any t * T.sint t * T.nonzero t) list res
+      Typed.(T.nonzero t) ->
+      Typed.(T.sint t) ->
+      Typed.(T.any t * T.sint t * T.nonzero t) list res
 
     (* A parser monad is an object such that, given a query handler with state
        ['state], returns a state monad-ish for that state which may fail or
@@ -167,10 +166,8 @@ struct
       let++ x = m handler get_all in
       f x
 
-    let query (q : query) : 'a t = fun (handler : handler) _ -> handler q
-
-    let get_all (q : get_all_query) : 'a t =
-     fun _ get_all state -> get_all q state
+    let query ty ofs : 'a t = fun (handler : handler) _ -> handler ty ofs
+    let get_all size ofs : 'a t = fun _ get_all -> get_all size ofs
 
     let[@inline] lift (m : 'a DecayMap.SM.t) : 'a t =
       let open SM.Syntax in
@@ -229,10 +226,10 @@ struct
           let* tag =
             if match tag_ty with TInt Isize | TUInt Usize -> true | _ -> false
             then
-              let+ v = query (unit_ptr, offset +!!@ tag_ofs) in
+              let+ v = query unit_ptr (offset +!!@ tag_ofs) in
               `Ptr (Typed.Ptr.ptr_of (Typed.cast_ptr_f v))
             else
-              let+ v = query (TLiteral tag_ty, offset +!!@ tag_ofs) in
+              let+ v = query (TLiteral tag_ty) (offset +!!@ tag_ofs) in
               `Int (Typed.cast_lit tag_ty v)
           in
           let pp_tag ft = function
@@ -305,13 +302,13 @@ struct
              https://github.com/rust-lang/unsafe-code-guidelines/issues/518 And
              a proper implementation is here:
              https://github.com/minirust/minirust/blob/master/tooling/minimize/src/chunks.rs *)
-          let+ blocks = get_all (Typed.cast_nonzero layout.size, offset) in
+          let+ blocks = get_all (Typed.cast_nonzero layout.size) offset in
           Typed.Adt.mk_union adt blocks
     | Primitive, TFnDef _ -> ok Typed.Adt.unit
     | Primitive, TVar (Free id) ->
         if%sat layout.size ==@ Usize.(0s) then ok (Typed.Adt.mk_poly id)
-        else query (ty, offset)
-    | Primitive, _ -> query (ty, offset)
+        else query ty offset
+    | Primitive, _ -> query ty offset
     | Array { is_ptr = true; _ }, _ ->
         let+ vs = iter (iter_fields ?meta layout ty) offset in
         let ptr, meta =

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -115,14 +115,14 @@ module Decoder (State_tys : sig
        and type 'a Symex.Value.ty = 'a Typed.ty
        and type Symex.Value.sbool = Typed.sbool
 
-  type fix
+  type syn
 end) =
 struct
   module ParserMonad = struct
     open State_tys
 
     type query = Types.ty * Typed.(T.sint t)
-    type 'a res = ('a, Error.t, fix) SM.Result.t
+    type 'a res = ('a, Error.t, syn list) SM.Result.t
 
     (* size * offset *)
     type get_all_query = Typed.(T.nonzero t) * Typed.(T.sint t)

--- a/soteria-rust/test/cram/simple.t/dangling_ptrs.rs
+++ b/soteria-rust/test/cram/simple.t/dangling_ptrs.rs
@@ -1,8 +1,60 @@
+#![feature(never_type)]
+
+fn edge_cases<T: Default>(check: fn(*mut T)) {
+    // reading a ZST through a null pointer is allowed
+    check(std::ptr::null_mut());
+
+    // through a dangling pointer too
+    check(11 as *mut T);
+
+    // through a freed-allocation
+    check(unsafe {
+        let b = Box::new(42);
+        let ptr = Box::into_raw(b) as *mut T;
+        let _ = Box::from_raw(ptr as *mut i32); // free the allocation
+        ptr
+    });
+
+    // through a function pointer
+    check((|| {}) as fn() as *mut T);
+
+    // writing through a const address
+    let const_addr = &mut 42 as *mut i32 as *mut T;
+    unsafe { *const_addr = T::default() };
+}
+
 #[soteria::test]
-fn null_ptr_zst() {
-    let ptr: *const () = std::ptr::null();
-    // this shouldn't fail; reading a ZST through a null pointer is allowed
-    let zst: () = unsafe { *ptr };
+fn access_zst() {
+    edge_cases(|ptr: *mut ()| {
+        let _zst = unsafe { *ptr };
+        unsafe { *ptr = () };
+    });
+}
+
+#[soteria::test]
+fn get_discriminant_zst() {
+    #[derive(Default, Clone, Copy)]
+    enum MyZst {
+        #[default]
+        A,
+    }
+
+    edge_cases(|ptr: *mut MyZst| match unsafe { *ptr } {
+        MyZst::A => {}
+    });
+
+    #[derive(Default, Clone, Copy)]
+    enum ZstFromUninhabited {
+        #[default]
+        A,
+        #[allow(dead_code)]
+        B(!),
+    }
+
+    edge_cases(|ptr: *mut ZstFromUninhabited| match unsafe { *ptr } {
+        ZstFromUninhabited::A => {}
+        ZstFromUninhabited::B(_) => unreachable!(),
+    });
 }
 
 #[soteria::test]

--- a/soteria-rust/test/cram/simple.t/run.t
+++ b/soteria-rust/test/cram/simple.t/run.t
@@ -202,29 +202,33 @@ Test transmutations keeping the bit-patterns the same
 Test null and dangling pointers
   $ soteria-rust exec dangling_ptrs.rs
   Compiling... done in <time>
-  => Running dangling_ptrs::null_ptr_zst...
-  note: dangling_ptrs::null_ptr_zst: done in <time>, ran 1 branch
+  => Running dangling_ptrs::access_zst...
+  note: dangling_ptrs::access_zst: done in <time>, ran 1 branch
+  PC 1: empty
+  
+  => Running dangling_ptrs::get_discriminant_zst...
+  note: dangling_ptrs::get_discriminant_zst: done in <time>, ran 1 branch
   PC 1: empty
   
   => Running dangling_ptrs::null_ptr_not_zst...
   error: dangling_ptrs::null_ptr_not_zst: found issues in <time>, errors in 1 branch (out of 1)
   error: Null dereference in dangling_ptrs::null_ptr_not_zst
-      --> $TESTCASE_ROOT/dangling_ptrs.rs:11:30
-    9 |  fn null_ptr_not_zst() {
+      --> $TESTCASE_ROOT/dangling_ptrs.rs:63:30
+   61 |  fn null_ptr_not_zst() {
       |  --------------------- 1: Entry point
-   10 |      let ptr: *const u32 = std::ptr::null();
-   11 |      let _val: u32 = unsafe { *ptr };
+   62 |      let ptr: *const u32 = std::ptr::null();
+   63 |      let _val: u32 = unsafe { *ptr };
       |                               ^^^^ Memory load
   PC 1: empty
   
   => Running dangling_ptrs::dangling_ptr_not_zst...
   error: dangling_ptrs::dangling_ptr_not_zst: found issues in <time>, errors in 1 branch (out of 1)
   bug: Dangling pointer in dangling_ptrs::dangling_ptr_not_zst
-      --> $TESTCASE_ROOT/dangling_ptrs.rs:17:29
-   15 |  fn dangling_ptr_not_zst() {
+      --> $TESTCASE_ROOT/dangling_ptrs.rs:69:29
+   67 |  fn dangling_ptr_not_zst() {
       |  ------------------------- 1: Entry point
-   16 |      let ptr: *const u8 = 0xdeadbeef as *const u8;
-   17 |      let _val: u8 = unsafe { *ptr };
+   68 |      let ptr: *const u8 = 0xdeadbeef as *const u8;
+   69 |      let _val: u8 = unsafe { *ptr };
       |                              ^^^^ Memory load
   PC 1: empty
   


### PR DESCRIPTION
- Removed the hack in `with_ptr` that would catch misses and convert them to dangling pointer errors if the pointer has no provenance; we now instead properly check whether the pointer is null (null deref) or has no provenance (dangling pointer), meaning `Rtree_block` shouldn't miss anymore
- Move the decoder handling logic inside `Rtree_block`, to avoid having to go through `Heap.with_ptr` (PMap access) + `Block.with_block` on any memory access. This is a nice 10% improvement on a test I had that used a sysroot!
- Made sure no-op heap accesses (e.g. reading a ZST, getting the discriminant of an enum with a known discriminant) never go through the heap

the perf results are a bit mid but i know for sure that for any heap access that requires >3 tree block operations, this is better