### PR TITLE
Add sums to `[@@deriving sym_states]`

### DIFF
--- a/soteria-c/lib/block.ml
+++ b/soteria-c/lib/block.ml
@@ -5,12 +5,15 @@ include With_origin (Freeable_ctree_block)
 let pp_pretty ft t =
   pp' ~inner:(Freeable_ctree_block.pp' ~inner:Ctree_block.pp_pretty) ft t
 
-let is_freed (t : ('a Soteria.Sym_states.Freeable.freeable, 'b) with_info) =
-  match t.node with Freed -> true | _ -> false
+let is_freed (t : (Freeable_ctree_block.t, 'b) with_info) =
+  match t.node with Freed () -> true | _ -> false
+
+let is_freed_syn (t : (Freeable_ctree_block.syn, 'b) with_info) =
+  match t.node with Ser_Freed () -> true | _ -> false
 
 let alloc ?loc ~zeroed size =
   {
-    node = Soteria.Sym_states.Freeable.Alive (Ctree_block.alloc ~zeroed size);
+    node = Freeable_ctree_block.Alive (Ctree_block.alloc ~zeroed size);
     info = loc;
   }
 

--- a/soteria-c/lib/state.ml
+++ b/soteria-c/lib/state.ml
@@ -205,14 +205,17 @@ let produce_basic_val loc offset ty v t =
   let*^ len = Layout.size_of_s ty in
   let len = Typed.Expr.of_value len in
   let block : Block.syn =
-    { node = Alive (MemVal { offset; len; v = SInit (v, ty) }); info = None }
+    {
+      node = Ser_Alive (MemVal { offset; len; v = SInit (v, ty) });
+      info = None;
+    }
   in
   let syn : syn = Ser_heap (loc, block) in
   produce syn t
 
 let produce_padding loc ~offset ~len =
   let block : Block.syn =
-    { node = Alive (MemVal { offset; len; v = SUninit }); info = None }
+    { node = Ser_Alive (MemVal { offset; len; v = SUninit }); info = None }
   in
   let serialized : syn = Ser_heap (loc, block) in
   produce serialized

--- a/soteria-c/lib/summary.ml
+++ b/soteria-c/lib/summary.ml
@@ -110,7 +110,7 @@ let filter_serialized_state relevant_vars (state : State.syn list) =
           else
             (* If the block is not freed, we record where the object was
                allocated *)
-            let leaked = not (Block.is_freed b) in
+            let leaked = not (Block.is_freed_syn b) in
             if leaked then Leak_set.add leak_origins b.info;
             [%l.trace
               "Filtering out unreachable location: %a which %a." Expr.pp loc

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -180,7 +180,7 @@ module Make (Borrows : Tree_borrows.T) = struct
     type 'a raw = ('a Soteria.Sym_states.Freeable.freeable, Meta.t) with_info
 
     let[@inline] is_leakable : 'a. 'a raw -> bool = function
-      | { node = Alive _; info = Some { kind = Heap; _ } } -> true
+      | { node = Ser_Alive _; info = Some { kind = Heap; _ } } -> true
       | _ -> false
 
     let[@inline] trace : 'a. 'a raw -> Trace.t option = function
@@ -258,7 +258,7 @@ module Make (Borrows : Tree_borrows.T) = struct
          let open SM.Syntax in
          let* block = SM.get_state () in
          match block with
-         | Some { node = Freed; _ } -> SM.Result.ok true
+         | Some { node = Freed (); _ } -> SM.Result.ok true
          | _ -> SM.Result.ok false)
   end
 
@@ -300,7 +300,7 @@ module Make (Borrows : Tree_borrows.T) = struct
   let pp_pretty ~ignore_freed ft { heap; _ } =
     let (ignore : 'a * Freeable_block_with_meta.t -> bool) =
       if ignore_freed then function
-        | _, { node = Freed; _ } -> true | _ -> false
+        | _, { node = Freed (); _ } -> true | _ -> false
       else fun _ -> false
     in
     match heap with

--- a/soteria/lib/sym_states/excl.ml
+++ b/soteria/lib/sym_states/excl.ml
@@ -1,3 +1,8 @@
+open Soteria_std
+open Logs.Import
+
+(** Create an exclusively owned state from a semantic value type. This is the
+    most simple of state models: the value is either owned or not owned. *)
 module Make (Symex : Symex.Base) (E : Data.Abstr.M(Symex).S_with_syn) = struct
   type t = E.t [@@deriving show { with_path = false }]
   type syn = E.syn [@@deriving show { with_path = false }]
@@ -50,4 +55,37 @@ module Make (Symex : Symex.Base) (E : Data.Abstr.M(Symex).S_with_syn) = struct
     | Some x ->
         let+ () = E.learn_eq s x in
         None
+end
+
+(** Create an exclusively owned state from a concrete value type. This is the
+    most simple of state models: the value is either owned or not owned. The
+    syntactic value type is the same as the semantic value type, and
+    substitutions are the identity. We only require
+    {{!Data.Abstr.M.S.fresh}[fresh]} to be implemented. *)
+module Make_concrete
+    (Symex : Symex.Base)
+    (E : sig
+      type t [@@mixins Sigs.Eq]
+
+      include Data.Abstr.M(Symex).S with type t := t
+    end) =
+struct
+  include
+    Make
+      (Symex)
+      (struct
+        include E
+
+        type syn = t [@@deriving show { with_path = false }]
+
+        let to_syn x = x
+        let fresh = E.fresh
+        let subst _ x = x
+        let exprs_syn _ = []
+
+        let learn_eq syn t =
+          let open Symex in
+          if E.equal syn t then Consumer.ok ()
+          else Consumer.lfail (Value.of_bool false)
+      end)
 end

--- a/soteria/lib/sym_states/freeable.ml
+++ b/soteria/lib/sym_states/freeable.ml
@@ -1,12 +1,10 @@
-(* TODO: Build this with the Sum transformer and `Excl(Freed)` *)
-
 open Soteria_std
 
-type 'a freeable = Freed | Alive of 'a
+type 'a freeable = Ser_Freed of unit | Ser_Alive of 'a
 
 let pp_freeable pp_a ft = function
-  | Freed -> Fmt.pf ft "Freed"
-  | Alive a -> pp_a ft a
+  | Ser_Freed () -> Fmt.pf ft "Freed"
+  | Ser_Alive a -> pp_a ft a
 
 module Make
     (Symex : Symex.Base)
@@ -20,29 +18,26 @@ module Make
       val assert_exclusively_owned : unit -> (unit, 'err, syn list) SM.Result.t
     end) =
 struct
-  type t = I.t freeable [@@deriving show { with_path = false }]
+  module Freed_syn = struct
+    type t = unit [@@deriving show { with_path = false }, eq]
 
-  let pp' ?(inner = I.pp) = pp_freeable inner
-  let pp ft t = pp' ft t
+    let fresh () = Symex.return ()
+  end
 
-  type syn = I.syn freeable [@@deriving show { with_path = false }]
+  module Freed = Excl.Make_concrete (Symex) (Freed_syn)
 
-  module SM =
-    State_monad.Make
-      (Symex)
-      (struct
-        type nonrec t = t option
-      end)
+  type t = Freed of Freed.t | Alive of I.t
+  [@@deriving sym_state { inside_soteria; symex = Symex; syn = I.syn freeable }]
 
-  let lift_fix fix = Alive fix
+  let pp' ?(inner = I.pp) ft = function
+    | Freed () -> Fmt.pf ft "Freed"
+    | Alive a -> inner ft a
+
+  let pp = pp' ?inner:None
+  let pp_syn = pp_freeable I.pp_syn
+  let lift_fix fix = Ser_Alive fix
   let lift_fix_r x = Compo_res.map_missing (List.map lift_fix) x
   let lift_fix_c x = Symex.Consumer.map_missing (List.map lift_fix) x
-
-  let to_syn = function
-    | Freed -> [ Freed ]
-    | Alive a -> List.map (fun x -> Alive x) (I.to_syn a)
-
-  let ins_outs = function Freed -> ([], []) | Alive s -> I.ins_outs s
 
   open SM
   open SM.Syntax
@@ -52,7 +47,7 @@ struct
     match st with
     | None -> Result.ok None
     | Some (Alive s) -> Result.ok (Some s)
-    | Some Freed -> Result.error `UseAfterFree
+    | Some (Freed ()) -> Result.error `UseAfterFree
 
   (* [f] must be a "symex state monad" *)
   let wrap (f : ('a, 'err, I.syn list) I.SM.Result.t) :
@@ -64,40 +59,5 @@ struct
 
   let free () : (unit, 'err, syn list) SM.Result.t =
     let** () = wrap (I.assert_exclusively_owned ()) in
-    SM.Result.set_state (Some Freed)
-
-  let produce (syn : syn) st : st Symex.Producer.t =
-    let open Symex.Producer in
-    let open Symex.Producer.Syntax in
-    match syn with
-    | Freed -> (
-        match st with None -> return (Some Freed) | Some _ -> vanish ())
-    | Alive ser ->
-        let* ist =
-          match st with
-          | None -> return None
-          | Some (Alive s) -> return (Some s)
-          | Some Freed -> vanish ()
-        in
-        let+ ist' = I.produce ser ist in
-        Option.map (fun s -> Alive s) ist'
-
-  let consume (syn : syn) (st : st) : (st, syn list) Symex.Consumer.t =
-    let open Symex.Consumer in
-    let open Symex.Consumer.Syntax in
-    match syn with
-    | Freed -> (
-        match st with
-        | None -> miss [ [ Freed ] ]
-        | Some Freed -> ok None
-        | Some (Alive _) -> lfail (Value.of_bool false))
-    | Alive ser -> (
-        let* ist =
-          match st with
-          | None -> ok None
-          | Some (Alive ist) -> ok (Some ist)
-          | Some Freed -> lfail (Value.of_bool false)
-        in
-        let+ ist = lift_fix_c (I.consume ser ist) in
-        match ist with Some ist -> Some (Alive ist) | None -> None)
+    SM.Result.set_state (Some (Freed ()))
 end

--- a/soteria/ppx/sym_state.ml
+++ b/soteria/ppx/sym_state.ml
@@ -13,6 +13,25 @@ module Names = struct
   let context_attr = "soteria." ^ ppx ^ ".context"
 end
 
+module Config = struct
+  type _ Effect.t +=
+    | Get_syn_ty : core_type option Effect.t
+    | Get_symex_module : Longident.t Effect.t
+    | Get_inside_soteria : bool Effect.t
+
+  let get_syn_ty () = Effect.perform Get_syn_ty
+  let get_symex_module () = Effect.perform Get_symex_module
+  let get_inside_soteria () = Effect.perform Get_inside_soteria
+
+  let with_config ~(syn_ty : core_type option) ~(symex_module : Longident.t)
+      ~(inside_soteria : bool) f =
+    let open Effect.Deep in
+    try f () with
+    | effect Get_syn_ty, k -> continue k syn_ty
+    | effect Get_symex_module, k -> continue k symex_module
+    | effect Get_inside_soteria, k -> continue k inside_soteria
+end
+
 let record_of_names ?base names =
   pexp_record (List.map (fun n -> (lident n, evar n)) names) base
 
@@ -135,16 +154,36 @@ let mk_field ld =
   in
   { name = ld.pld_name.txt; kind; loc = ld.pld_loc }
 
+let parse_mod_t (ct : core_type) =
+  let@ _ = with_loc ct.ptyp_loc in
+  match ct.ptyp_desc with
+  | Ptyp_constr ({ txt = Ldot (path, "t"); _ }, []) -> path
+  | _ -> err "sum constructors must carry a single <Module>.t argument"
+
+(** A sum constructor [Foo of <Module>.t] becomes a managed field named after
+    the constructor. Context and ignored attributes are record-only. *)
+let mk_variant_field (cd : constructor_declaration) =
+  let@ loc = with_loc cd.pcd_loc in
+  let sym_state =
+    match cd.pcd_args with
+    | Pcstr_tuple [ ct ] -> parse_mod_t ct
+    | _ -> err "sum constructors must carry a single <Module>.t argument"
+  in
+  { name = cd.pcd_name.txt; kind = Managed { sym_state; context = None }; loc }
+
+(** A record models a product memory model (all fields owned together); a
+    variant models a sum memory model (exactly one variant active at a time). *)
+type shape = Record of field list | Variant of field list
+
 let fields_of_td_exn (td : type_declaration) =
   let@ _ = with_loc td.ptype_loc in
   if td.ptype_name.txt <> "t" then
     err ~loc:td.ptype_name.loc "only supports type named 't'";
-  let labels =
-    match td.ptype_kind with
-    | Ptype_record labels -> labels
-    | _ -> err "only supports record types"
-  in
-  labels |> List.map mk_field |> Attributes.validate
+  match td.ptype_kind with
+  | Ptype_record labels ->
+      Record (labels |> List.map mk_field |> Attributes.validate)
+  | Ptype_variant ctors -> Variant (List.map mk_variant_field ctors)
+  | _ -> err "only supports record or variant types"
 
 (** Folds over fields, applying f to each field and joining with join, with
     empty as the base case. *)
@@ -153,14 +192,28 @@ let fold_fields ~empty ~f ~join fields =
   | [] -> empty
   | hd :: tl -> List.fold_left (fun acc field -> join acc (f field)) (f hd) tl
 
+(** The module the syn constructors live in, when a parameterised manifest puts
+    them in another module. *)
+let syn_ctor_prefix (manifest : core_type option) : Longident.t option =
+  match manifest with
+  | Some { ptyp_desc = Ptyp_constr ({ txt = Ldot (m, _); _ }, _ :: _); _ } ->
+      Some m
+  | _ -> None
+
+(** The longident of a field Foo's syn constructor, qualified if needed. *)
+let syn_ctor_lident name =
+  match syn_ctor_prefix @@ Config.get_syn_ty () with
+  | None -> lident (Names.syn name)
+  | Some prefix -> wloc (Ldot (prefix, Names.syn name))
+
 (** For a field Foo, creates pattern [Ser_foo(v)] *)
 let ppat_field field =
   let loc = get_loc () in
-  ppat_construct (lident (Names.syn field.name)) (Some [%pat? v])
+  ppat_construct (syn_ctor_lident field.name) (Some [%pat? v])
 
 (** For a field Foo and expression e, creates expression [Ser_foo(e)] *)
 let constr_field field expr =
-  pexp_construct (lident (Names.syn field.name)) (Some expr)
+  pexp_construct (syn_ctor_lident field.name) (Some expr)
 
 let match_on_syn fields f e =
   let loc = get_loc () in
@@ -179,22 +232,28 @@ let match_on_syn fields f e =
   in
   pexp_match e (cases @ [ irrefutable ])
 
-let syn_type_item (syn_ty : longident option) fields =
+let syn_type_item fields =
   let syn_ctor_decl (field, { sym_state; _ }) =
     let arg_ty = ptyp_constr_dot sym_state "syn" [] in
     constructor_declaration ~name:(Names.syn field.name)
       ~args:(Pcstr_tuple [ arg_ty ]) ~res:None
   in
   let fields = managed_fields fields in
-  let manifest : core_type option =
-    match syn_ty with
-    | Some ty -> Some (ptyp_constr (wloc ty) [])
-    | None -> None
+  let manifest = Config.get_syn_ty () in
+  let kind =
+    match manifest with
+    | Some { ptyp_desc = Ptyp_constr (_, _ :: _); _ } ->
+        (* A parameterised manifest (e.g. [I.syn freeable_syn]) rebinds a type
+           constructor that has type parameters, but [syn] has none;
+           re-declaring its representation would be an arity mismatch. We alias
+           it transparently instead — the constructors come from the
+           manifest. *)
+        Ptype_abstract
+    | _ -> Ptype_variant (List.map syn_ctor_decl fields)
   in
   let td =
-    type_declaration ~name:"syn" ~params:[] ~cstrs:[]
-      ~kind:(Ptype_variant (List.map syn_ctor_decl fields))
-      ~private_:Public ~manifest
+    type_declaration ~name:"syn" ~params:[] ~cstrs:[] ~kind ~private_:Public
+      ~manifest
   in
   pstr_type Recursive [ td ]
 
@@ -305,13 +364,18 @@ let to_opt_item ~loc fields =
 
 let empty_item ~loc = [%stri let empty = None]
 
-let sm_item ~loc symex_module =
-  let symex_module = pmod_ident (wloc symex_module) in
+let sm_item ~loc =
+  (* When the PPX is used inside Soteria itself, [Soteria.Sym_states] is not in
+     scope; the modules must be referred to directly (e.g. [Sym_states]). *)
+  let make =
+    pmod_ident
+      (if Config.get_inside_soteria () then liddots' [ "State_monad"; "Make" ]
+       else liddots' [ "Soteria"; "Sym_states"; "State_monad"; "Make" ])
+  in
+  let symex_module = pmod_ident (wloc (Config.get_symex_module ())) in
   [%stri
     module SM =
-      Soteria.Sym_states.State_monad.Make
-        ([%m
-        symex_module])
+      [%m make] ([%m symex_module])
         (struct
           type nonrec t = t option
         end)]
@@ -585,14 +649,128 @@ let consume_item ~loc fields =
         let st = of_opt st in
         [%e mk_cons_prod_match ~loc ~kind:`Consume fields]]
 
-let make_impl ~loc ~symex_module ~syn_ty (td : type_declaration) =
-  let@ loc = with_loc loc in
-  let fields = fields_of_td_exn td in
+(** For a variant Foo, pattern [Foo v] over the (unwrapped) state. *)
+let ppat_variant field arg = ppat_construct (lident field.name) (Some arg)
+
+let pp_variant_item ~loc fields =
+  let mk_case (field, { sym_state; _ }) =
+    let lhs = ppat_variant field [%pat? v] in
+    let rhs =
+      [%expr
+        Format.fprintf fmt "@[<2>%s@ " [%e estring field.name];
+        [%e pexp_ident_dot sym_state "pp"] fmt v;
+        Format.fprintf fmt "@]"]
+    in
+    case ~lhs ~guard:None ~rhs
+  in
+  [%stri
+    let pp fmt x =
+      [%e pexp_match [%expr x] (List.map mk_case (managed_fields fields))]]
+
+let to_syn_variant_item ~loc fields =
+  let mk_case (field, { sym_state; _ }) =
+    let lhs = ppat_variant field [%pat? x] in
+    let rhs =
+      [%expr
+        List.map
+          (fun v -> [%e constr_field field [%expr v]])
+          ([%e pexp_ident_dot sym_state "to_syn"] x)]
+    in
+    case ~lhs ~guard:None ~rhs
+  in
+  [%stri
+    let to_syn (st : t) : syn list =
+      [%e pexp_match [%expr st] (List.map mk_case (managed_fields fields))]]
+
+let mk_variant_dispatch ~loc ~kind fields =
+  (*
+   * The variant stores a bare [Module.t], but the inner produce/consume work on
+   * [Module.t option] (its own empty state), so we wrap/unwrap around the call:
+   *
+   * match syn with
+   * | Ser_foo v ->
+   *     let* inner =
+   *       match st with
+   *       | None -> return None
+   *       | Some (Foo x) -> return (Some x)
+   *       | Some (Bar _) -> vanish ()
+   *     in
+   *     let+ inner' = Module.<produce/consume> v inner in
+   *     (match inner' with None -> None | Some y -> Some (Foo y))
+   *)
+  let fn_name =
+    match kind with `Produce -> "produce" | `Consume -> "consume"
+  in
+  let pure e =
+    match kind with
+    | `Produce -> [%expr return [%e e]]
+    | `Consume -> [%expr ok [%e e]]
+  in
+  let incompatible =
+    match kind with
+    | `Produce -> [%expr vanish ()]
+    | `Consume -> [%expr lfail (SM.Symex.Value.of_bool false)]
+  in
+  let mk_case field { sym_state; _ } =
+    let other_cases =
+      managed_fields fields
+      |> List.filter_map (fun (other, _) ->
+          if other.name = field.name then None
+          else
+            Some
+              (case
+                 ~lhs:[%pat? Some [%p ppat_variant other [%pat? _]]]
+                 ~guard:None ~rhs:incompatible))
+    in
+    let st_match =
+      pexp_match [%expr st]
+        (case ~lhs:[%pat? None] ~guard:None ~rhs:(pure [%expr None])
+        :: case
+             ~lhs:[%pat? Some [%p ppat_variant field [%pat? x]]]
+             ~guard:None
+             ~rhs:(pure [%expr Some x])
+        :: other_cases)
+    in
+    let call = [%expr [%e pexp_ident_dot sym_state fn_name] v inner] in
+    let call =
+      match kind with
+      | `Produce -> call
+      | `Consume ->
+          let lift_fixes = evar (Names.lift_fixes field.name) in
+          [%expr
+            let+? fixes = [%e call] in
+            [%e lift_fixes] fixes]
+    in
+    [%expr
+      let* inner = [%e st_match] in
+      let+ inner' = [%e call] in
+      match inner' with
+      | None -> None
+      | Some y -> Some [%e pexp_construct (lident field.name) (Some [%expr y])]]
+  in
+  match_on_syn fields mk_case [%expr syn]
+
+let produce_variant_item ~loc fields =
+  [%stri
+    let produce (syn : syn) (st : t option) : t option SM.Symex.Producer.t =
+      let open SM.Symex.Producer in
+      let open SM.Symex.Producer.Syntax in
+      [%e mk_variant_dispatch ~loc ~kind:`Produce fields]]
+
+let consume_variant_item ~loc fields =
+  [%stri
+    let consume (syn : syn) (st : t option) :
+        (t option, syn list) SM.Symex.Consumer.t =
+      let open SM.Symex.Consumer in
+      let open SM.Symex.Consumer.Syntax in
+      [%e mk_variant_dispatch ~loc ~kind:`Consume fields]]
+
+let make_record_impl ~loc fields =
   [
-    sm_item ~loc symex_module;
+    sm_item ~loc;
     pp_item ~loc fields;
     show_item ~loc;
-    syn_type_item syn_ty fields;
+    syn_type_item fields;
     pp_syn_item ~loc fields;
     show_syn_item ~loc;
     of_opt_item ~loc fields;
@@ -606,26 +784,73 @@ let make_impl ~loc ~symex_module ~syn_ty (td : type_declaration) =
   @ List.map with_field_item (managed_fields fields)
   @ [ produce_item ~loc fields; consume_item ~loc fields ]
 
-let str_type_decl ~loc ~path:_ (_rec, tds) symex_module syn_ty =
+let make_variant_impl ~loc fields =
+  [
+    sm_item ~loc;
+    pp_variant_item ~loc fields;
+    show_item ~loc;
+    syn_type_item fields;
+    pp_syn_item ~loc fields;
+    show_syn_item ~loc;
+    empty_item ~loc;
+    to_syn_variant_item ~loc fields;
+    ins_outs_item ~loc fields;
+  ]
+  @ List.map lift_syn_fix_item (managed_fields fields)
+  @ [ produce_variant_item ~loc fields; consume_variant_item ~loc fields ]
+
+let make_impl ~loc (td : type_declaration) =
+  let@ loc = with_loc loc in
+  match fields_of_td_exn td with
+  | Record fields -> make_record_impl ~loc fields
+  | Variant fields -> make_variant_impl ~loc fields
+
+(* Convert a deriver payload expressions from the [syn] argument into a core
+   type. *)
+let rec core_type_of_expr (e : expression) : core_type =
+  let@ _ = with_loc e.pexp_loc in
+  match e.pexp_desc with
+  | Pexp_ident lid -> ptyp_constr lid []
+  | Pexp_apply (params, (_ :: _ as constrs)) ->
+      let constr_lid = function
+        | _, { pexp_desc = Pexp_ident lid; _ } -> lid
+        | _ -> err "syn expects a type, e.g. `Foo.t` or `I.syn freeable_syn`"
+      in
+      let init_params =
+        match params.pexp_desc with
+        | Pexp_tuple es -> List.map core_type_of_expr es
+        | _ -> [ core_type_of_expr params ]
+      in
+      let first, rest =
+        match List.map constr_lid constrs with
+        | c :: cs -> (c, cs)
+        | [] -> assert false
+      in
+      List.fold_left
+        (fun acc c -> ptyp_constr c [ acc ])
+        (ptyp_constr first init_params)
+        rest
+  | _ -> err "syn expects a type, e.g. `Foo.t` or `I.syn freeable_syn`"
+
+let str_type_decl ~loc ~path:_ (_rec, tds) symex_module syn_ty inside_soteria =
   let@ _ = with_loc loc in
   let symex_module =
     match symex_module with
     | Some { pexp_desc = Pexp_construct ({ txt; _ }, None); _ } -> txt
     | _ -> err "expected { symex = <Module> }"
   in
-  let syn_ty =
-    match syn_ty with
-    | Some { pexp_desc = Pexp_ident { txt; _ }; _ } -> Some txt
-    | None -> None
-    | _ -> err "expected { syn_ty = <ty> }"
-  in
+  let syn_ty = Option.map core_type_of_expr syn_ty in
+  let@ () = Config.with_config ~syn_ty ~symex_module ~inside_soteria in
   match tds with
-  | [ td ] -> make_impl ~loc ~symex_module ~syn_ty td
+  | [ td ] -> make_impl ~loc td
   | _ -> err "expects exactly one type declaration"
 
 let register () =
   let symex_arg = Deriving.Args.arg "symex" Ast_pattern.__ in
   let syn_ty_arg = Deriving.Args.arg "syn" Ast_pattern.__ in
-  let str_args = Deriving.Args.(empty +> symex_arg +> syn_ty_arg) in
+  let inside_soteria_arg = Deriving.Args.flag "inside_soteria" in
+  let str_args =
+    Deriving.Args.(empty +> symex_arg +> syn_ty_arg +> inside_soteria_arg)
+  in
   let str = Deriving.Generator.make str_args str_type_decl in
   Deriving.add Names.ppx ~str_type_decl:str |> Deriving.ignore

--- a/soteria/ppx/util.ml
+++ b/soteria/ppx/util.ml
@@ -59,6 +59,7 @@ module LocCtx = struct
   let liddots base path =
     wloc @@ List.fold_left (fun acc name -> Ldot (acc, name)) base path
 
+  let liddots' path = liddots (Lident (List.hd path)) (List.tl path)
   let pexp_ident_dot base name = pexp_ident (liddot base name)
   let pexp_ident_dots base name = pexp_ident (liddots base name)
 

--- a/soteria/tests/ppx/dune
+++ b/soteria/tests/ppx/dune
@@ -10,6 +10,10 @@
   ./test.sh
   ./sym_state/prelude.ml
   ./sym_state/simple.ml
+  ./sym_state/sum.ml
+  ./sym_state/sum_single.ml
+  ./sym_state/invalid_ctor_arg.ml
+  ./sym_state/inside_soteria.ml
   ./sym_state/ignored.ml
   ./sym_state/ignored_single.ml
   ./sym_state/ignored_fields.ml
@@ -21,6 +25,7 @@
   ./sym_state/ignore_extra_key.ml
   ./sym_state/ignored_is_empty_pp.ml
   ./sym_state/syn_manifest.ml
+  ./sym_state/syn_manifest_type_args.ml
   ./sym_state/syn_manifest_mismatch.ml
   ./sym_state/invalid_non_t.ml
   ./sym_state/ignore_missing_empty.ml

--- a/soteria/tests/ppx/sym_state/inside_soteria.ml
+++ b/soteria/tests/ppx/sym_state/inside_soteria.ml
@@ -1,0 +1,4 @@
+open Prelude
+
+type t = { heap : Heap.t option }
+[@@deriving sym_state { symex = Symex; inside_soteria }]

--- a/soteria/tests/ppx/sym_state/inside_soteria.t
+++ b/soteria/tests/ppx/sym_state/inside_soteria.t
@@ -1,0 +1,102 @@
+  $ ../test.sh inside_soteria.ml
+  open Prelude
+  
+  type t = { heap : Heap.t option }
+  [@@deriving sym_state { symex = Symex; inside_soteria }]
+  
+  include struct
+    [@@@ocaml.warning "-60"]
+  
+    let _ = fun (_ : t) -> ()
+  
+    module SM =
+      State_monad.Make
+        (Symex)
+        (struct
+          type nonrec t = t option
+        end)
+  
+    let pp fmt x =
+      Format.fprintf fmt "@[<2>{ ";
+      Format.fprintf fmt "@[%s =@ " "heap";
+      (match x.heap with
+      | None -> Format.pp_print_string fmt "empty"
+      | Some v -> Heap.pp fmt v);
+      Format.fprintf fmt "@]";
+      Format.fprintf fmt "@ }@]"
+  
+    let _ = pp
+    let show x = Format.asprintf "%a" pp x
+    let _ = show
+  
+    type syn = Ser_heap of Heap.syn
+  
+    let pp_syn ft (s : syn) =
+      match s with
+      | Ser_heap v -> Fmt.pf ft "(@[<2>%s@ %a@])" "Ser_heap" Heap.pp_syn v
+      | _ -> .
+  
+    let _ = pp_syn
+    let show_syn s = Format.asprintf "%a" pp_syn s
+    let _ = show_syn
+    let of_opt = function None -> { heap = None } | Some v -> v
+    let _ = of_opt
+    let to_opt = function { heap = None } -> None | t -> Some t
+    let _ = to_opt
+    let empty = None
+    let _ = empty
+  
+    let to_syn (st : t) : syn list =
+      List.map
+        (fun v -> Ser_heap v)
+        (Option.fold ~none:[] ~some:Heap.to_syn st.heap)
+  
+    let _ = to_syn
+  
+    let ins_outs (syn : syn) =
+      match syn with Ser_heap v -> Heap.ins_outs v | _ -> .
+  
+    let _ = ins_outs
+    let lift_heap_fixes = List.map (fun v -> Ser_heap v)
+    let _ = lift_heap_fixes
+  
+    let with_heap_sym f =
+      let open SM.Syntax in
+      let* st_opt = SM.get_state () in
+      let st = of_opt st_opt in
+      let { heap } = st in
+      let*^ res, heap = f heap in
+      let+ () = SM.set_state (to_opt { heap }) in
+      res
+  
+    let _ = with_heap_sym
+    let with_heap f = SM.Result.map_missing lift_heap_fixes (with_heap_sym f)
+    let _ = with_heap
+  
+    let produce (syn : syn) (st : t option) : t option SM.Symex.Producer.t =
+      let open SM.Symex.Producer.Syntax in
+      let st = of_opt st in
+      match syn with
+      | Ser_heap v ->
+          let+ heap = Heap.produce v st.heap in
+          to_opt { heap }
+      | _ -> .
+  
+    let _ = produce
+  
+    let consume (syn : syn) (st : t option) :
+        (t option, syn list) SM.Symex.Consumer.t =
+      let open SM.Symex.Consumer.Syntax in
+      let st = of_opt st in
+      match syn with
+      | Ser_heap v ->
+          let+ heap =
+            let+? fixes = Heap.consume v st.heap in
+            lift_heap_fixes fixes
+          in
+          to_opt { heap }
+      | _ -> .
+  
+    let _ = consume
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  Success ✅

--- a/soteria/tests/ppx/sym_state/invalid_ctor_arg.ml
+++ b/soteria/tests/ppx/sym_state/invalid_ctor_arg.ml
@@ -1,0 +1,3 @@
+open Prelude
+
+type t = Bad of Excl_int.t option [@@deriving sym_state { symex = Symex }]

--- a/soteria/tests/ppx/sym_state/invalid_ctor_arg.t
+++ b/soteria/tests/ppx/sym_state/invalid_ctor_arg.t
@@ -1,0 +1,7 @@
+Reject sum constructor carrying <Module>.t option instead of <Module>.t
+  $ ../test.sh invalid_ctor_arg.ml
+  File "invalid_ctor_arg.ml", line 3, characters 16-33:
+  3 | type t = Bad of Excl_int.t option [@@deriving sym_state { symex = Symex }]
+                      ^^^^^^^^^^^^^^^^^
+  Error: [@deriving sym_state] sum constructors must carry a single <Module>.t argument
+  [1]

--- a/soteria/tests/ppx/sym_state/prelude.ml
+++ b/soteria/tests/ppx/sym_state/prelude.ml
@@ -1,6 +1,10 @@
 module Typed = Soteria.Tiny_values.Typed
 module Symex = Soteria.Symex.Make (Soteria.Tiny_values.Tiny_solver.Z3_solver)
 
+(* Mirrors what is in scope inside the Soteria library itself, so the
+   [inside_soteria] flag's output compiles in this test harness. *)
+module State_monad = Soteria.Sym_states.State_monad
+
 module S_int = struct
   include Typed
 

--- a/soteria/tests/ppx/sym_state/sum.ml
+++ b/soteria/tests/ppx/sym_state/sum.ml
@@ -1,0 +1,4 @@
+open Prelude
+
+type t = Cell of Excl_int.t | Map of Heap.t
+[@@deriving sym_state { symex = Symex }]

--- a/soteria/tests/ppx/sym_state/sum.t
+++ b/soteria/tests/ppx/sym_state/sum.t
@@ -1,0 +1,127 @@
+Sum (variant) memory model
+  $ ../test.sh sum.ml
+  open Prelude
+  
+  type t = Cell of Excl_int.t | Map of Heap.t
+  [@@deriving sym_state { symex = Symex }]
+  
+  include struct
+    [@@@ocaml.warning "-60"]
+  
+    let _ = fun (_ : t) -> ()
+  
+    module SM =
+      Soteria.Sym_states.State_monad.Make
+        (Symex)
+        (struct
+          type nonrec t = t option
+        end)
+  
+    let pp fmt x =
+      match x with
+      | Cell v ->
+          Format.fprintf fmt "@[<2>%s@ " "Cell";
+          Excl_int.pp fmt v;
+          Format.fprintf fmt "@]"
+      | Map v ->
+          Format.fprintf fmt "@[<2>%s@ " "Map";
+          Heap.pp fmt v;
+          Format.fprintf fmt "@]"
+  
+    let _ = pp
+    let show x = Format.asprintf "%a" pp x
+    let _ = show
+  
+    type syn = Ser_Cell of Excl_int.syn | Ser_Map of Heap.syn
+  
+    let pp_syn ft (s : syn) =
+      match s with
+      | Ser_Cell v -> Fmt.pf ft "(@[<2>%s@ %a@])" "Ser_Cell" Excl_int.pp_syn v
+      | Ser_Map v -> Fmt.pf ft "(@[<2>%s@ %a@])" "Ser_Map" Heap.pp_syn v
+      | _ -> .
+  
+    let _ = pp_syn
+    let show_syn s = Format.asprintf "%a" pp_syn s
+    let _ = show_syn
+    let empty = None
+    let _ = empty
+  
+    let to_syn (st : t) : syn list =
+      match st with
+      | Cell x -> List.map (fun v -> Ser_Cell v) (Excl_int.to_syn x)
+      | Map x -> List.map (fun v -> Ser_Map v) (Heap.to_syn x)
+  
+    let _ = to_syn
+  
+    let ins_outs (syn : syn) =
+      match syn with
+      | Ser_Cell v -> Excl_int.ins_outs v
+      | Ser_Map v -> Heap.ins_outs v
+      | _ -> .
+  
+    let _ = ins_outs
+    let lift_Cell_fixes = List.map (fun v -> Ser_Cell v)
+    let _ = lift_Cell_fixes
+    let lift_Map_fixes = List.map (fun v -> Ser_Map v)
+    let _ = lift_Map_fixes
+  
+    let produce (syn : syn) (st : t option) : t option SM.Symex.Producer.t =
+      let open SM.Symex.Producer in
+      let open SM.Symex.Producer.Syntax in
+      match syn with
+      | Ser_Cell v -> (
+          let* inner =
+            match st with
+            | None -> return None
+            | Some (Cell x) -> return (Some x)
+            | Some (Map _) -> vanish ()
+          in
+          let+ inner' = Excl_int.produce v inner in
+          match inner' with None -> None | Some y -> Some (Cell y))
+      | Ser_Map v -> (
+          let* inner =
+            match st with
+            | None -> return None
+            | Some (Map x) -> return (Some x)
+            | Some (Cell _) -> vanish ()
+          in
+          let+ inner' = Heap.produce v inner in
+          match inner' with None -> None | Some y -> Some (Map y))
+      | _ -> .
+  
+    let _ = produce
+  
+    let consume (syn : syn) (st : t option) :
+        (t option, syn list) SM.Symex.Consumer.t =
+      let open SM.Symex.Consumer in
+      let open SM.Symex.Consumer.Syntax in
+      match syn with
+      | Ser_Cell v -> (
+          let* inner =
+            match st with
+            | None -> ok None
+            | Some (Cell x) -> ok (Some x)
+            | Some (Map _) -> lfail (SM.Symex.Value.of_bool false)
+          in
+          let+ inner' =
+            let+? fixes = Excl_int.consume v inner in
+            lift_Cell_fixes fixes
+          in
+          match inner' with None -> None | Some y -> Some (Cell y))
+      | Ser_Map v -> (
+          let* inner =
+            match st with
+            | None -> ok None
+            | Some (Map x) -> ok (Some x)
+            | Some (Cell _) -> lfail (SM.Symex.Value.of_bool false)
+          in
+          let+ inner' =
+            let+? fixes = Heap.consume v inner in
+            lift_Map_fixes fixes
+          in
+          match inner' with None -> None | Some y -> Some (Map y))
+      | _ -> .
+  
+    let _ = consume
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  Success ✅

--- a/soteria/tests/ppx/sym_state/sum_single.ml
+++ b/soteria/tests/ppx/sym_state/sum_single.ml
@@ -1,0 +1,3 @@
+open Prelude
+
+type t = Only of Excl_int.t [@@deriving sym_state { symex = Symex }]

--- a/soteria/tests/ppx/sym_state/sum_single.t
+++ b/soteria/tests/ppx/sym_state/sum_single.t
@@ -1,0 +1,87 @@
+Single-variant sum compiles without unused-match warnings
+  $ ../test.sh sum_single.ml
+  open Prelude
+  
+  type t = Only of Excl_int.t [@@deriving sym_state { symex = Symex }]
+  
+  include struct
+    [@@@ocaml.warning "-60"]
+  
+    let _ = fun (_ : t) -> ()
+  
+    module SM =
+      Soteria.Sym_states.State_monad.Make
+        (Symex)
+        (struct
+          type nonrec t = t option
+        end)
+  
+    let pp fmt x =
+      match x with
+      | Only v ->
+          Format.fprintf fmt "@[<2>%s@ " "Only";
+          Excl_int.pp fmt v;
+          Format.fprintf fmt "@]"
+  
+    let _ = pp
+    let show x = Format.asprintf "%a" pp x
+    let _ = show
+  
+    type syn = Ser_Only of Excl_int.syn
+  
+    let pp_syn ft (s : syn) =
+      match s with
+      | Ser_Only v -> Fmt.pf ft "(@[<2>%s@ %a@])" "Ser_Only" Excl_int.pp_syn v
+      | _ -> .
+  
+    let _ = pp_syn
+    let show_syn s = Format.asprintf "%a" pp_syn s
+    let _ = show_syn
+    let empty = None
+    let _ = empty
+  
+    let to_syn (st : t) : syn list =
+      match st with Only x -> List.map (fun v -> Ser_Only v) (Excl_int.to_syn x)
+  
+    let _ = to_syn
+  
+    let ins_outs (syn : syn) =
+      match syn with Ser_Only v -> Excl_int.ins_outs v | _ -> .
+  
+    let _ = ins_outs
+    let lift_Only_fixes = List.map (fun v -> Ser_Only v)
+    let _ = lift_Only_fixes
+  
+    let produce (syn : syn) (st : t option) : t option SM.Symex.Producer.t =
+      let open SM.Symex.Producer in
+      let open SM.Symex.Producer.Syntax in
+      match syn with
+      | Ser_Only v -> (
+          let* inner =
+            match st with None -> return None | Some (Only x) -> return (Some x)
+          in
+          let+ inner' = Excl_int.produce v inner in
+          match inner' with None -> None | Some y -> Some (Only y))
+      | _ -> .
+  
+    let _ = produce
+  
+    let consume (syn : syn) (st : t option) :
+        (t option, syn list) SM.Symex.Consumer.t =
+      let open SM.Symex.Consumer in
+      let open SM.Symex.Consumer.Syntax in
+      match syn with
+      | Ser_Only v -> (
+          let* inner =
+            match st with None -> ok None | Some (Only x) -> ok (Some x)
+          in
+          let+ inner' =
+            let+? fixes = Excl_int.consume v inner in
+            lift_Only_fixes fixes
+          in
+          match inner' with None -> None | Some y -> Some (Only y))
+      | _ -> .
+  
+    let _ = consume
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  Success ✅

--- a/soteria/tests/ppx/sym_state/syn_manifest_type_args.ml
+++ b/soteria/tests/ppx/sym_state/syn_manifest_type_args.ml
@@ -1,0 +1,8 @@
+open Prelude
+
+module Syn = struct
+  type 'a t = Ser_heap of 'a
+end
+
+type t = { heap : Heap.t option; steps : int [@sym_state.ignore { empty = 0 }] }
+[@@deriving sym_state { symex = Symex; syn = Heap.syn Syn.t }]

--- a/soteria/tests/ppx/sym_state/syn_manifest_type_args.t
+++ b/soteria/tests/ppx/sym_state/syn_manifest_type_args.t
@@ -1,0 +1,123 @@
+  $ ../test.sh syn_manifest_type_args.ml
+  open Prelude
+  
+  module Syn = struct
+    type 'a t = Ser_heap of 'a
+  end
+  
+  type t = { heap : Heap.t option; steps : int [@sym_state.ignore { empty = 0 }] }
+  [@@deriving sym_state { symex = Symex; syn = Heap.syn Syn.t }]
+  
+  include struct
+    [@@@ocaml.warning "-60"]
+  
+    let _ = fun (_ : t) -> ()
+  
+    module SM =
+      Soteria.Sym_states.State_monad.Make
+        (Symex)
+        (struct
+          type nonrec t = t option
+        end)
+  
+    let pp fmt x =
+      Format.fprintf fmt "@[<2>{ ";
+      Format.fprintf fmt "@[%s =@ " "heap";
+      (match x.heap with
+      | None -> Format.pp_print_string fmt "empty"
+      | Some v -> Heap.pp fmt v);
+      Format.fprintf fmt "@]";
+      Format.fprintf fmt ";@ ";
+      Format.fprintf fmt "@[%s =@ <ignored>@]" "steps";
+      Format.fprintf fmt "@ }@]"
+  
+    let _ = pp
+    let show x = Format.asprintf "%a" pp x
+    let _ = show
+  
+    type syn = Heap.syn Syn.t
+  
+    let pp_syn ft (s : syn) =
+      match s with
+      | Syn.Ser_heap v -> Fmt.pf ft "(@[<2>%s@ %a@])" "Ser_heap" Heap.pp_syn v
+      | _ -> .
+  
+    let _ = pp_syn
+    let show_syn s = Format.asprintf "%a" pp_syn s
+    let _ = show_syn
+    let of_opt = function None -> { heap = None; steps = 0 } | Some v -> v
+    let _ = of_opt
+  
+    let to_opt = function
+      | { heap = None; steps } when steps = 0 -> None
+      | t -> Some t
+  
+    let _ = to_opt
+    let empty = None
+    let _ = empty
+  
+    let to_syn (st : t) : syn list =
+      List.map
+        (fun v -> Syn.Ser_heap v)
+        (Option.fold ~none:[] ~some:Heap.to_syn st.heap)
+  
+    let _ = to_syn
+  
+    let ins_outs (syn : syn) =
+      match syn with Syn.Ser_heap v -> Heap.ins_outs v | _ -> .
+  
+    let _ = ins_outs
+    let lift_heap_fixes = List.map (fun v -> Syn.Ser_heap v)
+    let _ = lift_heap_fixes
+  
+    let with_heap_sym f =
+      let open SM.Syntax in
+      let* st_opt = SM.get_state () in
+      let st = of_opt st_opt in
+      let { heap; _ } = st in
+      let*^ res, heap = f heap in
+      let+ () = SM.set_state (to_opt { st with heap }) in
+      res
+  
+    let _ = with_heap_sym
+  
+    let with_steps_sym f =
+      let open SM.Syntax in
+      let* st_opt = SM.get_state () in
+      let st = of_opt st_opt in
+      let { steps; _ } = st in
+      let**^ res, steps = f steps in
+      let* () = SM.set_state (to_opt { st with steps }) in
+      SM.Result.ok res
+  
+    let _ = with_steps_sym
+    let with_heap f = SM.Result.map_missing lift_heap_fixes (with_heap_sym f)
+    let _ = with_heap
+  
+    let produce (syn : syn) (st : t option) : t option SM.Symex.Producer.t =
+      let open SM.Symex.Producer.Syntax in
+      let st = of_opt st in
+      match syn with
+      | Syn.Ser_heap v ->
+          let+ heap = Heap.produce v st.heap in
+          to_opt { st with heap }
+      | _ -> .
+  
+    let _ = produce
+  
+    let consume (syn : syn) (st : t option) :
+        (t option, syn list) SM.Symex.Consumer.t =
+      let open SM.Symex.Consumer.Syntax in
+      let st = of_opt st in
+      match syn with
+      | Syn.Ser_heap v ->
+          let+ heap =
+            let+? fixes = Heap.consume v st.heap in
+            lift_heap_fixes fixes
+          in
+          to_opt { st with heap }
+      | _ -> .
+  
+    let _ = consume
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  Success ✅

--- a/soteria/tutorial/core_symex.mld
+++ b/soteria/tutorial/core_symex.mld
@@ -21,7 +21,7 @@ whether a symbolic expression of type
 {{!Soteria.Symex.Value.S.sbool}[Value.sbool]} is satisfiable.
 
 {@ocaml[
-  module Symex = Symex.Make (Tiny_solver.Z3_solver)
+module Symex = Symex.Make (Tiny_solver.Z3_solver)
 ]}
 
 {2:return Write your first symbolic process}
@@ -57,16 +57,15 @@ The function receives a symbolic process to execute, an
 {{!Soteria.Symex.Approx.t}approximation mode}; an optional
 {{!Soteria.Symex.Fuel_gauge.t}fuel gauge} should the user desire to limit the
 breadth or depth of execution; and
-{{!Soteria.Soteria_std.Effects.Bookkeeping.mode}bookkeeping modes} ([Dump _], [Ignore],
-or [Caller]) for the aggregated statistics and flamegraphs
+{{!Soteria.Soteria_std.Effects.Bookkeeping.mode}bookkeeping modes} ([Dump _],
+[Ignore], or [Caller]) for the aggregated statistics and flamegraphs
 {{:https://github.com/brendangregg/flamegraph}[.collapsed]} files.
 
-It returns a list of branches, where each branch
-is a pair of the value returned by the symbolic process and the path condition
-that leads to this branch (in the form of a list of expressions). Note that the
-path condition uses {{!Soteria.Symex.Value.Expr}[Value.Expr]}, as this path
-condition is {e syntactic} now that it has left the context of the symbolic
-process.
+It returns a list of branches, where each branch is a pair of the value returned
+by the symbolic process and the path condition that leads to this branch (in the
+form of a list of expressions). Note that the path condition uses
+{{!Soteria.Symex.Value.Expr}[Value.Expr]}, as this path condition is
+{e syntactic} now that it has left the context of the symbolic process.
 
 For instance, let's execute the symbolic process we just created, using the
 {{!Soteria.Symex.Approx.OX}over-approximation} mode, and without providing any
@@ -119,16 +118,16 @@ computations. Without going into details about monads, Soteria provides a
  operators} ([let*]) to do exactly that.
 
 {@ocaml[
-  (* Puts the let* operator in scope *)
-  open Symex.Syntax
+(* Puts the let* operator in scope *)
+open Symex.Syntax
 
-  (* Puts infix operators for symbolic values in scope. These operators are
-     postifixed with "@" to avoid conflicts with the standard library. *)
-  open Typed.Infix
+(* Puts infix operators for symbolic values in scope. These operators are
+   postifixed with "@" to avoid conflicts with the standard library. *)
+open Typed.Infix
 
-  (* Puts the symbolic integer syntax in scope, so that we can write "2s" for
-     the symbolic integer 2, instead of "Typed.int 2" *)
-  open Typed.Syntax
+(* Puts the symbolic integer syntax in scope, so that we can write "2s" for the
+   symbolic integer 2, instead of "Typed.int 2" *)
+open Typed.Syntax
 ]}
 
 {@ocaml[

--- a/soteria/tutorial/logs.mld
+++ b/soteria/tutorial/logs.mld
@@ -25,7 +25,7 @@ information. To get started, you need to open the
 module into scope:
 
 {@ocaml[
-  open Soteria.Logs.Import
+open Soteria.Logs.Import
 ]}
 
 To ensure this import is always available in your project, you can instead also
@@ -40,8 +40,8 @@ most common one is {{!Soteria.Logs.L.info}[info]}, which logs informational
 messages:
 
 {@ocaml[
-  L.info (fun m -> m "Starting symbolic execution")
-  (* -> Starting symbolic execution *)
+L.info (fun m -> m "Starting symbolic execution")
+(* -> Starting symbolic execution *)
 ]}
 
 The logging API uses a callback pattern: you pass a function that receives a
@@ -52,9 +52,9 @@ is disabled.
 Let's log a message with a value:
 
 {@ocaml[
-  let x = 42 in
-  L.info (fun m -> m "The answer is %d" x)
-  (* -> The answer is 42 *)
+let x = 42 in
+L.info (fun m -> m "The answer is %d" x)
+(* -> The answer is 42 *)
 ]}
 
 {2:levels Log Levels}
@@ -72,16 +72,16 @@ Soteria provides six log levels, from most verbose to least verbose:
 Each level has a corresponding logging function in the [L] module:
 
 {@ocaml[
-  L.trace (fun m -> m "Detailed trace: entering function");
-  (* -> [TRACE] Detailed trace: entering function *)
-  L.debug (fun m -> m "Variable x = %d" 10);
-  (* -> [DEBUG] Variable x = 10 *)
-  L.info (fun m -> m "Processing completed successfully");
-  (* -> [INFO ] Processing completed successfully *)
-  L.warn (fun m -> m "This operation may be slow");
-  (* -> [WARN ] This operation may be slow *)
-  L.error (fun m -> m "Failed to parse input")
-  (* -> [ERROR] Failed to parse input *)
+L.trace (fun m -> m "Detailed trace: entering function");
+(* -> [TRACE] Detailed trace: entering function *)
+L.debug (fun m -> m "Variable x = %d" 10);
+(* -> [DEBUG] Variable x = 10 *)
+L.info (fun m -> m "Processing completed successfully");
+(* -> [INFO ] Processing completed successfully *)
+L.warn (fun m -> m "This operation may be slow");
+(* -> [WARN ] This operation may be slow *)
+L.error (fun m -> m "Failed to parse input")
+(* -> [ERROR] Failed to parse input *)
 ]}
 
 The {{!Soteria.Logs.L.smt}[smt]} level is special: it's designed for logging SMT
@@ -90,8 +90,8 @@ understanding solver behavior. Unless you're implementing a solver backend, you
 usually shouldn't need this level:
 
 {@ocaml[
-  L.smt (fun m -> m "Querying solver: (assert (> x 0))")
-  (* -> [SMT ] Querying solver: (assert (> x 0)) *)
+L.smt (fun m -> m "Querying solver: (assert (> x 0))")
+(* -> [SMT ] Querying solver: (assert (> x 0)) *)
 ]}
 
 {2:config Configuration}
@@ -108,12 +108,12 @@ configure:
 Here's how to configure logging programmatically:
 
 {@ocaml[
-  (* Create a configuration that logs at Debug level and above *)
-  let log_config =
-    Soteria.Logs.Config.make ~level:(Some Debug) ~kind:Stderr ~no_color:false ()
-  ;;
+(* Create a configuration that logs at Debug level and above *)
+let log_config =
+  Soteria.Logs.Config.make ~level:(Some Debug) ~kind:Stderr ~no_color:false ()
+;;
 
-  Soteria.Logs.Config.set_and_lock log_config
+Soteria.Logs.Config.set_and_lock log_config
 ]}
 
 {b Important:} configuration is global and can only be set once. After calling
@@ -131,20 +131,20 @@ You can organize output into collapsible sections using
 {{!Soteria.Logs.L.with_section}[with_section]}:
 
 {@ocaml[
-  L.with_section "Analyzing Module" (fun () ->
-      L.info (fun m -> m "Starting analysis");
+L.with_section "Analyzing Module" (fun () ->
+    L.info (fun m -> m "Starting analysis");
 
-      L.with_section "Function: main" (fun () ->
-          L.debug (fun m -> m "Analyzing function body");
-          L.trace (fun m -> m "Thinking about it...");
-          L.debug (fun m -> m "Found 3 branches"));
+    L.with_section "Function: main" (fun () ->
+        L.debug (fun m -> m "Analyzing function body");
+        L.trace (fun m -> m "Thinking about it...");
+        L.debug (fun m -> m "Found 3 branches"));
 
-      L.with_section "Function: helper" (fun () ->
-          L.debug (fun m -> m "Analyzing function body");
-          L.warn (fun m -> m "Something bad is brewing...");
-          L.error (fun m -> m "Oh no!"));
+    L.with_section "Function: helper" (fun () ->
+        L.debug (fun m -> m "Analyzing function body");
+        L.warn (fun m -> m "Something bad is brewing...");
+        L.error (fun m -> m "Oh no!"));
 
-      L.info (fun m -> m "Analysis complete"))
+    L.info (fun m -> m "Analysis complete"))
 ]}
 
 In HTML mode, each call to [with_section] renders as a collapsible block that
@@ -288,10 +288,10 @@ apply text styles with {{!Soteria.Logs.Printers.pp_style}[pp_style]}, or combine
 both with {{!Soteria.Logs.Printers.pp_clr2}[pp_clr2]}:
 
 {@ocaml[
-  let open Soteria.Logs.Printers in
-  L.info (fun m ->
-      m "%a, %a, %a" (pp_clr `Green) "Success" (pp_style `Bold) "Important"
-        (pp_clr2 `Red `Bold) "Critical")
+let open Soteria.Logs.Printers in
+L.info (fun m ->
+    m "%a, %a, %a" (pp_clr `Green) "Success" (pp_style `Bold) "Important"
+      (pp_clr2 `Red `Bold) "Critical")
 ]}
 
 {3 Semantic Colors}
@@ -300,10 +300,10 @@ For common message types, use semantic color functions ([pp_ok], [pp_warn],
 [pp_err], [pp_fatal]):
 
 {@ocaml[
-  let open Soteria.Logs.Printers in
-  L.info (fun m ->
-      m "%a, %a, %a, %a" pp_ok "OK" pp_warn "Warning" pp_err "Error" pp_fatal
-        "Fatal")
+let open Soteria.Logs.Printers in
+L.info (fun m ->
+    m "%a, %a, %a, %a" pp_ok "OK" pp_warn "Warning" pp_err "Error" pp_fatal
+      "Fatal")
 ]}
 
 {3 Special Formatters}
@@ -322,12 +322,12 @@ The following formatters are available for common value types:
   between runs (when [hide_unstable] is set in config)
 
 {@ocaml[
-  let open Soteria.Logs.Printers in
-  L.info (fun m ->
-      m "Time: %a, Coverage: %a, Found: %a" pp_time 1.543 pp_percent (10.0, 2.5)
-        (pp_plural ~sing:"branch" ~plur:"branches")
-        5)
-  (* -> Time: 1.54s, Coverage: 25.00%, Found: 5 branches *)
+let open Soteria.Logs.Printers in
+L.info (fun m ->
+    m "Time: %a, Coverage: %a, Found: %a" pp_time 1.543 pp_percent (10.0, 2.5)
+      (pp_plural ~sing:"branch" ~plur:"branches")
+      5)
+(* -> Time: 1.54s, Coverage: 25.00%, Found: 5 branches *)
 ]}
 
 {3 Unstable Values}
@@ -339,13 +339,13 @@ change between runs (like timestamps or durations) using
 printer.
 
 {@ocaml[
-  let open Soteria.Logs.Printers in
-  let current_time = Unix.gettimeofday () in
+let open Soteria.Logs.Printers in
+let current_time = Unix.gettimeofday () in
 
-  L.info (fun m ->
-      m "Completed at %a" (pp_unstable ~name:"timestamp" Fmt.float) current_time)
-  (* hide_unstable = false -> Completed at 1775127711.926 hide_unstable = true
-     -> Completed at <timestamp> *)
+L.info (fun m ->
+    m "Completed at %a" (pp_unstable ~name:"timestamp" Fmt.float) current_time)
+(* hide_unstable = false -> Completed at 1775127711.926 hide_unstable = true ->
+   Completed at <timestamp> *)
 ]}
 
 The [--hide-unstable] flag also makes sure that the printing profile (e.g.
@@ -359,17 +359,15 @@ for printing before calling the logging function. Instead, do that work inside
 the logging lambda, so it only runs if the log level is enabled:
 
 {@ocaml[
-  (* BAD: Always computes the string, even if logging is disabled *)
-  let expensive_string = String.concat ", " (List.init 1000 string_of_int) in
-  L.trace (fun m -> m "Generated: %s" expensive_string)
-  ;;
+(* BAD: Always computes the string, even if logging is disabled *)
+let expensive_string = String.concat ", " (List.init 1000 string_of_int) in
+L.trace (fun m -> m "Generated: %s" expensive_string)
+;;
 
-  (* GOOD: Only computes if needed *)
-  L.trace (fun m ->
-      let expensive_string =
-        String.concat ", " (List.init 1000 string_of_int)
-      in
-      m "Generated: %s" expensive_string)
+(* GOOD: Only computes if needed *)
+L.trace (fun m ->
+    let expensive_string = String.concat ", " (List.init 1000 string_of_int) in
+    m "Generated: %s" expensive_string)
 ]}
 
 {2:ppx PPX Extension}
@@ -388,12 +386,13 @@ does not supporting declarations within the logging statement, so if you need to
 do any let-bindings or computations, you should still use the full lambda form.
 
 {@ocaml[
-  [%l.info "Starting symbolic execution"];;
-  [%l.debug "Variable x = %d" 67];;
-
-  (* Expands to: *)
-  L.info (fun m -> m "Starting symbolic execution");;
-  L.debug (fun m -> m "Variable x = %d" 67)
+[%l.info "Starting symbolic execution"];;
+[%l.debug "Variable x = %d" 67]
+]}
+Expands to...
+{@ocaml[
+L.info (fun m -> m "Starting symbolic execution");;
+L.debug (fun m -> m "Variable x = %d" 67)
 ]}
 
 {2 That's it!}

--- a/soteria/tutorial/prelude.ml
+++ b/soteria/tutorial/prelude.ml
@@ -86,6 +86,8 @@ module Dummy_state = struct
 end
 module Heap = Dummy_state
 module Globs = Dummy_state
+module Inner = Dummy_state
+module Freed = Dummy_state
 module FunBiMap = struct
   type t = unit
   let empty = ()

--- a/soteria/tutorial/stats.mld
+++ b/soteria/tutorial/stats.mld
@@ -33,10 +33,9 @@ the {{!Soteria.Stats.Config.output_stats}[output_stats]} configuration is
 programmatically set to [Some _]).
 
 {@ocaml[
-  (* Manually initialising stats configuration, should be done using the
-     Cmdliner term in practice *)
-  let () =
-    Soteria.Stats.Config.set_and_lock { output_stats = Some "stats.json" }
+(* Manually initialising stats configuration, should be done using the Cmdliner
+   term in practice *)
+let () = Soteria.Stats.Config.set_and_lock { output_stats = Some "stats.json" }
 ]}
 
 {@ocaml[
@@ -246,14 +245,14 @@ See {{!Soteria.Symex.StatKeys}[Symex.StatKeys]} for all available entries.
 The {{!Soteria.Symex.S.run}[Symex.S.run]} function receives an optional [stats]
 parameter that allows deciding how statistics should be tracked during symbolic
 execution:
-- {{!Soteria.Soteria_std.Effects.Bookkeeping.mode.Ignore}[~stats:Ignore]}: Don't track any
-  statistics (default)
-- {{!Soteria.Soteria_std.Effects.Bookkeeping.mode.Dump}[~stats:(Dump ())]}: Track statistics
-  and print them after execution according to the current
+- {{!Soteria.Soteria_std.Effects.Bookkeeping.mode.Ignore}[~stats:Ignore]}: Don't
+  track any statistics (default)
+- {{!Soteria.Soteria_std.Effects.Bookkeeping.mode.Dump}[~stats:(Dump ())]}:
+  Track statistics and print them after execution according to the current
   {{!Soteria.Stats.Config}configuration} (see below)
-- {{!Soteria.Soteria_std.Effects.Bookkeeping.mode.Caller}[~stats:Caller]}: Statistics are
-  already tracked, and the effects they raise don't need to be handled here
-  (using {{!Soteria.Stats.As_ctx.with_}[with_]},
+- {{!Soteria.Soteria_std.Effects.Bookkeeping.mode.Caller}[~stats:Caller]}:
+  Statistics are already tracked, and the effects they raise don't need to be
+  handled here (using {{!Soteria.Stats.As_ctx.with_}[with_]},
   {{!Soteria.Stats.As_ctx.with_ignored}[with_ignored]}, or
   {{!Soteria.Stats.As_ctx.with_dumped}[with_dumped]})
 
@@ -277,23 +276,23 @@ module to centralize your stat key constants, document them, and register their
 printers — this makes the code maintainable as the number of statistics grows:
 
 {@ocaml[
-  module StatKeys = struct
-    let paths_explored = "analysis.paths_explored"
-    let total_time = "analysis.time"
-    let errors_found = "analysis.errors"
+module StatKeys = struct
+  let paths_explored = "analysis.paths_explored"
+  let total_time = "analysis.time"
+  let errors_found = "analysis.errors"
 
-    let () =
-      let open Soteria.Stats in
-      register_int_printer paths_explored ~name:"Paths Explored" (fun _ ft n ->
-          Fmt.pf ft "%d paths" n);
-      register_float_printer total_time ~name:"Analysis Time" (fun _ ->
-          Soteria.Logs.Printers.pp_time)
-  end
+  let () =
+    let open Soteria.Stats in
+    register_int_printer paths_explored ~name:"Paths Explored" (fun _ ft n ->
+        Fmt.pf ft "%d paths" n);
+    register_float_printer total_time ~name:"Analysis Time" (fun _ ->
+        Soteria.Logs.Printers.pp_time)
+end
 
-  let my_process () =
-    Soteria.Stats.As_ctx.incr StatKeys.paths_explored;
-    Soteria.Stats.As_ctx.add_float StatKeys.total_time 1.5;
-    ()
+let my_process () =
+  Soteria.Stats.As_ctx.incr StatKeys.paths_explored;
+  Soteria.Stats.As_ctx.add_float StatKeys.total_time 1.5;
+  ()
 ]}
 
 {2 That's it!}

--- a/soteria/tutorial/sym_state_ppx.mld
+++ b/soteria/tutorial/sym_state_ppx.mld
@@ -14,8 +14,9 @@ boilerplate required by state modules implementing the
 - [produce] and [consume] to support Soteria's logic.
 - [with_<field>] and [with_<field>_sym] helper wrappers.
 
-The [sym_state] PPX generates these from the state type declaration. More
-formally, this generates a product of the state models of the individual fields.
+The [sym_state] PPX generates these from the state type declaration. Deriving on
+a record generates a {e product} of the state models of the individual fields;
+deriving on a variant generates a {e sum} of them (see {!sums} below).
 
 {2 Basic usage}
 
@@ -157,6 +158,51 @@ Which can then easily be used:
 let load addr ty = with_heap_sym (FancyHeap.load addr ty)
 ]}
 
+{2:sums Sum memory models}
+
+The deriver also works on {b variant} types. Where a record derives a
+{e product}, where all fields are owned at once, a variant derives a {e sum}:
+the state is exactly one of the variants at a time. This is useful to model a
+resource with alternative representations that it can flip between, or a set of
+mutually-exclusive states.
+
+Each constructor carries a single state model, written as [<Module>.t] (with no
+[option]):
+
+{@ocaml[
+type t = Freed of Freed.t | Alive of Inner.t
+[@@deriving sym_state { symex = My_symex }]
+]}
+
+We do not allow [option] within sum types, to facilitate frame-preservation.
+Take the example above: if [Freed] and [Alive] were both [t option], then a
+state could be [Freed None], and a [consume] of [Alive …] would have to fail,
+even though the state is empty.
+
+Every generated function dispatches on the active variant, and serialization
+tags each variant with its own constructor, named [Ser_<Constructor>]:
+
+{@ocaml[
+type syn = Ser_Freed of Freed.syn | Ser_Alive of Inner.syn
+]}
+
+Unlike records, sums do not generate [of_opt], [to_opt] or [with_<field>]
+wrappers: there is no canonical variant to expand [None] into.
+
+{3 Producing and consuming across variants}
+
+[produce] and [consume] act on the variant selected by the [syn] constructor:
+
+- against an empty state, they create (resp. require) that variant;
+- against the {e same} variant, they delegate to its inner state model;
+- against a {e different} variant, they are contradictory: [produce] vanishes
+  and [consume] fails, since two variants cannot describe the same resource at
+  once.
+
+These are only defaults. If you need some different behaviour (e.g. to allow
+[produce] to switch variants), you can override them by redefining [produce] and
+[consume].
+
 {2 [syn] type equality}
 
 Some applications may want to expose a stable [syn] type through an interface,
@@ -174,3 +220,21 @@ type t = { heap : Heap.t option; globs : Globs.t option }
 {b Note} this only asserts the generated [syn] type is equal to [my_syn], it
 does not actually change any of the generated code to use [my_syn]. If [my_syn]
 does not match [syn], this will cause a compile error.
+
+{3 Parameterised manifests}
+
+The manifest may itself be a parameterised type, which is convenient for
+reusable combinators. For example, a [Freeable] combinator (a sum, as in
+{!sums}) can share a single serialization type across all its instantiations:
+
+{@ocaml[
+type 'a freeable_syn = Ser_Freed of Freed.syn | Ser_Alive of 'a
+
+type t = Freed of Freed.t | Alive of Inner.t
+[@@deriving sym_state { symex = My_symex; syn = Inner.syn freeable_syn }]
+]}
+
+When the manifest is parameterised, the generated [syn] is a transparent alias
+of it (rather than a re-declaration of the constructors), and its constructors
+are taken from the manifest type's module. Their names must still match the
+[Ser_<field>] / [Ser_<Constructor>] convention.

--- a/soteria/tutorial/sym_state_ppx.mld
+++ b/soteria/tutorial/sym_state_ppx.mld
@@ -23,8 +23,8 @@ Define a record type [t] where managed symbolic fields have type
 [<Module>.t option], then derive:
 
 {@ocaml[
-  type t = { heap : Heap.t option; globs : Globs.t option }
-  [@@deriving sym_state { symex = My_symex }]
+type t = { heap : Heap.t option; globs : Globs.t option }
+[@@deriving sym_state { symex = My_symex }]
 ]}
 
 The [symex] argument is required and indicates which symbolic monad family the
@@ -77,12 +77,12 @@ You can keep non-compositional auxiliary fields in [t] and still derive
 everything. Mark them with [@sym_state.ignore], providing their empty value:
 
 {@ocaml[
-  type t = {
-    heap : Heap.t option;
-    globs : Globs.t option;
-    functions : FunBiMap.t; [@sym_state.ignore { empty = FunBiMap.empty }]
-  }
-  [@@deriving sym_state { symex = My_symex }]
+type t = {
+  heap : Heap.t option;
+  globs : Globs.t option;
+  functions : FunBiMap.t; [@sym_state.ignore { empty = FunBiMap.empty }]
+}
+[@@deriving sym_state { symex = My_symex }]
 ]}
 
 Ignored fields are not serialized in [to_syn]. They are still considered in
@@ -91,9 +91,9 @@ and they still get a [with_field_sym] wrapper that operates over the underlying
 monad (e.g. [My_symex]).
 
 {@ocaml skip[
-  val with_functions_sym :
-    (FunBiMap.t -> ('a * FunBiMap.t, 'e, 'f) My_symex.Result.t) ->
-    ('a, 'e, 'f) SM.Result.t
+val with_functions_sym :
+  (FunBiMap.t -> ('a * FunBiMap.t, 'e, 'f) My_symex.Result.t) ->
+  ('a, 'e, 'f) SM.Result.t
 ]}
 
 If physical equality is not appropriate for the field, you can also provide a
@@ -101,16 +101,16 @@ custom equality function with [is_empty]. A custom printer can also be provided,
 with [pp] (by default the field is printed as "<ignored>").
 
 {@ocaml[
-  type t = {
-    functions : FunBiMap.t;
-        [@sym_state.ignore
-          {
-            empty = FunBiMap.empty;
-            is_empty = FunBiMap.is_empty;
-            pp = FunBiMap.pp;
-          }]
-  }
-  [@@deriving sym_state { symex = My_symex }]
+type t = {
+  functions : FunBiMap.t;
+      [@sym_state.ignore
+        {
+          empty = FunBiMap.empty;
+          is_empty = FunBiMap.is_empty;
+          pp = FunBiMap.pp;
+        }]
+}
+[@@deriving sym_state { symex = My_symex }]
 ]}
 
 {2 Using other fields as context}
@@ -128,33 +128,33 @@ This enables complex state shapes; for example, here [FancyHeap] is built on top
 of the [DecayedPointers.SM] state monad:
 
 {@ocaml[
-  type t = {
-    pointers : DecayedPointers.t option;
-    heap : FancyHeap.t option; [@sym_state.context { field = pointers }]
-    globs : Globs.t option;
-  }
-  [@@deriving sym_state { symex = My_symex }]
+type t = {
+  pointers : DecayedPointers.t option;
+  heap : FancyHeap.t option; [@sym_state.context { field = pointers }]
+  globs : Globs.t option;
+}
+[@@deriving sym_state { symex = My_symex }]
 ]}
 
 This makes the generated [with_heap] and [with_heap_sym] behave like this:
 
 {@ocaml[
-  let with_heap_sym f =
-    let open SM.Syntax in
-    let* st_opt = SM.get_state () in
-    let st = of_opt st_opt in
-    let { heap; pointers; _ } = st in
-    let*^ (res, heap), pointers =
-      DecayedPointers.SM.run_with_state ~state:pointers (f heap)
-    in
-    let+ () = SM.set_state (to_opt { st with heap; pointers }) in
-    res
+let with_heap_sym f =
+  let open SM.Syntax in
+  let* st_opt = SM.get_state () in
+  let st = of_opt st_opt in
+  let { heap; pointers; _ } = st in
+  let*^ (res, heap), pointers =
+    DecayedPointers.SM.run_with_state ~state:pointers (f heap)
+  in
+  let+ () = SM.set_state (to_opt { st with heap; pointers }) in
+  res
 ]}
 
 Which can then easily be used:
 
 {@ocaml[
-  let load addr ty = with_heap_sym (FancyHeap.load addr ty)
+let load addr ty = with_heap_sym (FancyHeap.load addr ty)
 ]}
 
 {2 [syn] type equality}
@@ -165,10 +165,10 @@ customising the generated [syn], it does allow asserting [syn] is equal to a
 user-defined one, using the [syn] option:
 
 {@ocaml[
-  type my_syn = Ser_heap of Heap.syn | Ser_globs of Globs.syn
+type my_syn = Ser_heap of Heap.syn | Ser_globs of Globs.syn
 
-  type t = { heap : Heap.t option; globs : Globs.t option }
-  [@@deriving sym_state { symex = My_symex; syn = my_syn }]
+type t = { heap : Heap.t option; globs : Globs.t option }
+[@@deriving sym_state { symex = My_symex; syn = my_syn }]
 ]}
 
 {b Note} this only asserts the generated [syn] type is equal to [my_syn], it


### PR DESCRIPTION
Add support for sum memory models with `[@@deriving sym_states]`
We don't do anything too fancy; the ADT must be defined as `| Var1 of Mm1.t | Var2 of Mm2.t | ...`, inlined structs or more than one field aren't allowed.
Still, this allows us to generate a good chunk of `Freeable` :) 

I remember us discussing for `[@@deriving syn]` how to define a type alias thing such that `t` was in face `sem t` and `syn` was `syn t`, so that we could reuse the same functions to handle both the semantic and syntactic value. Here I decided to keep it simple and to redefine `syn`. This required very minor changes to users of `Freeable`, which I find entirely worth the simplicity.

Finally, I ran a quick ocamlformat on the tutorials, so ignore most of the diff there; the only relevant change is adding a section on sums to the tutorial on `sym_states`