### PR TITLE
Encode enum variants concretely

### DIFF
--- a/soteria-rust/lib/builtins/core.ml
+++ b/soteria-rust/lib/builtins/core.ml
@@ -14,12 +14,28 @@ module M (StateM : State.StateM.S) = struct
   open Syntax
 
   let cmp ~signed l r =
+    let open Typed.Adt.Checked in
     let ordering = Crate.get_adt_lang_item_ref RustcLangItemOrderingEnum in
     let ( < ) = if signed then ( <$@ ) else ( <@ ) in
-    let discr =
-      Typed.ite (l < r) U8.(-1s) (Typed.ite (l ==@ r) U8.(0s) U8.(1s))
-    in
-    Typed.Adt.mk_enum ordering discr []
+    let lt = l < r in
+    let eq = l ==@ r in
+    if%sat lt then ok @@ mk_enum ordering "Less" []
+    else if%sat eq then ok @@ mk_enum ordering "Equal" []
+    else ok @@ mk_enum ordering "Greater" []
+  (* TODO: uncomment this when we support symbolic enums, and remove the
+   * three lines above
+   *
+   * match (Typed.to_bool lt, Typed.to_bool eq) with
+   * | Some true, _ -> ok @@ mk_enum ordering "Less" []
+   * | _, Some true -> ok @@ mk_enum ordering "Equal" []
+   * | Some false, Some false -> ok @@ mk_enum ordering "Greater" []
+   * | _ ->
+   *     let*^ ord = Rustsymex.nondet (Typed.t_enum ordering) in
+   *     let discr = Typed.Adt.discriminant_of ord in
+   *     let exp_discr = Typed.ite lt U8.(-1s) (Typed.ite eq U8.(0s) U8.(1s)) in
+   *     let+ () = assume [ discr ==@ exp_discr ] in
+   *     (ord : T.enum Typed.t :> [> T.enum ] Typed.t)
+   *)
 
   (** Rust allows shift operations on integers of differents sizes, which isn't
       possible in SMT-Lib, so we normalise the righthand side to match the left

--- a/soteria-rust/lib/interp.ml
+++ b/soteria-rust/lib/interp.ml
@@ -176,11 +176,8 @@ module Make (StateImpl : State.S) = struct
         Typed.Adt.mk_tuple vals
     | CAdt (Some var, fields) ->
         let adt = ty_as_adt const.ty in
-        let variants = Crate.as_enum @@ ty_as_adt const.ty in
-        let variant = Types.VariantId.nth variants var in
-        let discr = BV.of_literal variant.discriminant in
         let+ vals = map_list fields ~f:resolve_constant in
-        Typed.Adt.mk_enum adt discr vals
+        Typed.Adt.mk_enum adt var vals
     (* FIXME: this is hacky, but until we get proper monomorphisation this isn't
        too bad *)
     | CTraitConst (tref, const_id) -> (
@@ -798,7 +795,7 @@ module Make (StateImpl : State.S) = struct
                 Core.eval_lit_binop op ty v1 v2
             | AddChecked | SubChecked | MulChecked ->
                 Core.eval_checked_lit_binop op ty v1 v2
-            | Cmp -> ok (Core.cmp ~signed:(Layout.is_signed ty) v1 v2)
+            | Cmp -> Core.cmp ~signed:(Layout.is_signed ty) v1 v2
             | BitOr | BitAnd | BitXor -> (
                 let ty = TypesUtils.ty_as_literal (type_of_operand e1) in
                 let v1 = Typed.cast_lit ty v1 in
@@ -897,11 +894,8 @@ module Make (StateImpl : State.S) = struct
     (* Enum aggregate *)
     | Aggregate (AggregatedAdt (adt, Some v_id, None), vals) ->
         let* adt = Poly.subst_tyref adt in
-        let variants = Crate.as_enum adt in
-        let variant = Types.VariantId.nth variants v_id in
-        let discr = BV.of_literal variant.discriminant in
         let+ vals = eval_operand_list vals in
-        Typed.Adt.mk_enum adt discr vals
+        Typed.Adt.mk_enum adt v_id vals
     (* Union aggregate *)
     | Aggregate (AggregatedAdt (adt, None, Some field), ops) ->
         let* adt = Poly.subst_tyref adt in

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -50,7 +50,7 @@ and 'ghost ext_t =
   | Ptr of 'ghost sv * 'ghost sv option  (** pointer, with optional meta *)
   | ThinPtr of 'ghost ptr
       (** thin pointer, without metadata but with extra info on the pointer *)
-  | Enum of 'ghost sv * 'ghost sv list  (** discriminant * values *)
+  | Enum of Types.variant_id * 'ghost sv list  (** variant id * values *)
   | Tuple of 'ghost sv list  (** structs and tuples: ordered values *)
   | Array of 'ghost sv Iarray.t
       (** arrays: ordered values, all of the same type *)
@@ -102,8 +102,10 @@ module Rust_ext :
         Fmt.pf ft "%a[%a]" pp ptr.ptr
           Fmt.(option ~none:(any "*") Ptr_tag.pp)
           ptr.tag
-    | Enum (disc, vals) ->
-        Fmt.pf ft "Enum(%a: %a)" pp disc (Fmt.list ~sep:(Fmt.any ", ") pp) vals
+    | Enum (v, vals) ->
+        Fmt.pf ft "Enum(%a: %a)" Types.pp_variant_id v
+          (Fmt.list ~sep:(Fmt.any ", ") pp)
+          vals
     | Tuple vals -> Fmt.pf ft "(%a)" (Fmt.list ~sep:(Fmt.any ", ") pp) vals
     | Array vals -> Fmt.pf ft "[%a]" (Iarray.pp ~sep:(Fmt.any ", ") pp) vals
     | Union vs ->
@@ -133,10 +135,7 @@ module Rust_ext :
         iter_vars ptr;
         iter_vars meta
     | ThinPtr ptr -> iter_vars_ptr iter_vars ptr
-    | Enum (disc, vals) ->
-        iter_vars disc;
-        List.iter iter_vars vals
-    | Tuple vals -> List.iter iter_vars vals
+    | Enum (_, vals) | Tuple vals -> List.iter iter_vars vals
     | Array vals -> Iarray.iter iter_vars vals
     | Union vs -> List.iter (iter_vars_block iter_vars) vs
     | PolyVal _ -> ()
@@ -162,10 +161,11 @@ module Rust_ext :
         combine
           (combine (combine (combine ptr.tag 3) size.tag) align.tag)
           (Option.fold ~none:(-1) ~some:Ptr_tag.hash tag)
-    | Enum (disc, vals) ->
+    | Enum (var, vals) ->
         List.fold_left
           (fun acc (v : _ sv) -> combine acc v.tag)
-          (combine disc.tag 4) vals
+          (combine (Types.VariantId.to_int var) 4)
+          vals
     | Tuple vals ->
         List.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 5 vals
     | Array vals ->
@@ -244,10 +244,9 @@ module Rust_ext :
     | ThinPtr ptr ->
         let ptr, s = apply_subst_ptr apply ~missing_var s ptr in
         (ThinPtr ptr, s)
-    | Enum (discr, vs) ->
-        let discr, s = apply ~missing_var s discr in
+    | Enum (var, vs) ->
         let vs, s = apply_list apply ~missing_var s vs in
-        (Enum (discr, vs), s)
+        (Enum (var, vs), s)
     | Tuple vs ->
         let vs, s = apply_list apply ~missing_var s vs in
         (Tuple vs, s)

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -82,10 +82,15 @@ let float_precision :
 (* The raw pointer type; only used to materialise a fully-symbolic nondet
    pointer in [Value_codec] (see {!Ptr.of_raw}). *)
 let t_ptr () = t_ptr (8 * size_of_uint_ty Usize)
-let t_ptr_f () : 'a ty = TExtension TFullPtr
-let t_ptr_t () : 'a ty = TExtension TThinPtr
+let t_ptr_f () : _ ty = TExtension TFullPtr
+let t_ptr_t () : _ ty = TExtension TThinPtr
 let t_loc () = t_loc (8 * size_of_uint_ty Usize)
 let t_usize () = t_int (8 * size_of_uint_ty Usize)
+let t_enum adt : _ ty = TExtension (TEnum adt)
+
+let t_as_enum : _ ty -> Types.type_decl_ref = function
+  | TExtension (TEnum adt) -> adt
+  | ty -> L.failwith "t_as_enum: expected enum type, got %a" ppa_ty ty
 
 let t_lit : Types.literal_type -> [> T.sint ] ty = function
   | (TInt _ | TUInt _ | TBool | TChar) as ty -> t_int (size_of_literal_ty ty * 8)
@@ -372,7 +377,7 @@ module Adt = struct
     let elem_ty = if len = 0 then ty_of_rust elem_ty else get_ty arr.%(0) in
     Extension (Array arr) <| t_array elem_ty (Z.of_int len)
 
-  let mk_enum adt discr vs = Extension (Enum (discr, vs)) <| t_enum adt
+  let mk_enum adt v_id vs = Extension (Enum (v_id, vs)) <| t_enum adt
   let mk_union adt blocks = Extension (Union blocks) <| t_union adt
   let mk_poly ty_id = Extension (PolyVal ty_id) <| t_poly ()
 
@@ -396,9 +401,11 @@ module Adt = struct
     | Extension (Array vs) -> vs
     | _ -> todo_migration "as_array unop"
 
-  let as_enum_of_variant _var_id v =
+  let as_enum_of_variant var_id v =
     match kind v with
-    | Extension (Enum (_, vs)) -> vs
+    | Extension (Enum (v, vs)) ->
+        assert (Types.VariantId.equal_id v var_id);
+        vs
     | _ -> todo_migration "as_enum_of_variant unop"
 
   let as_tuple1 v =
@@ -421,7 +428,11 @@ module Adt = struct
 
   let discriminant_of v =
     match kind v with
-    | Extension (Enum (discr, _)) -> discr
+    | Extension (Enum (var_id, _)) ->
+        let adt = t_as_enum v.node.ty in
+        let vars = Crate.as_enum adt in
+        let variant = Types.VariantId.nth vars var_id in
+        BV.of_literal variant.discriminant
     | _ -> todo_migration "discriminant_of unop"
 
   let field_of idx v =
@@ -440,10 +451,11 @@ module Adt = struct
           L.failwith "Array index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "array_field_of op"
 
-  let field_of_variant _var_id idx v =
+  let field_of_variant var_id idx v =
     (* TODO: assert the variant? *)
     match kind v with
-    | Extension (Enum (_, vs)) -> (
+    | Extension (Enum (var, vs)) -> (
+        assert (Types.VariantId.equal_id var var_id);
         try List.nth vs idx
         with Invalid_argument _ ->
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
@@ -457,11 +469,12 @@ module Adt = struct
           L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_field op"
 
-  let set_field_of_variant _var_id idx f v =
+  let set_field_of_variant var_id idx f v =
     (* TODO: assert the variant *)
     match kind v with
-    | Extension (Enum (discr, vs)) -> (
-        try Extension (Enum (discr, List.set_nth idx f vs)) <| v.node.ty
+    | Extension (Enum (var, vs)) -> (
+        assert (Types.VariantId.equal_id var var_id);
+        try Extension (Enum (var, List.set_nth idx f vs)) <| v.node.ty
         with Invalid_argument _ ->
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_field_of_variant op"
@@ -489,8 +502,7 @@ module Adt = struct
         |> List.find (fun (v : Types.variant) -> v.variant_name = variant)
       in
       assert (List.compare_lengths variant.fields vs = 0);
-      let discr = BV.of_literal variant.discriminant in
-      mk_enum tref discr vs
+      mk_enum tref variant.id vs
   end
 end
 

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -426,15 +426,6 @@ module Adt = struct
     | Extension (PolyVal ty_id) -> ty_id
     | _ -> todo_migration "as_type_var unop"
 
-  let discriminant_of v =
-    match kind v with
-    | Extension (Enum (var_id, _)) ->
-        let adt = t_as_enum v.node.ty in
-        let vars = Crate.as_enum adt in
-        let variant = Types.VariantId.nth vars var_id in
-        BV.of_literal variant.discriminant
-    | _ -> todo_migration "discriminant_of unop"
-
   let field_of idx v =
     match kind v with
     | Extension (Tuple vs) -> (
@@ -494,6 +485,21 @@ module Adt = struct
 
   let update_field_of_variant var idx f v =
     set_field_of_variant var idx (f (field_of_variant var idx v)) v
+
+  let is_variant var_id v =
+    match kind v with
+    | Extension (Enum (var, _)) -> of_bool (Types.VariantId.equal_id var var_id)
+    | _ -> todo_migration "is_variant unop"
+
+  let discriminant_of (v : _ t) =
+    let variants = Crate.as_enum (t_as_enum v.node.ty) in
+    let rec aux : Types.variant list -> _ t = function
+      | [] -> L.failwith "discriminant_of: empty enum"
+      | [ var ] -> BV.of_literal var.discriminant
+      | var :: rest ->
+          ite (is_variant var.id v) (BV.of_literal var.discriminant) (aux rest)
+    in
+    aux variants
 
   module Checked = struct
     let mk_enum tref variant vs =

--- a/soteria-rust/lib/svalue/typed.mli
+++ b/soteria-rust/lib/svalue/typed.mli
@@ -236,6 +236,12 @@ module Adt : sig
   val as_tuple2 : [< T.tuple ] t -> [> T.any ] t * [> T.any ] t
   val as_tuple3 : [< T.tuple ] t -> [> T.any ] t * [> T.any ] t * [> T.any ] t
   val as_type_var : [< T.poly ] t -> Types.type_var_id
+
+  (** Whether the enum value is of the given variant. *)
+  val is_variant : Types.variant_id -> [< T.enum ] t -> [> T.sbool ] t
+
+  (** Get the discriminant of an enum. This may generate a large expression; if
+      you only need to check the variant, use {!is_variant} instead. *)
   val discriminant_of : [< T.enum ] t -> [> T.sint ] t
 
   (** Get the field of a tuple *)

--- a/soteria-rust/lib/svalue/typed.mli
+++ b/soteria-rust/lib/svalue/typed.mli
@@ -71,6 +71,7 @@ val t_usize : unit -> [> T.sint ] ty
 val t_lit : Types.literal_type -> [> T.sint ] ty
 val t_ptr_f : unit -> [> T.sptr_f ] ty
 val t_ptr_t : unit -> [> T.sptr_t ] ty
+val t_enum : Types.type_decl_ref -> [> T.enum ] ty
 
 (* casts *)
 
@@ -201,9 +202,12 @@ module Adt : sig
   (** Creates an array value with the given element type and elements. *)
   val mk_array : Types.ty -> [< T.any ] t iarray -> [> T.tuple ] t
 
-  (** Creates an enum value with the given discriminant and fields. *)
+  (** Creates an enum value with the given variant and fields. *)
   val mk_enum :
-    Types.type_decl_ref -> [< T.sint ] t -> [< T.any ] t list -> [> T.enum ] t
+    Types.type_decl_ref ->
+    Types.variant_id ->
+    [< T.any ] t list ->
+    [> T.enum ] t
 
   (** Creates a union value with the given value blocks. *)
   val mk_union : Types.type_decl_ref -> block list -> [> T.union ] t

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -9,12 +9,12 @@ open DecayMap.SM
 open Syntax
 
 (** Returns the variant id and variant matching the given discriminant. *)
-let variant_for_discr discr adt =
+let variant_for_enum (enum : Typed.([< T.enum ] t)) adt =
   let open Rustsymex in
   let open Syntax in
   let variants = Crate.as_enum adt in
   let* variant =
-    match_on variants ~constr:(fun v -> BV.of_literal v.discriminant ==@ discr)
+    match_on variants ~constr:(fun v -> Typed.Adt.is_variant v.id enum)
   in
   of_opt_not_impl "no matching variant for enum discriminant" variant
 
@@ -433,8 +433,7 @@ let rec encode ?depth ~offset (value : Typed.(T.any t)) (ty : Types.ty) :
     | Enum (_, layouts) -> (
         let adt = ty_as_adt ty in
         let value = Typed.cast_enum ~adt value in
-        let discr = Typed.Adt.discriminant_of value in
-        let* variant = variant_for_discr discr adt in
+        let* variant = variant_for_enum value adt in
         let variant = variant.id in
         let fields = Typed.Adt.as_enum_of_variant variant value in
         let++ fields =
@@ -570,8 +569,7 @@ let rec validity ?(check_ref = fun _ _ -> Rustsymex.Result.ok ()) ty v f =
   (* undefined.validity.enum *)
   | TAdt adt when Crate.is_enum adt ->
       let v = Typed.cast_enum ~adt v in
-      let discr = Typed.Adt.discriminant_of v in
-      let* variant = variant_for_discr discr adt in
+      let* variant = variant_for_enum v adt in
       Iter.of_list (field_tys variant.fields)
       |> Iter.mapi (fun i ty -> (ty, Typed.Adt.field_of_variant variant.id i v))
       |> iter_iter ~f:(fun (ty, v) -> validity ~check_ref ty v f)
@@ -858,8 +856,7 @@ let rec ref_tys_in
       (Typed.Adt.mk_array ty (Iarray.of_list vs), acc)
   | TAdt adt when Crate.is_enum adt ->
       let v = Typed.cast_enum ~adt v in
-      let discr = Typed.Adt.discriminant_of v in
-      let* var = variant_for_discr discr adt in
+      let* var = variant_for_enum v adt in
       let vs = Typed.Adt.as_enum_of_variant var.id v in
       let++ vs, acc = fs' init (field_tys Types.(var.fields)) vs in
       (Typed.Adt.mk_enum adt var.id vs, acc)

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -361,8 +361,7 @@ struct
         let* variant = variant_of_enum ~offset ty in
         let+ fields = iter (iter_fields ~variant ?meta layout ty) offset in
         let variant = Types.VariantId.nth variants variant in
-        let discr = BV.of_literal variant.discriminant in
-        Typed.Adt.mk_enum adt discr fields
+        Typed.Adt.mk_enum adt variant.id fields
     | Enum _, _ -> L.failwith "decode: expected enum type for enum layout"
 end
 
@@ -757,7 +756,7 @@ let rec nondet_raw :
             match variant with Some v -> return v | None -> vanish ()
           in
           let++ fields = nondets_raw @@ field_tys variant.fields in
-          Typed.Adt.mk_enum adt (BV.of_literal variant.discriminant) fields
+          Typed.Adt.mk_enum adt variant.id fields
       | Struct fields ->
           let++ fields = nondets_raw @@ field_tys fields in
           Typed.Adt.mk_tuple fields
@@ -863,7 +862,7 @@ let rec ref_tys_in
       let* var = variant_for_discr discr adt in
       let vs = Typed.Adt.as_enum_of_variant var.id v in
       let++ vs, acc = fs' init (field_tys Types.(var.fields)) vs in
-      (Typed.Adt.mk_enum adt discr vs, acc)
+      (Typed.Adt.mk_enum adt var.id vs, acc)
   | TPattern (inner, _) -> f init inner v
   | _ -> Result.ok (v, init)
 


### PR DESCRIPTION
In the process of encoding Rust values into SMT, I realised that our current system of having symbolic discriminants is incompatible with SMT-encoding. Given an enum value, the encoder must know what variant it is, without performing any symex. This is of course not possible with a symbolic discriminant! This was always kind of hacky anyways: an enum also carries its list of values, and that list is concrete, so this only really worked for some edge cases.

This simplifies a bit of code; the only cost is that the `Ord` binop now branches if multiple results are possible. This will be fixed when we have proper symbolic enums though, so it's a temporary regression.

```diff
-  | Enum of 'ghost sv * 'ghost sv list  (** discriminant * values *)
+  | Enum of Types.variant_id * ''ghost sv list (** variant * values *)
```

As a result, the natural operation to have isn't `discriminant_of` anymore but `is_variant`! `discriminant_of` is now just expressed in terms of `is_variant` and `ite`s -- this will make life easier when we do SMT encoding.

ill probably write somewhere a tutorial on what im learning from this process and some best practices when making extensions