### PR TITLE
Add solver declarations

### DIFF
--- a/soteria/lib/bv_values/encoding.ml
+++ b/soteria/lib/bv_values/encoding.ml
@@ -19,14 +19,14 @@ module Ptr_sort = struct
 
   (** The SMT-LIB constructor for [n]-bit pointers, applied to the location and
       offset terms. *)
-  let mk_ptr n loc ofs = atom (con n) $$ [ loc; ofs ]
+  let mk_ptr n loc ofs = con n $$. [ loc; ofs ]
 
   (** The SMT-LIB selector for the location of [n]-bit pointers. *)
   let loc_sel n = quote (Fmt.str "@ptr<%d>.loc" n)
 
   (** The SMT-LIB selector for the location of [n]-bit pointers, applied to a
       pointer term. *)
-  let get_loc n ptr = atom (loc_sel n) $ ptr
+  let get_loc n ptr = loc_sel n $. ptr
 
   (** The SMT-LIB selector for the offset of [n]-bit pointers. *)
   let ofs_sel n = quote (Fmt.str "@ptr<%d>.ofs" n)
@@ -61,7 +61,7 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     | TFloat F32 -> t_f32
     | TFloat F64 -> t_f64
     | TFloat F128 -> t_f128
-    | TSeq ty -> t_seq $ sort_of_ty ty
+    | TSeq ty -> t_seq (sort_of_ty ty)
     | TPointer n -> Ptr_sort.sort n
     | TBitVector n -> t_bits n
     | TExtension x -> Typed.Ext.encode_ty sort_of_ty x

--- a/soteria/lib/bv_values/encoding.ml
+++ b/soteria/lib/bv_values/encoding.ml
@@ -26,7 +26,8 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     | TBitVector n -> t_bits n
     | TExtension x -> Typed.Ext.encode_ty sort_of_ty x
 
-  let memo_encode_value_tbl : sexp Svalue.Hashtbl.t = Svalue.Hashtbl.create 1023
+  let memo_encode_value_tbl : (sexp * Solvers.Decls.t list) Svalue.Hashtbl.t =
+    Svalue.Hashtbl.create 1023
 
   let rm_to_smt : RoundingMode.t -> Smt.RoundingMode.t = function
     | NearestTiesToEven -> NearestTiesToEven
@@ -135,10 +136,20 @@ module Make (Typed : Typed_intf.Solver_value) = struct
 
   and encode_value_memo v =
     match Svalue.Hashtbl.find_opt memo_encode_value_tbl v with
-    | Some k -> k
+    | Some (k, decls) ->
+        List.iter (fun d -> Effect.perform (Solvers.Decls.Declare d)) decls;
+        k
     | None ->
-        let k = encode_value v in
-        Svalue.Hashtbl.add memo_encode_value_tbl v k;
+        let decls = ref [] in
+        let k =
+          try encode_value v
+          with effect Solvers.Decls.Declare d, cont ->
+            decls := d :: !decls;
+            (* forward to the solver's own handler *)
+            Effect.perform (Solvers.Decls.Declare d);
+            Effect.Deep.continue cont ()
+        in
+        Svalue.Hashtbl.add memo_encode_value_tbl v (k, List.rev !decls);
         k
 
   let encode_value (v : Svalue.t) =

--- a/soteria/lib/bv_values/encoding.ml
+++ b/soteria/lib/bv_values/encoding.ml
@@ -3,12 +3,52 @@ open Soteria_std
 open Smt
 open Svalue
 
+(** Raw pointers are encoded as a pair datatype of location and offset, declared
+    on the fly through {!Solvers.Decls}. Exposed to allow extensions to depend
+    on it.
+
+    A pointer of width [n] is encoded as a datatype with two fields, both
+    bitvectors of width [n]: the location and the offset. *)
+module Ptr_sort = struct
+  (** The SMT-LIB sort for [n]-bit pointers. *)
+  let name n = quote (Fmt.str "@ptr<%d>" n)
+
+  (** The SMT-LIB constructor for [n]-bit pointers; receives the location and
+      offset as arguments. *)
+  let con n = quote (Fmt.str "@mk-ptr<%d>" n)
+
+  (** The SMT-LIB constructor for [n]-bit pointers, applied to the location and
+      offset terms. *)
+  let mk_ptr n loc ofs = atom (con n) $$ [ loc; ofs ]
+
+  (** The SMT-LIB selector for the location of [n]-bit pointers. *)
+  let loc_sel n = quote (Fmt.str "@ptr<%d>.loc" n)
+
+  (** The SMT-LIB selector for the location of [n]-bit pointers, applied to a
+      pointer term. *)
+  let get_loc n ptr = atom (loc_sel n) $ ptr
+
+  (** The SMT-LIB selector for the offset of [n]-bit pointers. *)
+  let ofs_sel n = quote (Fmt.str "@ptr<%d>.ofs" n)
+
+  (** The SMT-LIB selector for the offset of [n]-bit pointers, applied to a
+      pointer term. *)
+  let get_ofs n ptr = atom (ofs_sel n) $ ptr
+
+  (* Declares (at most once) the datatype for [n]-bit pointers; returns its
+     sort. *)
+  let sort n =
+    let name = name n in
+    Solvers.Decls.declare ~key:name (fun yield ->
+        yield
+          (declare_datatype name []
+             [ (con n, [ (loc_sel n, t_bits n); (ofs_sel n, t_bits n) ]) ]));
+    Atom name
+end
+
 (** Lowers the svalues of a built typed layer [Typed] (from {!Typed.Make}) into
     SMT terms and sorts for the Z3 backend. *)
 module Make (Typed : Typed_intf.Solver_value) = struct
-  let pointers_not_supported () =
-    L.failwith "Encoding of pointers is not supported in Bv_values"
-
   module Svalue = Typed.Svalue
 
   type t = Svalue.t
@@ -22,7 +62,7 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     | TFloat F64 -> t_f64
     | TFloat F128 -> t_f128
     | TSeq ty -> t_seq $ sort_of_ty ty
-    | TPointer _ -> pointers_not_supported ()
+    | TPointer n -> Ptr_sort.sort n
     | TBitVector n -> t_bits n
     | TExtension x -> Typed.Ext.encode_ty sort_of_ty x
 
@@ -36,11 +76,11 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     | Floor -> Floor
     | Truncate -> Truncate
 
-  let smt_of_unop : Unop.t -> sexp -> sexp = function
+  let smt_of_unop ~ty : Unop.t -> sexp -> sexp = function
     | Not -> bool_not
     | FAbs -> fp_abs
-    | GetPtrLoc -> pointers_not_supported ()
-    | GetPtrOfs -> pointers_not_supported ()
+    | GetPtrLoc -> Ptr_sort.get_loc (Svalue.size_of ty)
+    | GetPtrOfs -> Ptr_sort.get_ofs (Svalue.size_of ty)
     | BvOfBool n -> fun b -> ite b (bv_k n Z.one) (bv_k n Z.zero)
     | BvOfFloat (rm, true, n) -> sbv_of_float (rm_to_smt rm) n
     | BvOfFloat (rm, false, n) -> ubv_of_float (rm_to_smt rm) n
@@ -110,7 +150,9 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     | BitVec z ->
         let n = Svalue.size_of v.node.ty in
         bv_k n z
-    | Ptr _ -> pointers_not_supported ()
+    | Ptr (l, o) ->
+        Ptr_sort.mk_ptr (Svalue.size_of v.node.ty) (encode_value_memo l)
+          (encode_value_memo o)
     | Seq vs -> (
         match vs with
         | [] -> L.failwith "need type to encode empty lists"
@@ -123,8 +165,8 @@ module Make (Typed : Typed_intf.Solver_value) = struct
         let encode_binder (v, ty) = list [ encode_var v; sort_of_ty ty ] in
         exists (List.map encode_binder vs) (encode_value_memo sv)
     | Unop (unop, v1) ->
-        let v1 = encode_value_memo v1 in
-        smt_of_unop unop v1
+        let e1 = encode_value_memo v1 in
+        smt_of_unop ~ty:v1.node.ty unop e1
     | Binop (binop, v1, v2) ->
         let v1 = encode_value_memo v1 in
         let v2 = encode_value_memo v2 in

--- a/soteria/lib/smt/smt.ml
+++ b/soteria/lib/smt/smt.ml
@@ -25,6 +25,7 @@ let app_ f (args : sexp list) : sexp = app (Atom f) args
 let ( $$ ) = app
 let ( $$. ) = app_
 let ( $ ) f v = f $$ [ v ]
+let ( $. ) f v = f $$. [ v ]
 
 (* Type annotation *)
 let as_type x t = "as" $$. [ x; t ]
@@ -226,7 +227,7 @@ let f128_k f =
 let f16_k f =
   app (ifam "to_fp" (float_shape 16)) [ RoundingMode.default; f32_k f ]
 
-let fp_abs f = "fp.abs" $$. [ f ]
+let fp_abs f = "fp.abs" $. f
 let fp_eq f1 f2 = "fp.eq" $$. [ f1; f2 ]
 let fp_leq f1 f2 = "fp.leq" $$. [ f1; f2 ]
 let fp_lt f1 f2 = "fp.lt" $$. [ f1; f2 ]
@@ -239,11 +240,11 @@ let fp_rem f1 f2 = "fp.rem" $$. [ f1; f2 ]
 (* [fp_is fc f] tests if [f] belongs to floating-point class [fc]. *)
 let fp_is (fc : fpclass) f =
   match fc with
-  | FP_normal -> "fp.isNormal" $$. [ f ]
-  | FP_subnormal -> "fp.isSubnormal" $$. [ f ]
-  | FP_zero -> "fp.isZero" $$. [ f ]
-  | FP_infinite -> "fp.isInfinite" $$. [ f ]
-  | FP_nan -> "fp.isNaN" $$. [ f ]
+  | FP_normal -> "fp.isNormal" $. f
+  | FP_subnormal -> "fp.isSubnormal" $. f
+  | FP_zero -> "fp.isZero" $. f
+  | FP_infinite -> "fp.isInfinite" $. f
+  | FP_nan -> "fp.isNaN" $. f
 
 let fp_round (rm : RoundingMode.t) f =
   "fp.roundToIntegral" $$. [ RoundingMode.to_sexp rm; f ]
@@ -251,34 +252,34 @@ let fp_round (rm : RoundingMode.t) f =
 (** {2 Float/bit-vector conversions} *)
 
 (* Bitwise reinterpretation of [bv] as a float of [size] bits (16/32/64/128). *)
-let float_of_bv size bv = app (ifam "to_fp" (float_shape size)) [ bv ]
+let float_of_bv size bv = ifam "to_fp" (float_shape size) $ bv
 
 (* Numeric conversion of an unsigned bit-vector to a float. *)
 let float_of_ubv rm size bv =
-  app (ifam "to_fp_unsigned" (float_shape size)) [ RoundingMode.to_sexp rm; bv ]
+  ifam "to_fp_unsigned" (float_shape size) $$ [ RoundingMode.to_sexp rm; bv ]
 
 (* Numeric conversion of a signed bit-vector to a float. *)
 let float_of_sbv rm size bv =
-  app (ifam "to_fp" (float_shape size)) [ RoundingMode.to_sexp rm; bv ]
+  ifam "to_fp" (float_shape size) $$ [ RoundingMode.to_sexp rm; bv ]
 
 (* Numeric conversion of a float to an unsigned [n]-bit bit-vector; undefined if
    out of range, NaN or inf. *)
 let ubv_of_float rm n f =
-  app (ifam "fp.to_ubv" [ n ]) [ RoundingMode.to_sexp rm; f ]
+  ifam "fp.to_ubv" [ n ] $$ [ RoundingMode.to_sexp rm; f ]
 
 (* Numeric conversion of a float to a signed [n]-bit bit-vector; undefined if
    out of range, NaN or inf. *)
 let sbv_of_float rm n f =
-  app (ifam "fp.to_sbv" [ n ]) [ RoundingMode.to_sexp rm; f ]
+  ifam "fp.to_sbv" [ n ] $$ [ RoundingMode.to_sexp rm; f ]
 
 (** {2 Int/bit-vector conversions} *)
 
 (* [int_of_bv signed bv] reads [bv] as a (signed or unsigned) integer. *)
 let int_of_bv signed bv =
-  if signed then "sbv_to_int" $$. [ bv ] else "ubv_to_int" $$. [ bv ]
+  if signed then "sbv_to_int" $. bv else "ubv_to_int" $. bv
 
 (* [bv_of_int size n] converts integer [n] to a [size]-bit bit-vector. *)
-let bv_of_int size n = app (ifam "int_to_bv" [ size ]) [ n ]
+let bv_of_int size n = ifam "int_to_bv" [ size ] $ n
 
 (** {2 Bit-vector overflow predicates} *)
 
@@ -292,10 +293,11 @@ let bv_smulo l r = "bvsmulo" $$. [ l; r ]
 
 (** {2 Sequences} *)
 
-(* [t_seq $ elt] is the type of sequences of [elt]. *)
-let t_seq = atom "Seq"
-let seq_singl x = atom "seq.unit" $ x
-let seq_concat xs = atom "seq.++" $$ xs
+let t_seq elt = "Seq" $. elt
+let seq_empty = atom "seq.empty"
+let seq_singl x = "seq.unit" $. x
+let seq_concat xs = "seq.++" $$. xs
+let seq_nth s i = "seq.nth" $$. [ s; i ]
 
 (** {2 Commands} *)
 
@@ -308,6 +310,10 @@ let declare f t = declare_fun f [] t
 
 type con_field = string * sexp
 
+(** [declare_datatype name type_params cons] is the SMT-LIB command to declare a
+    datatype [name] with type parameters [type_params] and constructors [cons],
+    where each constructor is a pair of its name and a list of its fields, each
+    field being a pair of its name and its type. *)
 let declare_datatype name type_params cons =
   let mk_field ((f, arg_ty) : con_field) = List [ Atom f; arg_ty ] in
   let mk_con (c, fs) = List (Atom c :: List.map mk_field fs) in

--- a/soteria/lib/smt/smt.ml
+++ b/soteria/lib/smt/smt.ml
@@ -35,6 +35,16 @@ let nat_zk x = Atom (Z.to_string x)
 let fam f is = List (Atom "_" :: Atom f :: is)
 let ifam f is = fam f (List.map nat_k is)
 
+(** [quote s] is [s] as a quoted symbol, so that it can contain arbitrary
+    characters, except [|] and backslash characters which are replaced. *)
+let quote s =
+  let must_escape = [%matches? '|' | '\\'] in
+  let s =
+    if not (String.exists must_escape s) then s
+    else String.map (fun c -> if must_escape c then '!' else c) s
+  in
+  "|" ^ s ^ "|"
+
 (** {2 Booleans} *)
 
 let t_bool = Atom "Bool"
@@ -284,7 +294,7 @@ let bv_smulo l r = "bvsmulo" $$. [ l; r ]
 
 (* [t_seq $ elt] is the type of sequences of [elt]. *)
 let t_seq = atom "Seq"
-let seq_singl x = atom "seq.unit" $$ [ x ]
+let seq_singl x = atom "seq.unit" $ x
 let seq_concat xs = atom "seq.++" $$ xs
 
 (** {2 Commands} *)
@@ -308,6 +318,10 @@ let declare_datatype name type_params cons =
     | _ -> "par" $$. [ List (List.map atom type_params); mk_cons ]
   in
   "declare-datatype" $$. [ Atom name; def ]
+
+(** [tester con v] is [((_ is con) v)], true iff [v] was built with datatype
+    constructor [con]. *)
+let tester con v = fam "is" [ Atom con ] $ v
 
 let assume e = "assert" $$. [ e ]
 

--- a/soteria/lib/solvers/decls.ml
+++ b/soteria/lib/solvers/decls.ml
@@ -1,0 +1,37 @@
+(** Auxiliary SMT-LIB declarations required by value encodings.
+
+    A {{!Value.S}solver value} (or in some cases, a
+    {{!Soteria.Bv_values.Svalue.Value_ext}value extension} may need global
+    SMT-LIB declarations to support its encoding, e.g. declaring an algebraic
+    datatype for a recursive value type. Encoders cannot communicate with the
+    solver directly, so we instead provide a function, {!declare}, to allow
+    doing it.
+
+    Solver implementations (like {!Z3}) handle the raised effect, {!Declare}, by
+    de-duplicating declarations (by {!field:key}) and sending them to the
+    underlying solver process before the command that is about to be run.
+    {b There is no guarantee the declaration will still be in scope for whatever
+       command follows:} encoders must {e always} re-declare definitions they
+    may need. *)
+
+type t = {
+  key : string;
+      (** Canonical identifier for the declaration. Two {!declare}s with the
+          same [key] are assumed to produce identical [commands], and are
+          deduplicated. *)
+  commands : Smt.sexp Iter.t;
+      (** Lazily produces the SMT-LIB commands declaring the object(s); only
+          invoked if [key] is not already declared, so that the declaration is
+          never built otherwise. *)
+}
+
+(** [equal d1 d2] is [true] if [d1] and [d2] have the same {!field:key}. *)
+let equal (d1 : t) (d2 : t) = String.equal d1.key d2.key
+
+type _ Effect.t += Declare : t -> unit Effect.t
+
+(** [declare ~key commands] ensures the commands produced by [commands] have
+    been sent to the solver before the encoding being produced is used.
+    Producing the commands may itself [declare] the declarations it depends on:
+    they are sent before the commands produced. *)
+let declare ~key commands = Effect.perform (Declare { key; commands })

--- a/soteria/lib/solvers/solvers.ml
+++ b/soteria/lib/solvers/solvers.ml
@@ -7,10 +7,15 @@
     A solver relies on a value encoding, which is defined by the {!Value.S}
     signature as a way to encode values and types into SMT-LIB.
 
+    Encodings may require auxiliary global declarations (e.g. algebraic
+    datatypes); they request them through {!Decls.declare}, which solver
+    implementations handle.
+
     Soteria then provides an implementation of this interface for Z3 in {!Z3};
     more backends are planned for the future. *)
 
 module Solver_interface = Solver_interface
 module Value = Value
+module Decls = Decls
 module Z3 = Z3
 module Config = Config

--- a/soteria/lib/solvers/z3.ml
+++ b/soteria/lib/solvers/z3.ml
@@ -85,7 +85,9 @@ module Make (Value : Value.S) :
             Logs.Printers.pp_time elapsed
   end
 
-  type t = Smt.solver
+  module Decl_store = Soteria_std.Reversible.Make_mutable_array (Decls)
+
+  type t = { smt : Smt.solver; decls : Decl_store.t }
   type value = Value.t
   type ty = Value.ty
 
@@ -108,23 +110,34 @@ module Make (Value : Value.S) :
     in
     let solver = { solver with ack_command; command } in
     !initialize_solver solver;
-    solver
+    { smt = solver; decls = Decl_store.init () }
+
+  (** Handle the {!Decls.Declare} effect. We make this recursive, in case the
+      iterator itself calls [declare] again. *)
+  let rec handle_decls : 'a. t -> (unit -> 'a) -> 'a =
+   fun t f ->
+    try f ()
+    with effect Decls.Declare d, k ->
+      if not (Decl_store.exists t.decls (Decls.equal d)) then (
+        Decl_store.add t.decls d;
+        handle_decls t (fun () -> d.commands (command t.smt)));
+      Effect.Deep.continue k ()
 
   let declare_var solver name ty =
     let name = Symex.Var.to_string name in
-    let ty = Value.sort_of_ty ty in
+    let ty = handle_decls solver (fun () -> Value.sort_of_ty ty) in
     let sexp = declare name ty in
-    command solver sexp
+    command solver.smt sexp
 
   let add_constraint solver v =
-    let v = Value.encode_value v in
+    let v = handle_decls solver (fun () -> Value.encode_value v) in
     let sexp = Smt.assume v in
-    command solver sexp
+    command solver.smt sexp
 
   let check_sat solver : Symex.Solver_result.t =
     Stats.As_ctx.incr StatKeys.check_sats;
     let smt_res =
-      try check solver
+      try check solver.smt
       with Smt.UnexpectedSolverResponse s ->
         [%l.error "Unexpected solver response: %s" (Smt.to_string s)];
         Unknown
@@ -136,14 +149,23 @@ module Make (Value : Value.S) :
         [%l.info "Solver returned unknown"];
         Unknown
 
-  let push solver n = command solver (Smt.push n)
-  let pop solver n = command solver (Smt.pop n)
+  let push solver n =
+    for _ = 1 to n do
+      Decl_store.save solver.decls
+    done;
+    command solver.smt (Smt.push n)
+
+  let pop solver n =
+    Decl_store.backtrack_n solver.decls n;
+    command solver.smt (Smt.pop n)
+
   let save solver = push solver 1
   let backtrack_n solver n = pop solver n
 
   let reset solver =
-    command solver reset;
-    !initialize_solver solver
+    command solver.smt reset;
+    Decl_store.reset solver.decls;
+    !initialize_solver solver.smt
 
-  let get_model solver = try Some (Smt.get_model solver) with _ -> None
+  let get_model solver = try Some (Smt.get_model solver.smt) with _ -> None
 end

--- a/soteria/lib/soteria_std/iarray.ml
+++ b/soteria/lib/soteria_std/iarray.ml
@@ -15,4 +15,17 @@ let copy_and_update f vs =
   unsafe_of_array vs
 
 let copy_and_set idx x vs = copy_and_update (fun vs -> vs.(idx) <- x) vs
+
+let map_changed f vs =
+  let changed = ref false in
+  let res =
+    map
+      (fun x ->
+        let r = f x in
+        if r != x then changed := true;
+        r)
+      vs
+  in
+  (res, !changed)
+
 let pp ?sep pp_elt = Fmt.iter ?sep iter pp_elt

--- a/soteria/lib/soteria_std/iarray.mli
+++ b/soteria/lib/soteria_std/iarray.mli
@@ -17,6 +17,11 @@ val copy_and_update : ('a array -> unit) -> 'a t -> 'a t
 *)
 val copy_and_set : int -> 'a -> 'a t -> 'a t
 
+(** Map a function over an array and return both the resulting array and a
+    boolean indicating whether any element was changed (using physical equality
+    [!=]). *)
+val map_changed : ('a -> 'a) -> 'a t -> 'a t * bool
+
 val pp :
   ?sep:(Format.formatter -> unit -> unit) ->
   (Format.formatter -> 'a -> unit) ->

--- a/soteria/lib/soteria_std/reversible.ml
+++ b/soteria/lib/soteria_std/reversible.ml
@@ -96,6 +96,10 @@ end) : sig
       and return that value. *)
   val find_map : t -> (Elt.t -> 'a option) -> 'a option
 
+  (** Returns true if there exists a value in the current state for which [f]
+      returns [true]. *)
+  val exists : t -> (Elt.t -> bool) -> bool
+
   (** Return a sequence of all values in the current state, in reverse order. *)
   val to_seq_rev : t -> Elt.t Seq.t
 end = struct
@@ -129,6 +133,7 @@ end = struct
   let add (slots, _) v = Dynarray.add_last slots v
   let iter (slots, _) f = Dynarray.iter f slots
   let find_map (slots, _) f = Dynarray.find_map f slots
+  let exists (slots, _) f = Dynarray.exists f slots
   let to_seq_rev (slots, _) = Dynarray.to_seq_rev slots
 end
 


### PR DESCRIPTION
Add `Soteria.Solvers.Decls`, which allows value encodings to add declarations to the current scope, through an algebraic effect. Declarations are keyed and lazily computed: if two values in the same scope need the same declaration, its SMT encoding will only be created and sent to the solver once.

This is all done within `Solvers`, separately from `Soteria.Symex`, since it is solver-dependent.

Thanks to this, we can now also provide an encoding for `Bv_values`'s  pointers! this used to not be possible due to the need to make declarations that were dependent on the pointer size. This also will enable encoding Rust enums into SMT-LIB :) one step closer to #421 

im quite happy with the design of this but if you have better ideas i welcome them; i could have make the embedding a bit deeper i suppose rather than raising straight `sexp`s but i think this is simpler to use. i also contemplated adding a `Decls.declare_datatype` convenience that used the datatype's name as a key, but that would require evaluating all parts of the datatype eagerly, which seems like an anti-pattern when we're providing a lazy iterator