### PR TITLE
Encode rust values to SMT

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -44,8 +44,10 @@
    (>= 0.9.0))
   (ppx_subliner
    (>= 0.2.1))
-  ppx_deriving
-  ppx_deriving_hash
+  (ppx_deriving
+   (>= 6.1.3))
+  (ppx_deriving_hash
+   (>= 0.1.4))
   fmt
   printbox
   printbox-text

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -302,7 +302,7 @@ module Make (Borrows : Tree_borrows.T) = struct
   let pp_pretty ~ignore_freed ft { heap; _ } =
     let (ignore : 'a * Freeable_block_with_meta.t -> bool) =
       if ignore_freed then [%matches? _, { node = Freed; _ }]
-      else Fun.const false
+      else fun _ -> false
     in
     match heap with
     | None -> Fmt.pf ft "Empty State"

--- a/soteria-rust/lib/state/tree_state.ml
+++ b/soteria-rust/lib/state/tree_state.ml
@@ -302,7 +302,7 @@ module Make (Borrows : Tree_borrows.T) = struct
   let pp_pretty ~ignore_freed ft { heap; _ } =
     let (ignore : 'a * Freeable_block_with_meta.t -> bool) =
       if ignore_freed then [%matches? _, { node = Freed; _ }]
-      else fun _ -> false
+      else Fun.const false
     in
     match heap with
     | None -> Fmt.pf ft "Empty State"

--- a/soteria-rust/lib/svalue/encoding.ml
+++ b/soteria-rust/lib/svalue/encoding.ml
@@ -145,6 +145,7 @@ let encode_unop sort_of_ty ~ty : Unop.t -> sexp -> sexp = function
       gen_decl (Enum_sort.sort sort_of_ty adt);
       let variant = Types.VariantId.nth (Crate.as_enum adt) var in
       Enum_sort.get_field adt variant i
+  | ArrayField i -> fun v -> seq_nth v (int_k i)
 
 let encode_value sort_of_ty encode ~ty = function
   | Tuple vs ->

--- a/soteria-rust/lib/svalue/encoding.ml
+++ b/soteria-rust/lib/svalue/encoding.ml
@@ -1,0 +1,161 @@
+open Charon
+open Common.Charon_util
+open Soteria.Smt
+open Ext_base
+
+(** Small helper to lazily declare a sort. *)
+let declare_sort ?(type_params = []) name f =
+  Soteria.Solvers.Decls.declare ~key:name (fun k ->
+      k (declare_datatype name type_params (f ())));
+  Atom name
+
+module Tuple_sort = struct
+  let pp_args ft sorts = Fmt.(list ~sep:(any ", ") pp_sexp) ft sorts
+  let name sorts = quote (Fmt.str "@tuple<%a>" pp_args sorts)
+  let con sorts = quote (Fmt.str "@mk-tuple<%a>" pp_args sorts)
+  let field_sel sorts i = quote (Fmt.str "@tuple<%a>.%d" pp_args sorts i)
+  let mk sorts fields = con sorts $$. fields
+  let get_field sorts i v = field_sel sorts i $. v
+
+  let sort sorts =
+    declare_sort (name sorts) (fun () ->
+        [ (con sorts, List.mapi (fun i s -> (field_sel sorts i, s)) sorts) ])
+end
+
+module Enum_sort = struct
+  let pp_base ft adt = Fmt.pf ft "@enum<%a>" Crate.pp_type_decl_ref adt
+  let name adt = quote (Fmt.to_to_string pp_base adt)
+
+  let variant_con adt (variant : Types.variant) =
+    quote (Fmt.str "%a::%s" pp_base adt variant.variant_name)
+
+  let field_sel adt (variant : Types.variant) i =
+    quote (Fmt.str "%a::%s.%d" pp_base adt variant.variant_name i)
+
+  let mk adt variant fields = variant_con adt variant $$. fields
+  let get_field adt variant i v = field_sel adt variant i $. v
+  let is_variant adt variant v = tester (variant_con adt variant) v
+
+  let sort sort_of_ty (adt : Types.type_decl_ref) =
+    let variants = Crate.as_enum adt in
+    if List.is_empty variants then
+      L.failwith "Cannot encode the empty enum %a to SMT-LIB"
+        Crate.pp_type_decl_ref adt;
+    declare_sort (name adt) (fun () ->
+        variants
+        |> List.map @@ fun (variant : Types.variant) ->
+           let fields =
+             variant.fields
+             |> List.mapi @@ fun i (f : Types.field) ->
+                (field_sel adt variant i, sort_of_ty (ty_of_rust f.field_ty))
+           in
+           (variant_con adt variant, fields))
+end
+
+module Thin_ptr_sort = struct
+  module Ptr_sort = Soteria.Bv_values.Encoding.Ptr_sort
+
+  let pp_base ft () = Fmt.pf ft "@thin-ptr<%d>" (usize_bits ())
+  let name () = quote (Fmt.to_to_string pp_base ())
+  let con () = quote (Fmt.str "@mk-thin-ptr<%d>" (usize_bits ()))
+  let part_sel part = quote (Fmt.str "%a.%a" pp_base () Unop.pp_ptr_part part)
+  let mk ptr size align = con () $$. [ ptr; size; align ]
+  let get_part part v = part_sel part $. v
+
+  let sort () =
+    declare_sort (name ()) (fun () ->
+        let bits = usize_bits () in
+        [
+          ( con (),
+            [
+              (part_sel PtrInner, Ptr_sort.sort bits);
+              (part_sel PtrSize, t_bits bits);
+              (part_sel PtrAlign, t_bits bits);
+            ] );
+        ])
+end
+
+module Ptr_meta_sort = struct
+  let base () = Fmt.str "@ptr-meta<%d>" (usize_bits ())
+  let name () = quote (base ())
+  let none_con () = quote (base () ^ "::none")
+  let int_con () = quote (base () ^ "::int")
+  let ptr_con () = quote (base () ^ "::ptr")
+  let int_sel () = quote (base () ^ "::int.0")
+  let ptr_sel () = quote (base () ^ "::ptr.0")
+  let mk_none () = none_con () $$. []
+  let mk_int v = int_con () $. v
+  let mk_ptr v = ptr_con () $. v
+  let get_int v = int_sel () $. v
+  let get_ptr v = ptr_sel () $. v
+
+  let sort () =
+    declare_sort (name ()) (fun () ->
+        let thin_sort = Thin_ptr_sort.sort () in
+        [
+          (none_con (), []);
+          (int_con (), [ (int_sel (), t_bits (usize_bits ())) ]);
+          (ptr_con (), [ (ptr_sel (), thin_sort) ]);
+        ])
+end
+
+module Full_ptr_sort = struct
+  let base () = Fmt.str "@full-ptr<%d>" (usize_bits ())
+  let name () = quote (base ())
+  let con () = quote (Fmt.str "@mk-full-ptr<%d>" (usize_bits ()))
+  let ptr_sel () = quote (base () ^ ".ptr")
+  let meta_sel () = quote (base () ^ ".meta")
+  let mk ptr meta = con () $$. [ ptr; meta ]
+  let get_ptr v = ptr_sel () $. v
+  let get_meta v = meta_sel () $. v
+
+  let sort () =
+    declare_sort (name ()) (fun () ->
+        let thin_sort = Thin_ptr_sort.sort () in
+        let meta_sort = Ptr_meta_sort.sort () in
+        [ (con (), [ (ptr_sel (), thin_sort); (meta_sel (), meta_sort) ]) ])
+end
+
+(* More explicit than an [ignore] *)
+let gen_decl = ignore
+
+let encode_ty sort_of_ty = function
+  | TTuple tys -> Tuple_sort.sort (List.map sort_of_ty tys)
+  | TEnum adt -> Enum_sort.sort sort_of_ty adt
+  | TArray (ty, _) -> t_seq (sort_of_ty ty)
+  | TThinPtr -> Thin_ptr_sort.sort ()
+  | TFullPtr -> Full_ptr_sort.sort ()
+  | TPtrMeta -> Ptr_meta_sort.sort ()
+  | (TUnion _ | TPolyType) as ty ->
+      L.failwith "Cannot encode type %a to SMT-LIB" pp_ext_ty ty
+
+let encode_value sort_of_ty encode ~ty = function
+  | Tuple vs ->
+      let tys = t_as_tuple ty in
+      let sorts = List.map sort_of_ty tys in
+      gen_decl (Tuple_sort.sort sorts);
+      Tuple_sort.mk sorts (List.map encode vs)
+  | Enum (var_id, vs) ->
+      let adt = t_as_enum ty in
+      gen_decl (Enum_sort.sort sort_of_ty adt);
+      let variant = Types.VariantId.nth (Crate.as_enum adt) var_id in
+      Enum_sort.mk adt variant (List.map encode vs)
+  | Array vs ->
+      let elem_ty, len = t_as_array ty in
+      if Z.equal Z.zero len then as_type seq_empty (t_seq (sort_of_ty elem_ty))
+      else
+        Iarray.to_list vs
+        |> List.map (fun v -> seq_singl (encode v))
+        |> seq_concat
+  | ThinPtr { ptr; size; align; tag = _ignored } ->
+      gen_decl (Thin_ptr_sort.sort ());
+      Thin_ptr_sort.mk (encode ptr) (encode size) (encode align)
+  | Ptr (ptr, meta) ->
+      gen_decl (Full_ptr_sort.sort ());
+      Full_ptr_sort.mk (encode ptr) (encode meta)
+  | PtrMeta MetaUnit -> Ptr_meta_sort.mk_none ()
+  | PtrMeta (MetaLen v) -> Ptr_meta_sort.mk_int (encode v)
+  | PtrMeta (MetaVTable v) -> Ptr_meta_sort.mk_ptr (encode v)
+  | Unop (op, v) -> encode_unop sort_of_ty ~ty:v.node.ty op (encode v)
+  | Union _ -> L.failwith "Cannot encode union values to SMT-LIB"
+  | PolyVal _ -> L.failwith "Cannot encode polymorphic values to SMT-LIB"

--- a/soteria-rust/lib/svalue/encoding.ml
+++ b/soteria-rust/lib/svalue/encoding.ml
@@ -133,6 +133,9 @@ let encode_unop sort_of_ty ~ty : Unop.t -> sexp -> sexp = function
   | ThinPtrPart part ->
       gen_decl (Thin_ptr_sort.sort ());
       Thin_ptr_sort.get_part part
+  | FullPtrInner ->
+      gen_decl (Full_ptr_sort.sort ());
+      Full_ptr_sort.get_ptr
 
 let encode_value sort_of_ty encode ~ty = function
   | Tuple vs ->

--- a/soteria-rust/lib/svalue/encoding.ml
+++ b/soteria-rust/lib/svalue/encoding.ml
@@ -140,6 +140,11 @@ let encode_unop sort_of_ty ~ty : Unop.t -> sexp -> sexp = function
       let sorts = List.map sort_of_ty (t_as_tuple ty) in
       gen_decl (Tuple_sort.sort sorts);
       Tuple_sort.get_field sorts i
+  | VariantField (var, i) ->
+      let adt = t_as_enum ty in
+      gen_decl (Enum_sort.sort sort_of_ty adt);
+      let variant = Types.VariantId.nth (Crate.as_enum adt) var in
+      Enum_sort.get_field adt variant i
 
 let encode_value sort_of_ty encode ~ty = function
   | Tuple vs ->

--- a/soteria-rust/lib/svalue/encoding.ml
+++ b/soteria-rust/lib/svalue/encoding.ml
@@ -136,6 +136,10 @@ let encode_unop sort_of_ty ~ty : Unop.t -> sexp -> sexp = function
   | FullPtrInner ->
       gen_decl (Full_ptr_sort.sort ());
       Full_ptr_sort.get_ptr
+  | Field i ->
+      let sorts = List.map sort_of_ty (t_as_tuple ty) in
+      gen_decl (Tuple_sort.sort sorts);
+      Tuple_sort.get_field sorts i
 
 let encode_value sort_of_ty encode ~ty = function
   | Tuple vs ->

--- a/soteria-rust/lib/svalue/encoding.ml
+++ b/soteria-rust/lib/svalue/encoding.ml
@@ -129,6 +129,11 @@ let encode_ty sort_of_ty = function
   | (TUnion _ | TPolyType) as ty ->
       L.failwith "Cannot encode type %a to SMT-LIB" pp_ext_ty ty
 
+let encode_unop sort_of_ty ~ty : Unop.t -> sexp -> sexp = function
+  | ThinPtrPart part ->
+      gen_decl (Thin_ptr_sort.sort ());
+      Thin_ptr_sort.get_part part
+
 let encode_value sort_of_ty encode ~ty = function
   | Tuple vs ->
       let tys = t_as_tuple ty in

--- a/soteria-rust/lib/svalue/encoding.ml
+++ b/soteria-rust/lib/svalue/encoding.ml
@@ -145,6 +145,12 @@ let encode_unop sort_of_ty ~ty : Unop.t -> sexp -> sexp = function
       gen_decl (Enum_sort.sort sort_of_ty adt);
       let variant = Types.VariantId.nth (Crate.as_enum adt) var in
       Enum_sort.get_field adt variant i
+  | IsVariant var ->
+      let adt = t_as_enum ty in
+      let variants = Crate.as_enum adt in
+      let variant = Types.VariantId.nth variants var in
+      gen_decl (Enum_sort.sort sort_of_ty adt);
+      Enum_sort.is_variant adt variant
   | ArrayField i -> fun v -> seq_nth v (int_k i)
 
 let encode_value sort_of_ty encode ~ty = function

--- a/soteria-rust/lib/svalue/encoding.ml
+++ b/soteria-rust/lib/svalue/encoding.ml
@@ -136,6 +136,11 @@ let encode_unop sort_of_ty ~ty : Unop.t -> sexp -> sexp = function
   | FullPtrInner ->
       gen_decl (Full_ptr_sort.sort ());
       Full_ptr_sort.get_ptr
+  | FullPtrMeta ->
+      gen_decl (Ptr_meta_sort.sort ());
+      Full_ptr_sort.get_meta
+  | PtrMetaAs MetaLen -> Ptr_meta_sort.get_int
+  | PtrMetaAs MetaVTable -> Ptr_meta_sort.get_ptr
   | Field i ->
       let sorts = List.map sort_of_ty (t_as_tuple ty) in
       gen_decl (Tuple_sort.sort sorts);

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -33,6 +33,7 @@ let pp pp ft v =
   | PolyVal tid -> Fmt.pf ft "PolyVal(%a)" Charon.Types.pp_type_var_id tid
   | Unop (ThinPtrPart part, v) -> Fmt.pf ft "%a.%a" pp v Unop.pp_ptr_part part
   | Unop (FullPtrInner, v) -> Fmt.pf ft "thin(%a)" pp v
+  | Unop (Field i, v) -> Fmt.pf ft "%a.%d" pp v i
 
 let iter_vars_ptr iter_vars { ptr; size; align; tag = _ } =
   iter_vars ptr;

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -31,6 +31,7 @@ let pp pp ft v =
         (Fmt.list ~sep:(Fmt.any ", ") (pp_block pp pp pp pp))
         vs
   | PolyVal tid -> Fmt.pf ft "PolyVal(%a)" Charon.Types.pp_type_var_id tid
+  | Unop (ThinPtrPart part, v) -> Fmt.pf ft "%a.%a" pp v Unop.pp_ptr_part part
 
 let iter_vars_ptr iter_vars { ptr; size; align; tag = _ } =
   iter_vars ptr;
@@ -58,6 +59,7 @@ let iter_vars iter_vars = function
   | Array vals -> Iarray.iter iter_vars vals
   | Union vs -> List.iter (iter_vars_block iter_vars) vs
   | PolyVal _ -> ()
+  | Unop (_, v) -> iter_vars v
 
 (* Allocation-free structural hash *)
 let[@inline] combine h x = (h * 65599) + x
@@ -103,6 +105,7 @@ let hash = function
           combine (combine (combine acc v) offset.tag) size.tag)
         6 vs
   | PolyVal x -> combine 7 (Types.TypeVarId.to_int x)
+  | Unop (op, v) -> combine (combine (Unop.hash op) 9) v.tag
 
 let mk build ty v =
   match v with
@@ -116,6 +119,7 @@ let mk build ty v =
   | Enum (v_id, vs) -> mk_enum ~build (t_as_enum ty) v_id vs
   | Union blocks -> mk_union ~build (t_as_union ty) blocks
   | PolyVal ty_id -> mk_poly ~build ty_id
+  | Unop (op, v) -> apply_unop ~build op v
 
 let eval eval v =
   match v with
@@ -166,6 +170,9 @@ let eval eval v =
       in
       if changed then Union vs' else v
   | PolyVal _ -> v
+  | Unop (op, x) ->
+      let x' = eval x in
+      if x == x' then v else Unop (op, x')
 
 let rec apply_list apply ~missing_var s vs =
   match vs with
@@ -240,6 +247,9 @@ let apply_subst apply ~missing_var s = function
       let vs, s = apply_list (apply_block apply) ~missing_var s vs in
       (Union vs, s)
   | PolyVal _ as v -> (v, s)
+  | Unop (op, v) ->
+      let v, s = apply ~missing_var s v in
+      (Unop (op, v), s)
 
 let encode_ty = Encoding.encode_ty
 let encode_value = Encoding.encode_value

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -70,51 +70,9 @@ let iter_vars iter_vars = function
   | PolyVal _ -> ()
   | Unop (_, v) -> iter_vars v
 
-(* Allocation-free structural hash *)
-let[@inline] combine h x = (h * 65599) + x
-
-let rec hash_ty : 'ghost ty -> int = function
-  | TEnum ty -> combine 0 (Hashtbl.hash ty)
-  | TUnion ty -> combine 1 (Hashtbl.hash ty)
-  | TTuple tys ->
-      List.fold_left (fun acc ty -> combine acc (Sv.hash_ty hash_ty ty)) 2 tys
-  | TThinPtr -> 3
-  | TFullPtr -> 4
-  | TPolyType -> 5
-  | TArray (ty, n) -> combine (combine 6 (Sv.hash_ty hash_ty ty)) (Z.hash n)
-  | TPtrMeta -> 7
-
-(* TODO: so derivable *)
-let hash = function
-  | Ptr (ptr, meta) -> combine (combine ptr.tag 1) meta.tag
-  | PtrMeta MetaUnit -> combine 2 0
-  | PtrMeta (MetaLen v) -> combine 2 (combine v.tag 1)
-  | PtrMeta (MetaVTable v) -> combine 2 (combine v.tag 2)
-  | ThinPtr { ptr; tag; size; align } ->
-      combine
-        (combine (combine (combine ptr.tag 3) size.tag) align.tag)
-        (Option.fold ~none:(-1) ~some:Ptr_tag.hash tag)
-  | Enum (var, vals) ->
-      List.fold_left
-        (fun acc (v : _ sv) -> combine acc v.tag)
-        (combine (Types.VariantId.to_int var) 4)
-        vals
-  | Tuple vals ->
-      List.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 5 vals
-  | Array vals ->
-      Iarray.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 8 vals
-  | Union vs ->
-      List.fold_left
-        (fun acc { value; offset : _ sv; size : _ sv } ->
-          let v =
-            match value with
-            | Scalar (v : _ sv) -> v.tag
-            | Aggregate ((ag : _ sv), ty) -> combine ag.tag (Hashtbl.hash ty)
-          in
-          combine (combine (combine acc v) offset.tag) size.tag)
-        6 vs
-  | PolyVal x -> combine 7 (Types.TypeVarId.to_int x)
-  | Unop (op, v) -> combine (combine (Unop.hash op) 9) v.tag
+let hash_ghost _ = 0
+let hash v = hash_ext_t hash_ghost v
+let hash_ty t = hash_ext_ty hash_ghost t
 
 let mk build ty v =
   match v with

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -241,5 +241,5 @@ let apply_subst apply ~missing_var s = function
       (Union vs, s)
   | PolyVal _ as v -> (v, s)
 
-let encode_ty _ = failwith "TODO: encode Rust ext_ty"
-let encode_value _ = failwith "TODO: encode Rust ext_t"
+let encode_ty = Encoding.encode_ty
+let encode_value = Encoding.encode_value

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -36,6 +36,8 @@ let pp pp ft v =
   | Unop (Field i, v) -> Fmt.pf ft "%a.%d" pp v i
   | Unop (VariantField (var, i), v) ->
       Fmt.pf ft "%a.as<%a>.%d" pp v Types.pp_variant_id var i
+  | Unop (IsVariant var, v) ->
+      Fmt.pf ft "%a.is<%a>" pp v Types.pp_variant_id var
   | Unop (ArrayField i, v) -> Fmt.pf ft "%a[%d]" pp v i
 
 let iter_vars_ptr iter_vars { ptr; size; align; tag = _ } =

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -1,280 +1,188 @@
-[@@@warning "-unused-constructor"]
-
 open Charon
-module Sv = Soteria.Bv_values.Svalue
+include Ext_base
 
-(* the full values *)
-type 'ghost sv =
-  (('ghost, 'ghost ext_t, 'ghost ext_ty) Sv.t
-  [@equal fun a b -> Sv.equal a b] [@compare fun a b -> Sv.compare a b])
+type 'ghost ty = 'ghost ext_ty
+type 'ghost t = 'ghost ext_t
 
-and 'ghost svty = 'ghost ext_ty Sv.ty
+let equal = equal_ext_t
+let compare = compare_ext_t
+let equal_ty = equal_ext_ty
+let compare_ty = compare_ext_ty
+let pp_ty ft (ty : 'ghost ty) = pp_ext_ty ft ty
 
-(* pointers; for simplicity's sake, we hardcode the pointer type. We can improve
-   this later, but we lack a clear usecase for parametric pointer types, and
-   have a clear reason to want deeply-embedded pointers *)
-and 'ghost ptr = {
-  ptr : 'ghost sv;
-  tag : Ptr_tag.t option;
-  size : 'ghost sv;
-  align : 'ghost sv;
-}
+let pp pp ft v =
+  match v with
+  | Ptr (ptr, meta) -> Fmt.pf ft "Ptr(%a, %a)" pp ptr pp meta
+  | PtrMeta MetaUnit -> Fmt.pf ft "()"
+  | PtrMeta (MetaLen len) -> Fmt.pf ft "len(%a)" pp len
+  | PtrMeta (MetaVTable vtable) -> Fmt.pf ft "vtable(%a)" pp vtable
+  | ThinPtr ptr ->
+      Fmt.pf ft "%a[%a]" pp ptr.ptr
+        Fmt.(option ~none:(any "*") Ptr_tag.pp)
+        ptr.tag
+  | Enum (v, vals) ->
+      Fmt.pf ft "Enum(%a: %a)" Types.pp_variant_id v
+        (Fmt.list ~sep:(Fmt.any ", ") pp)
+        vals
+  | Tuple vals -> Fmt.pf ft "(%a)" (Fmt.list ~sep:(Fmt.any ", ") pp) vals
+  | Array vals -> Fmt.pf ft "[%a]" (Iarray.pp ~sep:(Fmt.any ", ") pp) vals
+  | Union vs ->
+      Fmt.pf ft "Union(%a)"
+        (Fmt.list ~sep:(Fmt.any ", ") (pp_block pp pp pp pp))
+        vs
+  | PolyVal tid -> Fmt.pf ft "PolyVal(%a)" Charon.Types.pp_type_var_id tid
 
-(** The value inside a {!block}: either a scalar or an aggregate that can be
-    split further. *)
-and ('sc, 'ag) block_value = Scalar of 'sc | Aggregate of 'ag * Types.ty
+let iter_vars_ptr iter_vars { ptr; size; align; tag = _ } =
+  iter_vars ptr;
+  iter_vars size;
+  iter_vars align
 
-(** A block of an encoded value: a value, along with the offset it is at and the
-    size it spans. [ty] is [Some] iff the value is a whole aggregate of that
-    type. *)
-and ('sc, 'ag, 'ofs, 'sz) block = {
-  value : ('sc, 'ag) block_value;
-  offset : 'ofs;
-  size : 'sz;
-}
+let iter_vars_block_value iter_vars = function
+  | Scalar v -> iter_vars v
+  | Aggregate (ag, _ty) -> iter_vars ag
 
-(* values *)
-and 'ghost ext_ty =
-  | TEnum of (Types.type_decl_ref[@printer Crate.pp_type_decl_ref])
-      (** the type decl ref of an {b enum} *)
-  | TUnion of (Types.type_decl_ref[@printer Crate.pp_type_decl_ref])
-      (** the type decl ref of a {b union} *)
-  | TTuple of 'ghost svty list  (** structs and tuples (ordered fields) *)
-  | TArray of 'ghost svty * Z.t
-      (** arrays (all elements share the same type) *)
-  | TThinPtr
-  | TFullPtr
-  | TPtrMeta
-      (** the type of a pointer's metadata (unit, length or metadata). this is
-          not exposed to the user! *)
-  | TPolyType
+let iter_vars_block iter_vars { value; offset; size } =
+  iter_vars_block_value iter_vars value;
+  iter_vars offset;
+  iter_vars size
 
-and 'g ptr_meta = MetaLen of 'g sv | MetaVTable of 'g sv | MetaUnit
+(* TODO: derivable *)
+let iter_vars iter_vars = function
+  | Ptr (ptr, meta) ->
+      iter_vars ptr;
+      iter_vars meta
+  | PtrMeta MetaUnit -> ()
+  | PtrMeta (MetaLen len | MetaVTable len) -> iter_vars len
+  | ThinPtr ptr -> iter_vars_ptr iter_vars ptr
+  | Enum (_, vals) | Tuple vals -> List.iter iter_vars vals
+  | Array vals -> Iarray.iter iter_vars vals
+  | Union vs -> List.iter (iter_vars_block iter_vars) vs
+  | PolyVal _ -> ()
 
-and 'ghost ext_t =
-  | Ptr of 'ghost sv * 'ghost sv  (** pointer, with meta *)
-  | PtrMeta of 'ghost ptr_meta
-  | ThinPtr of 'ghost ptr
-      (** thin pointer, without metadata but with extra info on the pointer *)
-  | Enum of Types.variant_id * 'ghost sv list  (** variant id * values *)
-  | Tuple of 'ghost sv list  (** structs and tuples: ordered values *)
-  | Array of 'ghost sv Iarray.t
-      (** arrays: ordered values, all of the same type *)
-  | Union of ('ghost sv, 'ghost sv, 'ghost sv, 'ghost sv) block list
-      (** list of blocks in the union *)
-  | PolyVal of Charon.Types.type_var_id
-      (** The opaque value of a type variable, identified by (type variable
-          index, unique identifier). *)
-[@@deriving eq, ord]
+(* Allocation-free structural hash *)
+let[@inline] combine h x = (h * 65599) + x
 
-let pp_block_value pp_v pp_ag ft = function
-  | Scalar v -> pp_v ft v
-  | Aggregate (ag, ty) -> Fmt.pf ft "%a : %a" pp_ag ag Types.pp_ty ty
+let rec hash_ty : 'ghost ty -> int = function
+  | TEnum ty -> combine 0 (Hashtbl.hash ty)
+  | TUnion ty -> combine 1 (Hashtbl.hash ty)
+  | TTuple tys ->
+      List.fold_left (fun acc ty -> combine acc (Sv.hash_ty hash_ty ty)) 2 tys
+  | TThinPtr -> 3
+  | TFullPtr -> 4
+  | TPolyType -> 5
+  | TArray (ty, n) -> combine (combine 6 (Sv.hash_ty hash_ty ty)) (Z.hash n)
+  | TPtrMeta -> 7
 
-let pp_block pp_v pp_ag pp_ofs pp_sz ft { value; offset; size } =
-  Fmt.pf ft "(%a: %a-%a)" pp_ofs offset
-    (pp_block_value pp_v pp_ag)
-    value pp_sz size
+(* TODO: so derivable *)
+let hash = function
+  | Ptr (ptr, meta) -> combine (combine ptr.tag 1) meta.tag
+  | PtrMeta MetaUnit -> combine 2 0
+  | PtrMeta (MetaLen v) -> combine 2 (combine v.tag 1)
+  | PtrMeta (MetaVTable v) -> combine 2 (combine v.tag 2)
+  | ThinPtr { ptr; tag; size; align } ->
+      combine
+        (combine (combine (combine ptr.tag 3) size.tag) align.tag)
+        (Option.fold ~none:(-1) ~some:Ptr_tag.hash tag)
+  | Enum (var, vals) ->
+      List.fold_left
+        (fun acc (v : _ sv) -> combine acc v.tag)
+        (combine (Types.VariantId.to_int var) 4)
+        vals
+  | Tuple vals ->
+      List.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 5 vals
+  | Array vals ->
+      Iarray.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 8 vals
+  | Union vs ->
+      List.fold_left
+        (fun acc { value; offset : _ sv; size : _ sv } ->
+          let v =
+            match value with
+            | Scalar (v : _ sv) -> v.tag
+            | Aggregate ((ag : _ sv), ty) -> combine ag.tag (Hashtbl.hash ty)
+          in
+          combine (combine (combine acc v) offset.tag) size.tag)
+        6 vs
+  | PolyVal x -> combine 7 (Types.TypeVarId.to_int x)
 
-let rec pp_ext_ty ft : 'ghost ext_ty -> unit = function
-  | TEnum ty -> Crate.pp_type_decl_ref ft ty
-  | TUnion ty -> Crate.pp_type_decl_ref ft ty
-  | TTuple tys -> Fmt.(brackets (list ~sep:semi pp_svty)) ft tys
-  | TArray (ty, n) -> Fmt.pf ft "[%a; %a]" pp_svty ty Z.pp n
-  | TThinPtr -> Fmt.string ft "TThinPtr"
-  | TFullPtr -> Fmt.string ft "TFullPtr"
-  | TPtrMeta -> Fmt.string ft "TPtrMeta"
-  | TPolyType -> Fmt.string ft "TPolyType"
+(* TODO: re-apply the smart constructors here *)
+let mk _ty v : _ Sv.t_kind = Extension v
 
-and pp_svty ft (ty : 'ghost svty) = Sv.pp_ty pp_ext_ty ft ty
+(* TODO: re-apply the smart constructors here *)
+let eval _eval x = x
 
-module Rust_ext :
-  Sv.Value_ext
-    with type 'ghost t = 'ghost ext_t
-     and type 'ghost ty = 'ghost ext_ty = struct
-  type 'ghost ty = 'ghost ext_ty
-  type 'ghost t = 'ghost ext_t
+let rec apply_list apply ~missing_var s vs =
+  match vs with
+  | [] -> ([], s)
+  | v :: vs ->
+      let v, s = apply ~missing_var s v in
+      let vs, s = apply_list apply ~missing_var s vs in
+      (v :: vs, s)
 
-  let equal = equal_ext_t
-  let compare = compare_ext_t
-  let equal_ty = equal_ext_ty
-  let compare_ty = compare_ext_ty
-  let pp_ty ft (ty : 'ghost ty) = pp_ext_ty ft ty
+let apply_iarray apply ~missing_var s arr =
+  let n = Iarray.length arr in
+  if n = 0 then (arr, s)
+  else begin
+    let s = ref s in
+    let out =
+      Iarray.map
+        (fun prev ->
+          let v, s' = apply ~missing_var !s prev in
+          s := s';
+          v)
+        arr
+    in
+    (out, !s)
+  end
 
-  let pp pp ft v =
-    match v with
-    | Ptr (ptr, meta) -> Fmt.pf ft "Ptr(%a, %a)" pp ptr pp meta
-    | PtrMeta MetaUnit -> Fmt.pf ft "()"
-    | PtrMeta (MetaLen len) -> Fmt.pf ft "len(%a)" pp len
-    | PtrMeta (MetaVTable vtable) -> Fmt.pf ft "vtable(%a)" pp vtable
-    | ThinPtr ptr ->
-        Fmt.pf ft "%a[%a]" pp ptr.ptr
-          Fmt.(option ~none:(any "*") Ptr_tag.pp)
-          ptr.tag
-    | Enum (v, vals) ->
-        Fmt.pf ft "Enum(%a: %a)" Types.pp_variant_id v
-          (Fmt.list ~sep:(Fmt.any ", ") pp)
-          vals
-    | Tuple vals -> Fmt.pf ft "(%a)" (Fmt.list ~sep:(Fmt.any ", ") pp) vals
-    | Array vals -> Fmt.pf ft "[%a]" (Iarray.pp ~sep:(Fmt.any ", ") pp) vals
-    | Union vs ->
-        Fmt.pf ft "Union(%a)"
-          (Fmt.list ~sep:(Fmt.any ", ") (pp_block pp pp pp pp))
-          vs
-    | PolyVal tid -> Fmt.pf ft "PolyVal(%a)" Charon.Types.pp_type_var_id tid
+let apply_subst_ptr apply ~missing_var s { ptr; size; align; tag } =
+  let ptr, s = apply ~missing_var s ptr in
+  let size, s = apply ~missing_var s size in
+  let align, s = apply ~missing_var s align in
+  ({ ptr; size; align; tag }, s)
 
-  let iter_vars_ptr iter_vars { ptr; size; align; tag = _ } =
-    iter_vars ptr;
-    iter_vars size;
-    iter_vars align
+let apply_subst_block_value apply ~missing_var s = function
+  | Scalar v ->
+      let v, s = apply ~missing_var s v in
+      (Scalar v, s)
+  | Aggregate (ag, ty) ->
+      let ag, s = apply ~missing_var s ag in
+      (Aggregate (ag, ty), s)
 
-  let iter_vars_block_value iter_vars = function
-    | Scalar v -> iter_vars v
-    | Aggregate (ag, _ty) -> iter_vars ag
+let apply_subst_block apply ~missing_var s { value; offset; size } =
+  let value, s = apply_subst_block_value apply ~missing_var s value in
+  let offset, s = apply ~missing_var s offset in
+  let size, s = apply ~missing_var s size in
+  ({ value; offset; size }, s)
 
-  let iter_vars_block iter_vars { value; offset; size } =
-    iter_vars_block_value iter_vars value;
-    iter_vars offset;
-    iter_vars size
+(* TODO: derivable *)
+let apply_subst apply ~missing_var s = function
+  | Ptr (v, m) ->
+      let v, s = apply ~missing_var s v in
+      let m, s = apply ~missing_var s m in
+      (Ptr (v, m), s)
+  | PtrMeta MetaUnit -> (PtrMeta MetaUnit, s)
+  | PtrMeta (MetaLen v) ->
+      let v, s = apply ~missing_var s v in
+      (PtrMeta (MetaLen v), s)
+  | PtrMeta (MetaVTable v) ->
+      let v, s = apply ~missing_var s v in
+      (PtrMeta (MetaVTable v), s)
+  | ThinPtr ptr ->
+      let ptr, s = apply_subst_ptr apply ~missing_var s ptr in
+      (ThinPtr ptr, s)
+  | Enum (var, vs) ->
+      let vs, s = apply_list apply ~missing_var s vs in
+      (Enum (var, vs), s)
+  | Tuple vs ->
+      let vs, s = apply_list apply ~missing_var s vs in
+      (Tuple vs, s)
+  | Array vs ->
+      let vs, s = apply_iarray apply ~missing_var s vs in
+      (Array vs, s)
+  | Union vs ->
+      let vs, s = apply_list (apply_subst_block apply) ~missing_var s vs in
+      (Union vs, s)
+  | PolyVal _ as v -> (v, s)
 
-  (* TODO: derivable *)
-  let iter_vars iter_vars = function
-    | Ptr (ptr, meta) ->
-        iter_vars ptr;
-        iter_vars meta
-    | PtrMeta MetaUnit -> ()
-    | PtrMeta (MetaLen len | MetaVTable len) -> iter_vars len
-    | ThinPtr ptr -> iter_vars_ptr iter_vars ptr
-    | Enum (_, vals) | Tuple vals -> List.iter iter_vars vals
-    | Array vals -> Iarray.iter iter_vars vals
-    | Union vs -> List.iter (iter_vars_block iter_vars) vs
-    | PolyVal _ -> ()
-
-  (* Allocation-free structural hash *)
-  let[@inline] combine h x = (h * 65599) + x
-
-  let rec hash_ty : 'ghost ty -> int = function
-    | TEnum ty -> combine 0 (Hashtbl.hash ty)
-    | TUnion ty -> combine 1 (Hashtbl.hash ty)
-    | TTuple tys ->
-        List.fold_left (fun acc ty -> combine acc (Sv.hash_ty hash_ty ty)) 2 tys
-    | TThinPtr -> 3
-    | TFullPtr -> 4
-    | TPolyType -> 5
-    | TArray (ty, n) -> combine (combine 6 (Sv.hash_ty hash_ty ty)) (Z.hash n)
-    | TPtrMeta -> 7
-
-  (* TODO: so derivable *)
-  let hash = function
-    | Ptr (ptr, meta) -> combine (combine ptr.tag 1) meta.tag
-    | PtrMeta MetaUnit -> combine 2 0
-    | PtrMeta (MetaLen v) -> combine 2 (combine v.tag 1)
-    | PtrMeta (MetaVTable v) -> combine 2 (combine v.tag 2)
-    | ThinPtr { ptr; tag; size; align } ->
-        combine
-          (combine (combine (combine ptr.tag 3) size.tag) align.tag)
-          (Option.fold ~none:(-1) ~some:Ptr_tag.hash tag)
-    | Enum (var, vals) ->
-        List.fold_left
-          (fun acc (v : _ sv) -> combine acc v.tag)
-          (combine (Types.VariantId.to_int var) 4)
-          vals
-    | Tuple vals ->
-        List.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 5 vals
-    | Array vals ->
-        Iarray.fold_left (fun acc (v : _ sv) -> combine acc v.tag) 8 vals
-    | Union vs ->
-        List.fold_left
-          (fun acc { value; offset : _ sv; size : _ sv } ->
-            let v =
-              match value with
-              | Scalar (v : _ sv) -> v.tag
-              | Aggregate ((ag : _ sv), ty) -> combine ag.tag (Hashtbl.hash ty)
-            in
-            combine (combine (combine acc v) offset.tag) size.tag)
-          6 vs
-    | PolyVal x -> combine 7 (Types.TypeVarId.to_int x)
-
-  (* TODO: re-apply the smart constructors here *)
-  let mk _ty v : _ Sv.t_kind = Extension v
-
-  (* TODO: re-apply the smart constructors here *)
-  let eval _eval x = x
-
-  let rec apply_list apply ~missing_var s vs =
-    match vs with
-    | [] -> ([], s)
-    | v :: vs ->
-        let v, s = apply ~missing_var s v in
-        let vs, s = apply_list apply ~missing_var s vs in
-        (v :: vs, s)
-
-  let apply_iarray apply ~missing_var s arr =
-    let n = Iarray.length arr in
-    if n = 0 then (arr, s)
-    else begin
-      let s = ref s in
-      let out =
-        Iarray.map
-          (fun prev ->
-            let v, s' = apply ~missing_var !s prev in
-            s := s';
-            v)
-          arr
-      in
-      (out, !s)
-    end
-
-  let apply_subst_ptr apply ~missing_var s { ptr; size; align; tag } =
-    let ptr, s = apply ~missing_var s ptr in
-    let size, s = apply ~missing_var s size in
-    let align, s = apply ~missing_var s align in
-    ({ ptr; size; align; tag }, s)
-
-  let apply_subst_block_value apply ~missing_var s = function
-    | Scalar v ->
-        let v, s = apply ~missing_var s v in
-        (Scalar v, s)
-    | Aggregate (ag, ty) ->
-        let ag, s = apply ~missing_var s ag in
-        (Aggregate (ag, ty), s)
-
-  let apply_subst_block apply ~missing_var s { value; offset; size } =
-    let value, s = apply_subst_block_value apply ~missing_var s value in
-    let offset, s = apply ~missing_var s offset in
-    let size, s = apply ~missing_var s size in
-    ({ value; offset; size }, s)
-
-  (* TODO: derivable *)
-  let apply_subst apply ~missing_var s = function
-    | Ptr (v, m) ->
-        let v, s = apply ~missing_var s v in
-        let m, s = apply ~missing_var s m in
-        (Ptr (v, m), s)
-    | PtrMeta MetaUnit -> (PtrMeta MetaUnit, s)
-    | PtrMeta (MetaLen v) ->
-        let v, s = apply ~missing_var s v in
-        (PtrMeta (MetaLen v), s)
-    | PtrMeta (MetaVTable v) ->
-        let v, s = apply ~missing_var s v in
-        (PtrMeta (MetaVTable v), s)
-    | ThinPtr ptr ->
-        let ptr, s = apply_subst_ptr apply ~missing_var s ptr in
-        (ThinPtr ptr, s)
-    | Enum (var, vs) ->
-        let vs, s = apply_list apply ~missing_var s vs in
-        (Enum (var, vs), s)
-    | Tuple vs ->
-        let vs, s = apply_list apply ~missing_var s vs in
-        (Tuple vs, s)
-    | Array vs ->
-        let vs, s = apply_iarray apply ~missing_var s vs in
-        (Array vs, s)
-    | Union vs ->
-        let vs, s = apply_list (apply_subst_block apply) ~missing_var s vs in
-        (Union vs, s)
-    | PolyVal _ as v -> (v, s)
-
-  let encode_ty _ = failwith "TODO: encode Rust ext_ty"
-  let encode_value _ = failwith "TODO: encode Rust ext_t"
-end
+let encode_ty _ = failwith "TODO: encode Rust ext_ty"
+let encode_value _ = failwith "TODO: encode Rust ext_t"

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -105,7 +105,7 @@ let hash = function
   | PolyVal x -> combine 7 (Types.TypeVarId.to_int x)
 
 (* TODO: re-apply the smart constructors here *)
-let mk _ty v : _ Sv.t_kind = Extension v
+let mk ( <| ) ty v = Sv.Extension v <| ty
 
 (* TODO: re-apply the smart constructors here *)
 let eval _eval x = x

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -36,6 +36,7 @@ let pp pp ft v =
   | Unop (Field i, v) -> Fmt.pf ft "%a.%d" pp v i
   | Unop (VariantField (var, i), v) ->
       Fmt.pf ft "%a.as<%a>.%d" pp v Types.pp_variant_id var i
+  | Unop (ArrayField i, v) -> Fmt.pf ft "%a[%d]" pp v i
 
 let iter_vars_ptr iter_vars { ptr; size; align; tag = _ } =
   iter_vars ptr;
@@ -119,7 +120,7 @@ let mk build ty v =
   | PtrMeta (MetaLen v) -> mk_len_meta ~build v
   | PtrMeta (MetaVTable v) -> mk_vtable_meta ~build v
   | Tuple vs -> mk_tuple ~build vs
-  | Array vs -> mk_array_of_svty ~build (fst (t_as_array ty)) vs
+  | Array vs -> mk_array_of_svty ~build (array_elem_ty ty) vs
   | Enum (v_id, vs) -> mk_enum ~build (t_as_enum ty) v_id vs
   | Union blocks -> mk_union ~build (t_as_union ty) blocks
   | PolyVal ty_id -> mk_poly ~build ty_id

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -32,6 +32,7 @@ let pp pp ft v =
         vs
   | PolyVal tid -> Fmt.pf ft "PolyVal(%a)" Charon.Types.pp_type_var_id tid
   | Unop (ThinPtrPart part, v) -> Fmt.pf ft "%a.%a" pp v Unop.pp_ptr_part part
+  | Unop (FullPtrInner, v) -> Fmt.pf ft "thin(%a)" pp v
 
 let iter_vars_ptr iter_vars { ptr; size; align; tag = _ } =
   iter_vars ptr;

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -34,6 +34,8 @@ let pp pp ft v =
   | Unop (ThinPtrPart part, v) -> Fmt.pf ft "%a.%a" pp v Unop.pp_ptr_part part
   | Unop (FullPtrInner, v) -> Fmt.pf ft "thin(%a)" pp v
   | Unop (Field i, v) -> Fmt.pf ft "%a.%d" pp v i
+  | Unop (VariantField (var, i), v) ->
+      Fmt.pf ft "%a.as<%a>.%d" pp v Types.pp_variant_id var i
 
 let iter_vars_ptr iter_vars { ptr; size; align; tag = _ } =
   iter_vars ptr;

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -33,6 +33,8 @@ let pp pp ft v =
   | PolyVal tid -> Fmt.pf ft "PolyVal(%a)" Charon.Types.pp_type_var_id tid
   | Unop (ThinPtrPart part, v) -> Fmt.pf ft "%a.%a" pp v Unop.pp_ptr_part part
   | Unop (FullPtrInner, v) -> Fmt.pf ft "thin(%a)" pp v
+  | Unop (FullPtrMeta, v) -> Fmt.pf ft "meta(%a)" pp v
+  | Unop (PtrMetaAs part, v) -> Fmt.pf ft "%a.as<%a>" pp v Unop.pp_ptr_meta part
   | Unop (Field i, v) -> Fmt.pf ft "%a.%d" pp v i
   | Unop (VariantField (var, i), v) ->
       Fmt.pf ft "%a.as<%a>.%d" pp v Types.pp_variant_id var i

--- a/soteria-rust/lib/svalue/ext.ml
+++ b/soteria-rust/lib/svalue/ext.ml
@@ -104,11 +104,68 @@ let hash = function
         6 vs
   | PolyVal x -> combine 7 (Types.TypeVarId.to_int x)
 
-(* TODO: re-apply the smart constructors here *)
-let mk ( <| ) ty v = Sv.Extension v <| ty
+let mk build ty v =
+  match v with
+  | ThinPtr ptr -> mk_thin_ptr ~build ptr
+  | Ptr (ptr, meta) -> mk_full_ptr ~build ptr meta
+  | PtrMeta MetaUnit -> mk_unit_meta ~build ()
+  | PtrMeta (MetaLen v) -> mk_len_meta ~build v
+  | PtrMeta (MetaVTable v) -> mk_vtable_meta ~build v
+  | Tuple vs -> mk_tuple ~build vs
+  | Array vs -> mk_array_of_svty ~build (fst (t_as_array ty)) vs
+  | Enum (v_id, vs) -> mk_enum ~build (t_as_enum ty) v_id vs
+  | Union blocks -> mk_union ~build (t_as_union ty) blocks
+  | PolyVal ty_id -> mk_poly ~build ty_id
 
-(* TODO: re-apply the smart constructors here *)
-let eval _eval x = x
+let eval eval v =
+  match v with
+  | Ptr (p, m) ->
+      let p' = eval p in
+      let m' = eval m in
+      if p == p' && m == m' then v else Ptr (p', m')
+  | PtrMeta MetaUnit -> v
+  | PtrMeta (MetaLen l) ->
+      let l' = eval l in
+      if l == l' then v else PtrMeta (MetaLen l')
+  | PtrMeta (MetaVTable vt) ->
+      let vt' = eval vt in
+      if vt == vt' then v else PtrMeta (MetaVTable vt')
+  | ThinPtr { ptr; size; align; tag } ->
+      let ptr' = eval ptr in
+      let size' = eval size in
+      let align' = eval align in
+      if ptr == ptr' && size == size' && align == align' then v
+      else ThinPtr { ptr = ptr'; size = size'; align = align'; tag }
+  | Enum (var_id, vs) ->
+      let vs', changed = List.map_changed eval vs in
+      if not changed then v else Enum (var_id, vs')
+  | Tuple vs ->
+      let vs', changed = List.map_changed eval vs in
+      if changed then Tuple vs' else v
+  | Array vs ->
+      let vs', changed = Iarray.map_changed eval vs in
+      if changed then Array vs' else v
+  | Union vs ->
+      let vs', changed =
+        List.map_changed
+          (fun ({ value; offset; size } as blk) ->
+            let value' =
+              match value with
+              | Scalar v ->
+                  let v' = eval v in
+                  if v == v' then value else Scalar v'
+              | Aggregate (ag, ty) ->
+                  let ag' = eval ag in
+                  if ag == ag' then value else Aggregate (ag', ty)
+            in
+            let offset' = eval offset in
+            let size' = eval size in
+            if value == value' && offset == offset' && size == size' then blk
+            else { value = value'; offset = offset'; size = size' })
+          vs
+      in
+      if changed then Union vs' else v
+  | PolyVal _ -> v
 
 let rec apply_list apply ~missing_var s vs =
   match vs with
@@ -140,7 +197,7 @@ let apply_subst_ptr apply ~missing_var s { ptr; size; align; tag } =
   let align, s = apply ~missing_var s align in
   ({ ptr; size; align; tag }, s)
 
-let apply_subst_block_value apply ~missing_var s = function
+let apply_block_value apply ~missing_var s = function
   | Scalar v ->
       let v, s = apply ~missing_var s v in
       (Scalar v, s)
@@ -148,8 +205,8 @@ let apply_subst_block_value apply ~missing_var s = function
       let ag, s = apply ~missing_var s ag in
       (Aggregate (ag, ty), s)
 
-let apply_subst_block apply ~missing_var s { value; offset; size } =
-  let value, s = apply_subst_block_value apply ~missing_var s value in
+let apply_block apply ~missing_var s { value; offset; size } =
+  let value, s = apply_block_value apply ~missing_var s value in
   let offset, s = apply ~missing_var s offset in
   let size, s = apply ~missing_var s size in
   ({ value; offset; size }, s)
@@ -180,7 +237,7 @@ let apply_subst apply ~missing_var s = function
       let vs, s = apply_iarray apply ~missing_var s vs in
       (Array vs, s)
   | Union vs ->
-      let vs, s = apply_list (apply_subst_block apply) ~missing_var s vs in
+      let vs, s = apply_list (apply_block apply) ~missing_var s vs in
       (Union vs, s)
   | PolyVal _ as v -> (v, s)
 

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -6,7 +6,7 @@ module Sv = Soteria.Bv_values.Svalue
 
 module Unop = struct
   type ptr_part = PtrInner | PtrSize | PtrAlign
-  and t = ThinPtrPart of ptr_part [@@deriving eq, ord, hash]
+  and t = ThinPtrPart of ptr_part | FullPtrInner [@@deriving eq, ord, hash]
 
   let pp_ptr_part ft = function
     | PtrInner -> Fmt.string ft "ptr"
@@ -199,6 +199,11 @@ let mk_len_meta ~build:(( <| ) : _ build) len =
 let mk_vtable_meta ~build:(( <| ) : _ build) vtable =
   Extension (PtrMeta (MetaVTable vtable)) <| TExtension TPtrMeta
 
+let full_ptr_inner ~build:(( <| ) : _ build) (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (Ptr (p, _)) -> p
+  | _ -> Extension (Unop (FullPtrInner, v)) <| TExtension TThinPtr
+
 (** {3 Tuples} *)
 
 let mk_tuple ~build:(( <| ) : _ build) vs =
@@ -235,3 +240,4 @@ let mk_poly ~build:(( <| ) : _ build) ty_id =
 
 let apply_unop ~build : Unop.t -> _ sv -> _ sv = function
   | ThinPtrPart part -> thin_ptr_part ~build part
+  | FullPtrInner -> full_ptr_inner ~build

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -5,7 +5,8 @@ module Sv = Soteria.Bv_values.Svalue
 (** {2 Type definitions} *)
 
 module Unop = struct
-  type ptr_part = PtrInner | PtrSize | PtrAlign [@@deriving eq, ord, hash]
+  type ptr_part = PtrInner | PtrSize | PtrAlign
+  and t = ThinPtrPart of ptr_part [@@deriving eq, ord, hash]
 
   let pp_ptr_part ft = function
     | PtrInner -> Fmt.string ft "ptr"
@@ -74,6 +75,7 @@ and 'g ext_t =
   | PolyVal of Charon.Types.type_var_id
       (** The opaque value of a type variable, identified by (type variable
           index, unique identifier). *)
+  | Unop of Unop.t * 'g sv  (** unary operation *)
 [@@deriving eq, ord]
 
 let pp_block_value pp_v pp_ag ft = function
@@ -167,6 +169,22 @@ type 'g build = ('g, 'g ext_t, 'g ext_ty) Sv.t_kind -> 'g svty -> 'g sv
 let mk_thin_ptr ~build:(( <| ) : _ build) ptr =
   Extension (ThinPtr ptr) <| TExtension TThinPtr
 
+let thin_ptr_part ~build:(( <| ) : _ build) (part : Unop.ptr_part)
+    (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (ThinPtr inner) -> (
+      match part with
+      | PtrInner -> inner.ptr
+      | PtrSize -> inner.size
+      | PtrAlign -> inner.align)
+  | _ ->
+      let ty : 'ghost svty =
+        match part with
+        | PtrInner -> TPointer (usize_bits ())
+        | PtrSize | PtrAlign -> TBitVector (usize_bits ())
+      in
+      Extension (Unop (ThinPtrPart part, v)) <| ty
+
 (** {3 Fat pointers} *)
 
 let mk_full_ptr ~build:(( <| ) : _ build) ptr meta =
@@ -212,3 +230,8 @@ let mk_union ~build:(( <| ) : _ build) adt blocks =
 
 let mk_poly ~build:(( <| ) : _ build) ty_id =
   Extension (PolyVal ty_id) <| TExtension TPolyType
+
+(** {3 Operators} *)
+
+let apply_unop ~build : Unop.t -> _ sv -> _ sv = function
+  | ThinPtrPart part -> thin_ptr_part ~build part

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -35,7 +35,8 @@ end
 
 (* the full values *)
 type 'g sv =
-  (('g, 'g ext_t, 'g ext_ty) Sv.t[@equal Sv.equal] [@compare Sv.compare])
+  (('g, 'g ext_t, 'g ext_ty) Sv.t
+  [@equal Sv.equal] [@compare Sv.compare] [@hash fun (v : _ Sv.t) -> v.tag])
 
 and 'g svty = 'g ext_ty Sv.ty
 
@@ -51,7 +52,9 @@ and 'g ptr = {
 
 (** The value inside a {!block}: either a scalar or an aggregate that can be
     split further. *)
-and ('sc, 'ag) block_value = Scalar of 'sc | Aggregate of 'ag * Types.ty
+and ('sc, 'ag) block_value =
+  | Scalar of 'sc
+  | Aggregate of 'ag * (Types.ty[@hash Hashtbl.hash])
 
 (** A block of an encoded value: a value, along with the offset it is at and the
     size it spans. [ty] is [Some] iff the value is a whole aggregate of that
@@ -64,9 +67,13 @@ and ('sc, 'ag, 'ofs, 'sz) block = {
 
 (* values *)
 and 'g ext_ty =
-  | TEnum of (Types.type_decl_ref[@printer Crate.pp_type_decl_ref])
+  | TEnum of
+      (Types.type_decl_ref
+      [@printer Crate.pp_type_decl_ref] [@hash Hashtbl.hash])
       (** the type decl ref of an {b enum} *)
-  | TUnion of (Types.type_decl_ref[@printer Crate.pp_type_decl_ref])
+  | TUnion of
+      (Types.type_decl_ref
+      [@printer Crate.pp_type_decl_ref] [@hash Hashtbl.hash])
       (** the type decl ref of a {b union} *)
   | TTuple of 'g svty list  (** structs and tuples (ordered fields) *)
   | TArray of 'g svty * Z.t  (** arrays (all elements share the same type) *)
@@ -84,16 +91,17 @@ and 'g ext_t =
   | PtrMeta of 'g ptr_meta
   | ThinPtr of 'g ptr
       (** thin pointer, without metadata but with extra info on the pointer *)
-  | Enum of Types.variant_id * 'g sv list  (** variant id * values *)
+  | Enum of (Types.variant_id[@hash Charon.Types.VariantId.to_int]) * 'g sv list
+      (** variant id * values *)
   | Tuple of 'g sv list  (** structs and tuples: ordered values *)
   | Array of 'g sv Iarray.t  (** arrays: ordered values, all of the same type *)
   | Union of ('g sv, 'g sv, 'g sv, 'g sv) block list
       (** list of blocks in the union *)
-  | PolyVal of Charon.Types.type_var_id
+  | PolyVal of (Charon.Types.type_var_id[@hash Charon.Types.TypeVarId.to_int])
       (** The opaque value of a type variable, identified by (type variable
           index, unique identifier). *)
   | Unop of Unop.t * 'g sv  (** unary operation *)
-[@@deriving eq, ord]
+[@@deriving eq, ord, hash]
 
 let pp_block_value pp_v pp_ag ft = function
   | Scalar v -> pp_v ft v

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -4,10 +4,20 @@ module Sv = Soteria.Bv_values.Svalue
 
 (** {2 Type definitions} *)
 
+module Unop = struct
+  type ptr_part = PtrInner | PtrSize | PtrAlign [@@deriving eq, ord, hash]
+
+  let pp_ptr_part ft = function
+    | PtrInner -> Fmt.string ft "ptr"
+    | PtrSize -> Fmt.string ft "size"
+    | PtrAlign -> Fmt.string ft "align"
+
+  let show_ptr_part = Fmt.to_to_string pp_ptr_part
+end
+
 (* the full values *)
 type 'g sv =
-  (('g, 'g ext_t, 'g ext_ty) Sv.t
-  [@equal fun a b -> Sv.equal a b] [@compare fun a b -> Sv.compare a b])
+  (('g, 'g ext_t, 'g ext_ty) Sv.t[@equal Sv.equal] [@compare Sv.compare])
 
 and 'g svty = 'g ext_ty Sv.ty
 

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -1,0 +1,87 @@
+open Charon
+module Sv = Soteria.Bv_values.Svalue
+
+(* the full values *)
+type 'ghost sv =
+  (('ghost, 'ghost ext_t, 'ghost ext_ty) Sv.t
+  [@equal fun a b -> Sv.equal a b] [@compare fun a b -> Sv.compare a b])
+
+and 'ghost svty = 'ghost ext_ty Sv.ty
+
+(* pointers; for simplicity's sake, we hardcode the pointer type. We can improve
+   this later, but we lack a clear usecase for parametric pointer types, and
+   have a clear reason to want deeply-embedded pointers *)
+and 'ghost ptr = {
+  ptr : 'ghost sv;
+  tag : Ptr_tag.t option;
+  size : 'ghost sv;
+  align : 'ghost sv;
+}
+
+(** The value inside a {!block}: either a scalar or an aggregate that can be
+    split further. *)
+and ('sc, 'ag) block_value = Scalar of 'sc | Aggregate of 'ag * Types.ty
+
+(** A block of an encoded value: a value, along with the offset it is at and the
+    size it spans. [ty] is [Some] iff the value is a whole aggregate of that
+    type. *)
+and ('sc, 'ag, 'ofs, 'sz) block = {
+  value : ('sc, 'ag) block_value;
+  offset : 'ofs;
+  size : 'sz;
+}
+
+(* values *)
+and 'ghost ext_ty =
+  | TEnum of (Types.type_decl_ref[@printer Crate.pp_type_decl_ref])
+      (** the type decl ref of an {b enum} *)
+  | TUnion of (Types.type_decl_ref[@printer Crate.pp_type_decl_ref])
+      (** the type decl ref of a {b union} *)
+  | TTuple of 'ghost svty list  (** structs and tuples (ordered fields) *)
+  | TArray of 'ghost svty * Z.t
+      (** arrays (all elements share the same type) *)
+  | TThinPtr
+  | TFullPtr
+  | TPtrMeta
+      (** the type of a pointer's metadata (unit, length or metadata). this is
+          not exposed to the user! *)
+  | TPolyType
+
+and 'g ptr_meta = MetaLen of 'g sv | MetaVTable of 'g sv | MetaUnit
+
+and 'ghost ext_t =
+  | Ptr of 'ghost sv * 'ghost sv  (** pointer, with meta *)
+  | PtrMeta of 'ghost ptr_meta
+  | ThinPtr of 'ghost ptr
+      (** thin pointer, without metadata but with extra info on the pointer *)
+  | Enum of Types.variant_id * 'ghost sv list  (** variant id * values *)
+  | Tuple of 'ghost sv list  (** structs and tuples: ordered values *)
+  | Array of 'ghost sv Iarray.t
+      (** arrays: ordered values, all of the same type *)
+  | Union of ('ghost sv, 'ghost sv, 'ghost sv, 'ghost sv) block list
+      (** list of blocks in the union *)
+  | PolyVal of Charon.Types.type_var_id
+      (** The opaque value of a type variable, identified by (type variable
+          index, unique identifier). *)
+[@@deriving eq, ord]
+
+let pp_block_value pp_v pp_ag ft = function
+  | Scalar v -> pp_v ft v
+  | Aggregate (ag, ty) -> Fmt.pf ft "%a : %a" pp_ag ag Types.pp_ty ty
+
+let pp_block pp_v pp_ag pp_ofs pp_sz ft { value; offset; size } =
+  Fmt.pf ft "(%a: %a-%a)" pp_ofs offset
+    (pp_block_value pp_v pp_ag)
+    value pp_sz size
+
+let rec pp_ext_ty ft : 'ghost ext_ty -> unit = function
+  | TEnum ty -> Crate.pp_type_decl_ref ft ty
+  | TUnion ty -> Crate.pp_type_decl_ref ft ty
+  | TTuple tys -> Fmt.(brackets (list ~sep:semi pp_svty)) ft tys
+  | TArray (ty, n) -> Fmt.pf ft "[%a; %a]" pp_svty ty Z.pp n
+  | TThinPtr -> Fmt.string ft "TThinPtr"
+  | TFullPtr -> Fmt.string ft "TFullPtr"
+  | TPtrMeta -> Fmt.string ft "TPtrMeta"
+  | TPolyType -> Fmt.string ft "TPolyType"
+
+and pp_svty ft (ty : 'ghost svty) = Sv.pp_ty pp_ext_ty ft ty

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -7,7 +7,11 @@ module Sv = Soteria.Bv_values.Svalue
 module Unop = struct
   type ptr_part = PtrInner | PtrSize | PtrAlign
 
-  and t = ThinPtrPart of ptr_part | FullPtrInner | Field of int
+  and t =
+    | ThinPtrPart of ptr_part
+    | FullPtrInner
+    | Field of int
+    | VariantField of (Types.variant_id[@hash Types.VariantId.to_int]) * int
   [@@deriving eq, ord, hash]
 
   let pp_ptr_part ft = function
@@ -230,6 +234,31 @@ let set_field ~build idx x (v : 'ghost sv) =
 let mk_enum ~build:(( <| ) : _ build) adt var_id vs =
   Extension (Enum (var_id, vs)) <| TExtension (TEnum adt)
 
+let field_of_variant ~build:(( <| ) : _ build) var idx (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (Enum (v, vs)) ->
+      assert (Types.equal_variant_id v var);
+      List.nth vs idx
+  | _ ->
+      let adt = t_as_enum v.node.ty in
+      let variant = Types.VariantId.nth (Crate.as_enum adt) var in
+      let field : Types.field = List.nth variant.fields idx in
+      Extension (Unop (VariantField (var, idx), v)) <| ty_of_rust field.field_ty
+
+let as_enum_of_variant ~build var (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (Enum (v, vs)) ->
+      assert (Types.equal_variant_id v var);
+      vs
+  | _ ->
+      let adt = t_as_enum v.node.ty in
+      let variant = Types.VariantId.nth (Crate.as_enum adt) var in
+      List.mapi (fun i _ -> field_of_variant ~build var i v) variant.fields
+
+let set_field_of_variant ~build var idx x (v : 'ghost sv) =
+  let vs = List.set_nth idx x (as_enum_of_variant ~build var v) in
+  mk_enum ~build (t_as_enum v.node.ty) var vs
+
 (** {3 Arrays} *)
 
 let mk_array_of_svty ~build:(( <| ) : _ build) elem_ty vs =
@@ -257,3 +286,4 @@ let apply_unop ~build : Unop.t -> _ sv -> _ sv = function
   | ThinPtrPart part -> thin_ptr_part ~build part
   | FullPtrInner -> full_ptr_inner ~build
   | Field i -> field_of ~build i
+  | VariantField (var_id, i) -> field_of_variant ~build var_id i

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -1,21 +1,24 @@
 open Charon
+open Common.Charon_util
 module Sv = Soteria.Bv_values.Svalue
 
+(** {2 Type definitions} *)
+
 (* the full values *)
-type 'ghost sv =
-  (('ghost, 'ghost ext_t, 'ghost ext_ty) Sv.t
+type 'g sv =
+  (('g, 'g ext_t, 'g ext_ty) Sv.t
   [@equal fun a b -> Sv.equal a b] [@compare fun a b -> Sv.compare a b])
 
-and 'ghost svty = 'ghost ext_ty Sv.ty
+and 'g svty = 'g ext_ty Sv.ty
 
 (* pointers; for simplicity's sake, we hardcode the pointer type. We can improve
    this later, but we lack a clear usecase for parametric pointer types, and
    have a clear reason to want deeply-embedded pointers *)
-and 'ghost ptr = {
-  ptr : 'ghost sv;
+and 'g ptr = {
+  ptr : 'g sv;
   tag : Ptr_tag.t option;
-  size : 'ghost sv;
-  align : 'ghost sv;
+  size : 'g sv;
+  align : 'g sv;
 }
 
 (** The value inside a {!block}: either a scalar or an aggregate that can be
@@ -32,14 +35,13 @@ and ('sc, 'ag, 'ofs, 'sz) block = {
 }
 
 (* values *)
-and 'ghost ext_ty =
+and 'g ext_ty =
   | TEnum of (Types.type_decl_ref[@printer Crate.pp_type_decl_ref])
       (** the type decl ref of an {b enum} *)
   | TUnion of (Types.type_decl_ref[@printer Crate.pp_type_decl_ref])
       (** the type decl ref of a {b union} *)
-  | TTuple of 'ghost svty list  (** structs and tuples (ordered fields) *)
-  | TArray of 'ghost svty * Z.t
-      (** arrays (all elements share the same type) *)
+  | TTuple of 'g svty list  (** structs and tuples (ordered fields) *)
+  | TArray of 'g svty * Z.t  (** arrays (all elements share the same type) *)
   | TThinPtr
   | TFullPtr
   | TPtrMeta
@@ -49,16 +51,15 @@ and 'ghost ext_ty =
 
 and 'g ptr_meta = MetaLen of 'g sv | MetaVTable of 'g sv | MetaUnit
 
-and 'ghost ext_t =
-  | Ptr of 'ghost sv * 'ghost sv  (** pointer, with meta *)
-  | PtrMeta of 'ghost ptr_meta
-  | ThinPtr of 'ghost ptr
+and 'g ext_t =
+  | Ptr of 'g sv * 'g sv  (** pointer, with meta *)
+  | PtrMeta of 'g ptr_meta
+  | ThinPtr of 'g ptr
       (** thin pointer, without metadata but with extra info on the pointer *)
-  | Enum of Types.variant_id * 'ghost sv list  (** variant id * values *)
-  | Tuple of 'ghost sv list  (** structs and tuples: ordered values *)
-  | Array of 'ghost sv Iarray.t
-      (** arrays: ordered values, all of the same type *)
-  | Union of ('ghost sv, 'ghost sv, 'ghost sv, 'ghost sv) block list
+  | Enum of Types.variant_id * 'g sv list  (** variant id * values *)
+  | Tuple of 'g sv list  (** structs and tuples: ordered values *)
+  | Array of 'g sv Iarray.t  (** arrays: ordered values, all of the same type *)
+  | Union of ('g sv, 'g sv, 'g sv, 'g sv) block list
       (** list of blocks in the union *)
   | PolyVal of Charon.Types.type_var_id
       (** The opaque value of a type variable, identified by (type variable
@@ -74,7 +75,7 @@ let pp_block pp_v pp_ag pp_ofs pp_sz ft { value; offset; size } =
     (pp_block_value pp_v pp_ag)
     value pp_sz size
 
-let rec pp_ext_ty ft : 'ghost ext_ty -> unit = function
+let rec pp_ext_ty ft : 'g ext_ty -> unit = function
   | TEnum ty -> Crate.pp_type_decl_ref ft ty
   | TUnion ty -> Crate.pp_type_decl_ref ft ty
   | TTuple tys -> Fmt.(brackets (list ~sep:semi pp_svty)) ft tys
@@ -84,4 +85,120 @@ let rec pp_ext_ty ft : 'ghost ext_ty -> unit = function
   | TPtrMeta -> Fmt.string ft "TPtrMeta"
   | TPolyType -> Fmt.string ft "TPolyType"
 
-and pp_svty ft (ty : 'ghost svty) = Sv.pp_ty pp_ext_ty ft ty
+and pp_svty ft (ty : 'g svty) = Sv.pp_ty pp_ext_ty ft ty
+
+(** {2 Types and Rust type conversions} *)
+
+let float_precision :
+    Values.float_type -> Soteria.Bv_values.Svalue.FloatPrecision.t = function
+  | F16 -> F16
+  | F32 -> F32
+  | F64 -> F64
+  | F128 -> F128
+
+let rec ty_of_rust : Types.ty -> 'g svty = function
+  | TLiteral (TFloat ft) -> TFloat (float_precision ft)
+  | TLiteral lit -> TBitVector (8 * size_of_literal_ty lit)
+  | TRef _ | TRawPtr _ | TFnPtr _ -> TExtension TFullPtr
+  | TNever | TFnDef _ -> TExtension (TTuple [])
+  | TVar _ -> TExtension TPolyType
+  | TPattern (ty, _) -> ty_of_rust ty
+  | TArray (ty, n) -> TExtension (TArray (ty_of_rust ty, z_of_constant_expr n))
+  | TAdt { id = TTuple; generics = { types; _ } } ->
+      TExtension (TTuple (List.map ty_of_rust types))
+  | TAdt ({ id = TAdtId _; _ } as adt) -> (
+      assert (tyref_is_substituted adt);
+      match (Crate.get_adt adt).kind with
+      | Struct fs ->
+          TExtension
+            (TTuple
+               (List.map (fun (f : Types.field) -> ty_of_rust f.field_ty) fs))
+      | Enum _ -> TExtension (TEnum adt)
+      | Union _ -> TExtension (TUnion adt)
+      | kind ->
+          L.failwith "ty_of_rust unexpected adt kind %a" Types.pp_type_decl_kind
+            kind)
+  | ( TError _ | TPtrMetadata _ | TTraitType _ | TDynTrait _ | TSlice _
+    | TAdt { id = TBuiltin _; _ } ) as ty ->
+      L.failwith "ty_of_rust unexpected type %a" pp_ty ty
+
+let t_as_tuple (ty : 'g svty) =
+  match ty with
+  | TExtension (TTuple tys) -> tys
+  | _ -> invalid_arg "t_as_tuple: not a tuple type"
+
+let t_as_array (ty : 'g svty) =
+  match ty with
+  | TExtension (TArray (elem_ty, n)) -> (elem_ty, n)
+  | _ -> invalid_arg "t_as_array: not an array type"
+
+let t_as_enum (ty : 'g svty) =
+  match ty with
+  | TExtension (TEnum adt) -> adt
+  | _ -> invalid_arg "t_as_enum: not an enum type"
+
+let t_as_union (ty : 'g svty) =
+  match ty with
+  | TExtension (TUnion adt) -> adt
+  | _ -> invalid_arg "t_as_union: not a union type"
+
+let usize_bits () = 8 * size_of_uint_ty Usize
+
+(** {2 Smart constructors}
+
+    We want to have our smart constructors accessible from within the extension,
+    so that the extension's [eval] and [mk] functions can use the same smart
+    constructors as the rest of the engine. *)
+
+type 'g build = ('g, 'g ext_t, 'g ext_ty) Sv.t_kind -> 'g svty -> 'g sv
+
+(** {3 Thin pointers} *)
+
+let mk_thin_ptr ~build:(( <| ) : _ build) ptr =
+  Extension (ThinPtr ptr) <| TExtension TThinPtr
+
+(** {3 Fat pointers} *)
+
+let mk_full_ptr ~build:(( <| ) : _ build) ptr meta =
+  Extension (Ptr (ptr, meta)) <| TExtension TFullPtr
+
+let mk_unit_meta ~build:(( <| ) : _ build) () =
+  Extension (PtrMeta MetaUnit) <| TExtension TPtrMeta
+
+let mk_len_meta ~build:(( <| ) : _ build) len =
+  Extension (PtrMeta (MetaLen len)) <| TExtension TPtrMeta
+
+let mk_vtable_meta ~build:(( <| ) : _ build) vtable =
+  Extension (PtrMeta (MetaVTable vtable)) <| TExtension TPtrMeta
+
+(** {3 Tuples} *)
+
+let mk_tuple ~build:(( <| ) : _ build) vs =
+  let tys = List.map (fun (v : _ sv) -> v.node.ty) vs in
+  Extension (Tuple vs) <| TExtension (TTuple tys)
+
+(** {3 Enums} *)
+
+let mk_enum ~build:(( <| ) : _ build) adt var_id vs =
+  Extension (Enum (var_id, vs)) <| TExtension (TEnum adt)
+
+(** {3 Arrays} *)
+
+let mk_array_of_svty ~build:(( <| ) : _ build) elem_ty vs =
+  Extension (Array vs)
+  <| TExtension (TArray (elem_ty, Z.of_int (Iarray.length vs)))
+
+let mk_array ~(build : _ build) elem_ty (vs : _ sv Iarray.t) =
+  let elem_ty =
+    if Iarray.length vs = 0 then ty_of_rust elem_ty
+    else (Iarray.get vs 0).node.ty
+  in
+  mk_array_of_svty ~build elem_ty vs
+
+(** {3 Unions and PolyVal} (limited support)  *)
+
+let mk_union ~build:(( <| ) : _ build) adt blocks =
+  Extension (Union blocks) <| TExtension (TUnion adt)
+
+let mk_poly ~build:(( <| ) : _ build) ty_id =
+  Extension (PolyVal ty_id) <| TExtension TPolyType

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -12,6 +12,9 @@ module Unop = struct
     | FullPtrInner
     | Field of int
     | VariantField of (Types.variant_id[@hash Types.VariantId.to_int]) * int
+    (* TODO: we could make [ArrayField] a binop, with the second operator a
+       (possibly symbolic) value, to allow symbolically sized arrays! *)
+    | ArrayField of int
   [@@deriving eq, ord, hash]
 
   let pp_ptr_part ft = function
@@ -150,6 +153,16 @@ let t_as_array (ty : 'g svty) =
   | TExtension (TArray (elem_ty, n)) -> (elem_ty, n)
   | _ -> invalid_arg "t_as_array: not an array type"
 
+let array_length (ty : 'g svty) =
+  match ty with
+  | TExtension (TArray (_, n)) -> n
+  | _ -> invalid_arg "array_length: not an array type"
+
+let array_elem_ty (ty : 'g svty) =
+  match ty with
+  | TExtension (TArray (elem_ty, _)) -> elem_ty
+  | _ -> invalid_arg "array_elem_ty: not an array type"
+
 let t_as_enum (ty : 'g svty) =
   match ty with
   | TExtension (TEnum adt) -> adt
@@ -272,6 +285,22 @@ let mk_array ~(build : _ build) elem_ty (vs : _ sv Iarray.t) =
   in
   mk_array_of_svty ~build elem_ty vs
 
+let array_field_of ~build:(( <| ) : _ build) idx (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (Array vs) -> Iarray.get vs idx
+  | _ -> Extension (Unop (ArrayField idx, v)) <| array_elem_ty v.node.ty
+
+let as_array ~build (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (Array vs) -> vs
+  | _ ->
+      let n = array_length v.node.ty in
+      Iarray.init (Z.to_int n) (fun i -> array_field_of ~build i v)
+
+let set_array_field ~build idx x (v : 'ghost sv) =
+  mk_array_of_svty ~build (array_elem_ty v.node.ty)
+    (Iarray.copy_and_set idx x (as_array ~build v))
+
 (** {3 Unions and PolyVal} (limited support)  *)
 
 let mk_union ~build:(( <| ) : _ build) adt blocks =
@@ -287,3 +316,4 @@ let apply_unop ~build : Unop.t -> _ sv -> _ sv = function
   | FullPtrInner -> full_ptr_inner ~build
   | Field i -> field_of ~build i
   | VariantField (var_id, i) -> field_of_variant ~build var_id i
+  | ArrayField i -> array_field_of ~build i

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -351,7 +351,7 @@ let set_array_field ~build idx x (v : 'ghost sv) =
   mk_array_of_svty ~build (array_elem_ty v.node.ty)
     (Iarray.copy_and_set idx x (as_array ~build v))
 
-(** {3 Unions and PolyVal} (limited support)  *)
+(** {3 Unions and PolyVal (limited support)} *)
 
 let mk_union ~build:(( <| ) : _ build) adt blocks =
   Extension (Union blocks) <| TExtension (TUnion adt)

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -6,10 +6,13 @@ module Sv = Soteria.Bv_values.Svalue
 
 module Unop = struct
   type ptr_part = PtrInner | PtrSize | PtrAlign
+  and ptr_meta = MetaLen | MetaVTable
 
   and t =
     | ThinPtrPart of ptr_part
     | FullPtrInner
+    | FullPtrMeta
+    | PtrMetaAs of ptr_meta
     | Field of int
     | VariantField of (Types.variant_id[@hash Types.VariantId.to_int]) * int
     | IsVariant of (Types.variant_id[@hash Types.VariantId.to_int])
@@ -24,6 +27,10 @@ module Unop = struct
     | PtrAlign -> Fmt.string ft "align"
 
   let show_ptr_part = Fmt.to_to_string pp_ptr_part
+
+  let pp_ptr_meta ft = function
+    | MetaLen -> Fmt.string ft "len"
+    | MetaVTable -> Fmt.string ft "vtable"
 end
 
 (* the full values *)
@@ -96,6 +103,11 @@ let pp_block pp_v pp_ag pp_ofs pp_sz ft { value; offset; size } =
   Fmt.pf ft "(%a: %a-%a)" pp_ofs offset
     (pp_block_value pp_v pp_ag)
     value pp_sz size
+
+let pp_ptr_meta_kind ft = function
+  | MetaUnit -> Fmt.string ft "unit"
+  | MetaLen _ -> Fmt.pf ft "len"
+  | MetaVTable _ -> Fmt.pf ft "vtable"
 
 let rec pp_ext_ty ft : 'g ext_ty -> unit = function
   | TEnum ty -> Crate.pp_type_decl_ref ft ty
@@ -224,6 +236,37 @@ let full_ptr_inner ~build:(( <| ) : _ build) (v : 'ghost sv) =
   | Extension (Ptr (p, _)) -> p
   | _ -> Extension (Unop (FullPtrInner, v)) <| TExtension TThinPtr
 
+let of_thin_ptr ~build v = mk_full_ptr ~build v (mk_unit_meta ~build ())
+
+let full_ptr_meta_raw ~build:(( <| ) : _ build) (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (Ptr (_, m)) -> m
+  | _ -> Extension (Unop (FullPtrMeta, v)) <| TExtension TPtrMeta
+
+let ptr_meta_as ~build:(( <| ) : _ build) (part : Unop.ptr_meta) (v : 'ghost sv)
+    =
+  match v.node.kind with
+  | Extension (PtrMeta m) -> (
+      match (part, m) with
+      | MetaLen, MetaLen len -> len
+      | MetaVTable, MetaVTable vtable -> vtable
+      | _ ->
+          L.failwith "ptr_meta_as: expected %a but got %a" Unop.pp_ptr_meta part
+            pp_ptr_meta_kind m)
+  | _ ->
+      let ty : 'ghost svty =
+        match part with
+        | MetaLen -> TBitVector (usize_bits ())
+        | MetaVTable -> TExtension TThinPtr
+      in
+      Extension (Unop (PtrMetaAs part, v)) <| ty
+
+let full_ptr_meta ~build (part : Unop.ptr_meta) (v : 'ghost sv) =
+  full_ptr_meta_raw ~build v |> ptr_meta_as ~build part
+
+let full_ptr_set_inner ~build inner (v : 'ghost sv) =
+  mk_full_ptr ~build inner (full_ptr_meta_raw ~build v)
+
 (** {3 Tuples} *)
 
 let mk_tuple ~build:(( <| ) : _ build) vs =
@@ -321,6 +364,8 @@ let mk_poly ~build:(( <| ) : _ build) ty_id =
 let apply_unop ~build : Unop.t -> _ sv -> _ sv = function
   | ThinPtrPart part -> thin_ptr_part ~build part
   | FullPtrInner -> full_ptr_inner ~build
+  | FullPtrMeta -> full_ptr_meta_raw ~build
+  | PtrMetaAs part -> ptr_meta_as ~build part
   | Field i -> field_of ~build i
   | VariantField (var_id, i) -> field_of_variant ~build var_id i
   | IsVariant var_id -> is_variant ~build var_id

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -6,7 +6,9 @@ module Sv = Soteria.Bv_values.Svalue
 
 module Unop = struct
   type ptr_part = PtrInner | PtrSize | PtrAlign
-  and t = ThinPtrPart of ptr_part | FullPtrInner [@@deriving eq, ord, hash]
+
+  and t = ThinPtrPart of ptr_part | FullPtrInner | Field of int
+  [@@deriving eq, ord, hash]
 
   let pp_ptr_part ft = function
     | PtrInner -> Fmt.string ft "ptr"
@@ -210,6 +212,19 @@ let mk_tuple ~build:(( <| ) : _ build) vs =
   let tys = List.map (fun (v : _ sv) -> v.node.ty) vs in
   Extension (Tuple vs) <| TExtension (TTuple tys)
 
+let field_of ~build:(( <| ) : _ build) idx (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (Tuple vs) -> List.nth vs idx
+  | _ -> Extension (Unop (Field idx, v)) <| List.nth (t_as_tuple v.node.ty) idx
+
+let as_tuple ~build (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (Tuple vs) -> vs
+  | _ -> List.mapi (fun i _ -> field_of ~build i v) (t_as_tuple v.node.ty)
+
+let set_field ~build idx x (v : 'ghost sv) =
+  mk_tuple ~build (List.set_nth idx x (as_tuple ~build v))
+
 (** {3 Enums} *)
 
 let mk_enum ~build:(( <| ) : _ build) adt var_id vs =
@@ -241,3 +256,4 @@ let mk_poly ~build:(( <| ) : _ build) ty_id =
 let apply_unop ~build : Unop.t -> _ sv -> _ sv = function
   | ThinPtrPart part -> thin_ptr_part ~build part
   | FullPtrInner -> full_ptr_inner ~build
+  | Field i -> field_of ~build i

--- a/soteria-rust/lib/svalue/ext_base.ml
+++ b/soteria-rust/lib/svalue/ext_base.ml
@@ -12,6 +12,7 @@ module Unop = struct
     | FullPtrInner
     | Field of int
     | VariantField of (Types.variant_id[@hash Types.VariantId.to_int]) * int
+    | IsVariant of (Types.variant_id[@hash Types.VariantId.to_int])
     (* TODO: we could make [ArrayField] a binop, with the second operator a
        (possibly symbolic) value, to allow symbolically sized arrays! *)
     | ArrayField of int
@@ -272,6 +273,12 @@ let set_field_of_variant ~build var idx x (v : 'ghost sv) =
   let vs = List.set_nth idx x (as_enum_of_variant ~build var v) in
   mk_enum ~build (t_as_enum v.node.ty) var vs
 
+let is_variant ~build:(( <| ) : _ build) var (v : 'ghost sv) =
+  match v.node.kind with
+  | Extension (Enum (cur_var, _)) ->
+      Bool (Types.equal_variant_id var cur_var) <| TBool
+  | _ -> Extension (Unop (IsVariant var, v)) <| TBool
+
 (** {3 Arrays} *)
 
 let mk_array_of_svty ~build:(( <| ) : _ build) elem_ty vs =
@@ -316,4 +323,5 @@ let apply_unop ~build : Unop.t -> _ sv -> _ sv = function
   | FullPtrInner -> full_ptr_inner ~build
   | Field i -> field_of ~build i
   | VariantField (var_id, i) -> field_of_variant ~build var_id i
+  | IsVariant var_id -> is_variant ~build var_id
   | ArrayField i -> array_field_of ~build i

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -325,21 +325,20 @@ module Ptr = struct
 
   (* {1 Full/wide pointers ([sptr_f])} *)
 
-  let mk_ptr_f ptr meta =
+  let of_ptr_t ptr = Ext0.of_thin_ptr ~build:( <| ) ptr
+  let with_ptr fptr tptr = Ext0.full_ptr_set_inner ~build:( <| ) tptr fptr
+
+  let mk_ptr_f ptr (meta : _ t) =
     let meta =
-      match get_ty meta with
+      match meta.node.ty with
       | TBitVector _ -> Ext0.mk_len_meta ~build:( <| ) meta
       | TExtension TThinPtr -> Ext0.mk_vtable_meta ~build:( <| ) meta
-      | ty -> L.failwith "invalid meta ty: %a" ppa_ty ty
+      | ty -> L.failwith "mk_ptr_f: invalid metadata type %a" ppa_ty ty
     in
     Ext0.mk_full_ptr ~build:( <| ) ptr meta
 
-  let of_ptr_t ptr =
-    let unit_meta = Ext0.mk_unit_meta ~build:( <| ) () in
-    Extension (Ptr (ptr, unit_meta)) <| t_ptr_f ()
-
-  let mk_ptr_f_opt ptr meta =
-    match meta with None -> of_ptr_t ptr | Some meta -> mk_ptr_f ptr meta
+  let mk_ptr_f_opt ptr meta_opt =
+    match meta_opt with Some meta -> mk_ptr_f ptr meta | None -> of_ptr_t ptr
 
   (** The null full (wide) pointer: a {!null} thin pointer with no metadata. *)
   let null_f () = of_ptr_t (null ())
@@ -347,29 +346,8 @@ module Ptr = struct
   (** Like {!of_address}, but produces a full pointer with no metadata. *)
   let of_address_f addr = of_ptr_t (of_address addr)
 
-  let len_meta ptr =
-    match kind ptr with
-    | Extension
-        (Ptr (_, { node = { kind = Extension (PtrMeta (MetaLen len)); _ }; _ }))
-      ->
-        len
-    | Extension (Ptr (_, _)) -> L.failwith "len_meta mismatch"
-    | _ -> todo_migration "PtrFull get meta"
-
-  let vtable_meta ptr =
-    match kind ptr with
-    | Extension
-        (Ptr (_, { node = { kind = Extension (PtrMeta (MetaVTable vt)); _ }; _ }))
-      ->
-        vt
-    | Extension (Ptr (_, _)) -> L.failwith "vtable_meta mismatch"
-    | _ -> todo_migration "PtrFull get meta"
-
-  let with_ptr fptr tptr =
-    match kind fptr with
-    | Extension (Ptr (_, meta)) -> Extension (Ptr (tptr, meta)) <| fptr.node.ty
-    | _ -> todo_migration "PtrFull set ptr"
-
+  let len_meta ptr = Ext0.full_ptr_meta ~build:( <| ) MetaLen ptr
+  let vtable_meta ptr = Ext0.full_ptr_meta ~build:( <| ) MetaVTable ptr
   let ptr_of ptr = Ext0.full_ptr_inner ~build:( <| ) ptr
 end
 

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -378,14 +378,7 @@ module Adt = struct
 
   let mk_tuple vs = Ext0.mk_tuple ~build:( <| ) vs
   let unit = mk_tuple []
-
-  (* HACK: i don't like this; it forces all fields to be resolved, which is
-     often overkill. i think i want to get rid of this, and force clients to
-     instead go through [index_of] *)
-  let as_tuple v =
-    match kind v with
-    | Extension (Tuple vs) -> vs
-    | _ -> todo_migration "as_tuple unop"
+  let as_tuple v = Ext0.as_tuple ~build:( <| ) v
 
   let as_tuple1 v =
     match as_tuple v with [ a ] -> a | _ -> cast_error v (t_tuple [ t_int 1 ])
@@ -400,22 +393,8 @@ module Adt = struct
     | [ a; b; c ] -> (a, b, c)
     | _ -> cast_error v (t_tuple [ t_int 3 ])
 
-  let field_of idx v =
-    match kind v with
-    | Extension (Tuple vs) -> (
-        try List.nth vs idx
-        with Invalid_argument _ ->
-          L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
-    | _ -> todo_migration "field_of op"
-
-  let set_field idx f v =
-    match kind v with
-    | Extension (Tuple vs) -> (
-        try Extension (Tuple (List.set_nth idx f vs)) <| v.node.ty
-        with Invalid_argument _ ->
-          L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
-    | _ -> todo_migration "set_field op"
-
+  let field_of idx v = Ext0.field_of ~build:( <| ) idx v
+  let set_field idx f v = Ext0.set_field ~build:( <| ) idx f v
   let update_field idx f v = set_field idx (f (field_of idx v)) v
 
   (** {2 Enums} *)

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -243,20 +243,25 @@ module Ptr = struct
 
   (* {1 Internal raw-pointer plumbing (never exposed)} *)
 
-  let _get_ptr ptr =
-    match kind ptr with
-    | Extension (ThinPtr ptr) -> ptr
-    | _ -> todo_migration "todo: ThinPtr.ptr getter"
+  let _thin_part part ptr = Ext0.thin_ptr_part ~build:( <| ) part ptr
 
   let _set_ptr ptr f =
-    match kind ptr with
-    | Extension (ThinPtr inner) -> Ext0.mk_thin_ptr ~build:( <| ) (f inner)
-    | _ ->
-        (* NOTE: i actually don't think we want a setter unop, we just want to
-           rebuild the ptr from scratch *)
-        todo_migration "ThinPtr.ptr setter"
+    let inner =
+      match kind ptr with
+      | Extension (ThinPtr inner) -> inner
+      | _ ->
+          (* Symbolic thin pointer: rebuild it from its parts. As in [tag_of],
+             we assume symbolic pointers have no tag. *)
+          {
+            ptr = _thin_part PtrInner ptr;
+            size = _thin_part PtrSize ptr;
+            align = _thin_part PtrAlign ptr;
+            tag = None;
+          }
+    in
+    Ext0.mk_thin_ptr ~build:( <| ) (f inner)
 
-  let _inner ptr = (_get_ptr ptr).ptr
+  let _inner ptr = _thin_part PtrInner ptr
 
   let of_raw ~ptr ~size ~align ~tag =
     Ext0.mk_thin_ptr ~build:( <| ) { ptr; size; align; tag }
@@ -274,17 +279,22 @@ module Ptr = struct
     _set_ptr ptr (fun inner ->
         { inner with ptr = Self.Ptr.add_ofs inner.ptr o })
 
-  (* Sets the (absolute) offset of a thin pointer, keeping its location, size,
-     alignment and tag. Rebuilds only the inner raw pointer. *)
   let set_ofs ptr o =
     _set_ptr ptr (fun inner ->
         { inner with ptr = Self.Ptr.mk (Self.Ptr.loc inner.ptr) o })
 
-  let align_of ptr = (_get_ptr ptr).align
-  let size_of ptr = (_get_ptr ptr).size
-  let allocation_info ptr = (size_of ptr, align_of ptr)
-  let tag_of ptr = (_get_ptr ptr).tag
   let with_tag ptr tag = _set_ptr ptr (fun inner -> { inner with tag })
+  let align_of ptr = _thin_part PtrAlign ptr
+  let size_of ptr = _thin_part PtrSize ptr
+  let allocation_info ptr = (size_of ptr, align_of ptr)
+
+  let tag_of ptr =
+    match kind ptr with
+    | Extension (ThinPtr inner) -> inner.tag
+    | _ ->
+        (* HACK: we assume symbolic pointers have no tag *)
+        None
+
   let has_provenance ptr = not (is_at_null_loc ptr)
   let have_same_provenance p1 p2 = sem_eq (loc p1) (loc p2)
 

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -71,13 +71,7 @@ let () =
 let cast_error v ty = raise (CastError (v, ty, v.node.ty))
 let todo_migration msg = raise (TypedMigration msg)
 let ( <| ) = Self.Svalue.( <| )
-
-let float_precision :
-    Values.float_type -> Soteria.Bv_values.Svalue.FloatPrecision.t = function
-  | F16 -> F16
-  | F32 -> F32
-  | F64 -> F64
-  | F128 -> F128
+let float_precision = Ext0.float_precision
 
 (* The raw pointer type; only used to materialise a fully-symbolic nondet
    pointer in [Value_codec] (see {!Ptr.of_raw}). *)
@@ -88,10 +82,6 @@ let t_ptr_meta () : _ ty = TExtension TPtrMeta
 let t_loc () = t_loc (8 * size_of_uint_ty Usize)
 let t_usize () = t_int (8 * size_of_uint_ty Usize)
 let t_enum adt : _ ty = TExtension (TEnum adt)
-
-let t_as_enum : _ ty -> Types.type_decl_ref = function
-  | TExtension (TEnum adt) -> adt
-  | ty -> L.failwith "t_as_enum: expected enum type, got %a" ppa_ty ty
 
 let t_lit : Types.literal_type -> [> T.sint ] ty = function
   | (TInt _ | TUInt _ | TBool | TChar) as ty -> t_int (size_of_literal_ty ty * 8)
@@ -113,29 +103,6 @@ let t_union adt : [> T.union ] ty =
   TExtension (TUnion adt)
 
 let t_poly () : [> T.poly ] ty = TExtension TPolyType
-
-let rec ty_of_rust : Types.ty -> _ ty = function
-  | TLiteral (TFloat ft) -> t_float ft
-  | TLiteral lit -> t_lit lit
-  | TRef _ | TRawPtr _ | TFnPtr _ -> t_ptr_f ()
-  | TNever | TFnDef _ -> t_unit
-  | TVar _ -> t_poly ()
-  | TPattern (ty, _) -> ty_of_rust ty
-  | TArray (ty, n) -> t_array (ty_of_rust ty) (z_of_constant_expr n)
-  | TAdt { id = TTuple; generics = { types; _ } } ->
-      t_tuple (List.map ty_of_rust types)
-  | TAdt ({ id = TAdtId _; _ } as adt) -> (
-      match (Crate.get_adt adt).kind with
-      | Struct fs ->
-          t_tuple (List.map (fun (f : Types.field) -> ty_of_rust f.field_ty) fs)
-      | Enum _ -> t_enum adt
-      | Union _ -> t_union adt
-      | kind ->
-          L.failwith "ty_of_rust unexpected adt kind %a" Types.pp_type_decl_kind
-            kind)
-  | ( TError _ | TPtrMetadata _ | TTraitType _ | TDynTrait _ | TSlice _
-    | TAdt { id = TBuiltin _; _ } ) as ty ->
-      L.failwith "ty_of_rust unexpected type %a" Common.Charon_util.pp_ty ty
 
 let cast_checked ~ty v =
   match cast_checked v ty with Some v -> v | None -> cast_error v ty
@@ -283,7 +250,7 @@ module Ptr = struct
 
   let _set_ptr ptr f =
     match kind ptr with
-    | Extension (ThinPtr inner) -> Extension (ThinPtr (f inner)) <| ptr.node.ty
+    | Extension (ThinPtr inner) -> Ext0.mk_thin_ptr ~build:( <| ) (f inner)
     | _ ->
         (* NOTE: i actually don't think we want a setter unop, we just want to
            rebuild the ptr from scratch *)
@@ -292,7 +259,7 @@ module Ptr = struct
   let _inner ptr = (_get_ptr ptr).ptr
 
   let of_raw ~ptr ~size ~align ~tag =
-    Extension (ThinPtr { ptr; size; align; tag }) <| t_ptr_t ()
+    Ext0.mk_thin_ptr ~build:( <| ) { ptr; size; align; tag }
 
   let mk_ptr_t ~loc ~ofs ~size ~align ~tag =
     of_raw ~ptr:(Self.Ptr.mk loc ofs) ~size ~align ~tag
@@ -351,15 +318,14 @@ module Ptr = struct
   let mk_ptr_f ptr meta =
     let meta =
       match get_ty meta with
-      | TBitVector _ -> Extension (PtrMeta (MetaLen meta)) <| t_ptr_meta ()
-      | TExtension TThinPtr ->
-          Extension (PtrMeta (MetaVTable meta)) <| t_ptr_meta ()
+      | TBitVector _ -> Ext0.mk_len_meta ~build:( <| ) meta
+      | TExtension TThinPtr -> Ext0.mk_vtable_meta ~build:( <| ) meta
       | ty -> L.failwith "invalid meta ty: %a" ppa_ty ty
     in
-    Extension (Ptr (ptr, meta)) <| t_ptr_f ()
+    Ext0.mk_full_ptr ~build:( <| ) ptr meta
 
   let of_ptr_t ptr =
-    let unit_meta = Extension (PtrMeta MetaUnit) <| t_ptr_meta () in
+    let unit_meta = Ext0.mk_unit_meta ~build:( <| ) () in
     Extension (Ptr (ptr, unit_meta)) <| t_ptr_f ()
 
   let mk_ptr_f_opt ptr meta =
@@ -401,17 +367,12 @@ module Ptr = struct
 end
 
 module Adt = struct
-  let unit = Extension (Tuple []) <| t_tuple []
-  let mk_tuple vs = Extension (Tuple vs) <| t_tuple (List.map get_ty vs)
-
-  let mk_array elem_ty arr =
-    let len = Iarray.length arr in
-    let elem_ty = if len = 0 then ty_of_rust elem_ty else get_ty arr.%(0) in
-    Extension (Array arr) <| t_array elem_ty (Z.of_int len)
-
-  let mk_enum adt v_id vs = Extension (Enum (v_id, vs)) <| t_enum adt
-  let mk_union adt blocks = Extension (Union blocks) <| t_union adt
-  let mk_poly ty_id = Extension (PolyVal ty_id) <| t_poly ()
+  let mk_tuple vs = Ext0.mk_tuple ~build:( <| ) vs
+  let mk_array elem_ty arr = Ext0.mk_array ~build:( <| ) elem_ty arr
+  let mk_enum adt v_id vs = Ext0.mk_enum ~build:( <| ) adt v_id vs
+  let mk_union adt blocks = Ext0.mk_union ~build:( <| ) adt blocks
+  let mk_poly ty_id = Ext0.mk_poly ~build:( <| ) ty_id
+  let unit = mk_tuple []
 
   (* HACK: i have no idea what this really means or how to lift this for
      variables... *)

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -400,33 +400,11 @@ module Adt = struct
   (** {2 Enums} *)
 
   let mk_enum adt v_id vs = Ext0.mk_enum ~build:( <| ) adt v_id vs
+  let as_enum_of_variant var v = Ext0.as_enum_of_variant ~build:( <| ) var v
+  let field_of_variant var idx v = Ext0.field_of_variant ~build:( <| ) var idx v
 
-  let as_enum_of_variant var_id v =
-    match kind v with
-    | Extension (Enum (v, vs)) ->
-        assert (Types.VariantId.equal_id v var_id);
-        vs
-    | _ -> todo_migration "as_enum_of_variant unop"
-
-  let field_of_variant var_id idx v =
-    (* TODO: assert the variant? *)
-    match kind v with
-    | Extension (Enum (var, vs)) -> (
-        assert (Types.VariantId.equal_id var var_id);
-        try List.nth vs idx
-        with Invalid_argument _ ->
-          L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
-    | _ -> todo_migration "field_of_variant op"
-
-  let set_field_of_variant var_id idx f v =
-    (* TODO: assert the variant *)
-    match kind v with
-    | Extension (Enum (var, vs)) -> (
-        assert (Types.VariantId.equal_id var var_id);
-        try Extension (Enum (var, List.set_nth idx f vs)) <| v.node.ty
-        with Invalid_argument _ ->
-          L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
-    | _ -> todo_migration "set_field_of_variant op"
+  let set_field_of_variant var idx f v =
+    Ext0.set_field_of_variant ~build:( <| ) var idx f v
 
   let update_field_of_variant var idx f v =
     set_field_of_variant var idx (f (field_of_variant var idx v)) v

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -427,27 +427,9 @@ module Adt = struct
   (** {2 Arrays} *)
 
   let mk_array elem_ty arr = Ext0.mk_array ~build:( <| ) elem_ty arr
-
-  let as_array v =
-    match kind v with
-    | Extension (Array vs) -> vs
-    | _ -> todo_migration "as_array unop"
-
-  let array_field_of idx v =
-    match kind v with
-    | Extension (Array vs) -> (
-        try vs.%(idx)
-        with Invalid_argument _ ->
-          L.failwith "Array index %d out of bounds for value %a" idx ppa v)
-    | _ -> todo_migration "array_field_of op"
-
-  let set_array_field idx x v =
-    match kind v with
-    | Extension (Array vs) -> (
-        try Extension (Array (Iarray.copy_and_set idx x vs)) <| v.node.ty
-        with Invalid_argument _ ->
-          L.failwith "Array index %d out of bounds for value %a" idx ppa v)
-    | _ -> todo_migration "set_array_field op"
+  let as_array v = Ext0.as_array ~build:( <| ) v
+  let array_field_of idx v = Ext0.array_field_of ~build:( <| ) idx v
+  let set_array_field idx f v = Ext0.set_array_field ~build:( <| ) idx f v
 
   let update_array_field idx f v =
     set_array_field idx (f (array_field_of idx v)) v

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -2,7 +2,7 @@ open Iarray.Infix
 open Charon
 open Common.Charon_util
 open Soteria.Bv_values.Svalue
-open Ext.Rust_ext
+open Ext
 
 (* keep a handle on the unit [Ext], as [include Self] below shadows it with
    [Ext.Rust_ext] *)
@@ -21,7 +21,7 @@ type ('sc, 'ag, 'ofs, 'sz) block_raw = ('sc, 'ag, 'ofs, 'sz) Ext.block = {
 (* [Make_transparent] exposes [t]/[ty] as the underlying untyped svalue, so the
    extension helpers below can be written without ghost-typing ceremony. The
    [typed.mli] re-seals [t]/[ty] as abstract for the rest of Soteria Rust. *)
-module Self = Soteria.Bv_values.Typed.Make_transparent (Ext.Rust_ext) ()
+module Self = Soteria.Bv_values.Typed.Make_transparent (Ext) ()
 include Self
 
 module T = struct

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -365,15 +365,12 @@ module Ptr = struct
     | Extension (Ptr (_, _)) -> L.failwith "vtable_meta mismatch"
     | _ -> todo_migration "PtrFull get meta"
 
-  let ptr_of ptr =
-    match kind ptr with
-    | Extension (Ptr (ptr, _)) -> ptr
-    | _ -> todo_migration "PtrFull get ptr"
-
   let with_ptr fptr tptr =
     match kind fptr with
     | Extension (Ptr (_, meta)) -> Extension (Ptr (tptr, meta)) <| fptr.node.ty
     | _ -> todo_migration "PtrFull set ptr"
+
+  let ptr_of ptr = Ext0.full_ptr_inner ~build:( <| ) ptr
 end
 
 module Adt = struct

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -374,19 +374,10 @@ module Ptr = struct
 end
 
 module Adt = struct
-  let mk_tuple vs = Ext0.mk_tuple ~build:( <| ) vs
-  let mk_array elem_ty arr = Ext0.mk_array ~build:( <| ) elem_ty arr
-  let mk_enum adt v_id vs = Ext0.mk_enum ~build:( <| ) adt v_id vs
-  let mk_union adt blocks = Ext0.mk_union ~build:( <| ) adt blocks
-  let mk_poly ty_id = Ext0.mk_poly ~build:( <| ) ty_id
-  let unit = mk_tuple []
+  (** {2 Tuples} *)
 
-  (* HACK: i have no idea what this really means or how to lift this for
-     variables... *)
-  let as_union v =
-    match kind v with
-    | Extension (Union blocks) -> blocks
-    | _ -> todo_migration "as_union unop"
+  let mk_tuple vs = Ext0.mk_tuple ~build:( <| ) vs
+  let unit = mk_tuple []
 
   (* HACK: i don't like this; it forces all fields to be resolved, which is
      often overkill. i think i want to get rid of this, and force clients to
@@ -395,18 +386,6 @@ module Adt = struct
     match kind v with
     | Extension (Tuple vs) -> vs
     | _ -> todo_migration "as_tuple unop"
-
-  let as_array v =
-    match kind v with
-    | Extension (Array vs) -> vs
-    | _ -> todo_migration "as_array unop"
-
-  let as_enum_of_variant var_id v =
-    match kind v with
-    | Extension (Enum (v, vs)) ->
-        assert (Types.VariantId.equal_id v var_id);
-        vs
-    | _ -> todo_migration "as_enum_of_variant unop"
 
   let as_tuple1 v =
     match as_tuple v with [ a ] -> a | _ -> cast_error v (t_tuple [ t_int 1 ])
@@ -421,11 +400,6 @@ module Adt = struct
     | [ a; b; c ] -> (a, b, c)
     | _ -> cast_error v (t_tuple [ t_int 3 ])
 
-  let as_type_var v =
-    match kind v with
-    | Extension (PolyVal ty_id) -> ty_id
-    | _ -> todo_migration "as_type_var unop"
-
   let field_of idx v =
     match kind v with
     | Extension (Tuple vs) -> (
@@ -434,13 +408,26 @@ module Adt = struct
           L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "field_of op"
 
-  let array_field_of idx v =
+  let set_field idx f v =
     match kind v with
-    | Extension (Array vs) -> (
-        try vs.%(idx)
+    | Extension (Tuple vs) -> (
+        try Extension (Tuple (List.set_nth idx f vs)) <| v.node.ty
         with Invalid_argument _ ->
-          L.failwith "Array index %d out of bounds for value %a" idx ppa v)
-    | _ -> todo_migration "array_field_of op"
+          L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
+    | _ -> todo_migration "set_field op"
+
+  let update_field idx f v = set_field idx (f (field_of idx v)) v
+
+  (** {2 Enums} *)
+
+  let mk_enum adt v_id vs = Ext0.mk_enum ~build:( <| ) adt v_id vs
+
+  let as_enum_of_variant var_id v =
+    match kind v with
+    | Extension (Enum (v, vs)) ->
+        assert (Types.VariantId.equal_id v var_id);
+        vs
+    | _ -> todo_migration "as_enum_of_variant unop"
 
   let field_of_variant var_id idx v =
     (* TODO: assert the variant? *)
@@ -452,14 +439,6 @@ module Adt = struct
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "field_of_variant op"
 
-  let set_field idx f v =
-    match kind v with
-    | Extension (Tuple vs) -> (
-        try Extension (Tuple (List.set_nth idx f vs)) <| v.node.ty
-        with Invalid_argument _ ->
-          L.failwith "Tuple index %d out of bounds for value %a" idx ppa v)
-    | _ -> todo_migration "set_field op"
-
   let set_field_of_variant var_id idx f v =
     (* TODO: assert the variant *)
     match kind v with
@@ -469,19 +448,6 @@ module Adt = struct
         with Invalid_argument _ ->
           L.failwith "Enum field index %d out of bounds for value %a" idx ppa v)
     | _ -> todo_migration "set_field_of_variant op"
-
-  let set_array_field idx x v =
-    match kind v with
-    | Extension (Array vs) -> (
-        try Extension (Array (Iarray.copy_and_set idx x vs)) <| v.node.ty
-        with Invalid_argument _ ->
-          L.failwith "Array index %d out of bounds for value %a" idx ppa v)
-    | _ -> todo_migration "set_array_field op"
-
-  let update_field idx f v = set_field idx (f (field_of idx v)) v
-
-  let update_array_field idx f v =
-    set_array_field idx (f (array_field_of idx v)) v
 
   let update_field_of_variant var idx f v =
     set_field_of_variant var idx (f (field_of_variant var idx v)) v
@@ -500,6 +466,51 @@ module Adt = struct
           ite (is_variant var.id v) (BV.of_literal var.discriminant) (aux rest)
     in
     aux variants
+
+  (** {2 Arrays} *)
+
+  let mk_array elem_ty arr = Ext0.mk_array ~build:( <| ) elem_ty arr
+
+  let as_array v =
+    match kind v with
+    | Extension (Array vs) -> vs
+    | _ -> todo_migration "as_array unop"
+
+  let array_field_of idx v =
+    match kind v with
+    | Extension (Array vs) -> (
+        try vs.%(idx)
+        with Invalid_argument _ ->
+          L.failwith "Array index %d out of bounds for value %a" idx ppa v)
+    | _ -> todo_migration "array_field_of op"
+
+  let set_array_field idx x v =
+    match kind v with
+    | Extension (Array vs) -> (
+        try Extension (Array (Iarray.copy_and_set idx x vs)) <| v.node.ty
+        with Invalid_argument _ ->
+          L.failwith "Array index %d out of bounds for value %a" idx ppa v)
+    | _ -> todo_migration "set_array_field op"
+
+  let update_array_field idx f v =
+    set_array_field idx (f (array_field_of idx v)) v
+
+  (** {2 Unions and PolyVal} *)
+
+  let mk_union adt blocks = Ext0.mk_union ~build:( <| ) adt blocks
+  let mk_poly ty_id = Ext0.mk_poly ~build:( <| ) ty_id
+
+  (* HACK: i have no idea what this really means or how to lift this for
+     variables... *)
+  let as_union v =
+    match kind v with
+    | Extension (Union blocks) -> blocks
+    | _ -> todo_migration "as_union unop"
+
+  let as_type_var v =
+    match kind v with
+    | Extension (PolyVal ty_id) -> ty_id
+    | _ -> todo_migration "as_type_var unop"
 
   module Checked = struct
     let mk_enum tref variant vs =

--- a/soteria-rust/lib/svalue/typed.ml
+++ b/soteria-rust/lib/svalue/typed.ml
@@ -409,10 +409,7 @@ module Adt = struct
   let update_field_of_variant var idx f v =
     set_field_of_variant var idx (f (field_of_variant var idx v)) v
 
-  let is_variant var_id v =
-    match kind v with
-    | Extension (Enum (var, _)) -> of_bool (Types.VariantId.equal_id var var_id)
-    | _ -> todo_migration "is_variant unop"
+  let is_variant var_id v = Ext0.is_variant ~build:( <| ) var_id v
 
   let discriminant_of (v : _ t) =
     let variants = Crate.as_enum (t_as_enum v.node.ty) in

--- a/soteria-rust/lib/svalue/typed.mli
+++ b/soteria-rust/lib/svalue/typed.mli
@@ -12,7 +12,10 @@ type ('sc, 'ag, 'ofs, 'sz) block_raw = ('sc, 'ag, 'ofs, 'sz) Ext.block = {
 
 (* The extended ghost-typed interface, sharing [Solver_value]'s [t]/[ty] so
    values flow between the interpreter and the symex monad. *)
-include Soteria.Bv_values.Typed.S with module Ext = Ext.Rust_ext
+include
+  Soteria.Bv_values.Typed.S
+    with type 'a Ext.t = 'a Ext.t
+     and type 'a Ext.ty = 'a Ext.ty
 
 (* T *)
 

--- a/soteria-rust/lib/value_codec.ml
+++ b/soteria-rust/lib/value_codec.ml
@@ -543,10 +543,21 @@ let rec validity ?(check_ref = fun _ _ -> Rustsymex.Result.ok ()) ty v f =
   (* undefined.validity.enum *)
   | TAdt adt when Crate.is_enum adt ->
       let v = Typed.cast_enum ~adt v in
-      let* variant = variant_for_enum v adt in
-      Iter.of_list (field_tys variant.fields)
-      |> Iter.mapi (fun i ty -> (ty, Typed.Adt.field_of_variant variant.id i v))
-      |> iter_iter ~f:(fun (ty, v) -> validity ~check_ref ty v f)
+      Iter.of_list (Crate.as_enum adt)
+      |> Iter.filter_map (fun (variant : Types.variant) ->
+          (* we filter variants we know aren't possible to avoid traversing
+             concrete enums in full for no reason *)
+          let guard = Typed.Adt.is_variant variant.id v in
+          if Typed.equal guard Typed.v_false then None else Some (variant, guard))
+      |> iter_iter ~f:(fun ((variant : Types.variant), guard) ->
+          let check_ref ptr ty =
+            if%sat guard then check_ref ptr ty else ok ()
+          in
+          let f c e = f (Typed.not guard ||@ c) e in
+          Iter.of_list (field_tys variant.fields)
+          |> Iter.mapi (fun i ty ->
+              (ty, Typed.Adt.field_of_variant variant.id i v))
+          |> iter_iter ~f:(fun (ty, v) -> validity ~check_ref ty v f))
   (* undefined.validity.struct *)
   | TAdt adt when Crate.is_struct_or_tuple adt ->
       let v = Typed.cast_tuple v in
@@ -717,18 +728,10 @@ let rec nondet_raw :
       let type_decl = Crate.get_adt adt in
       match type_decl.kind with
       | Enum [] -> vanish ()
-      | Enum (v :: _ as variants) ->
-          let* discr = nondet (Typed.t_lit (lit_ty_of_lit v.discriminant)) in
-          let discr : Typed.(T.sint t) = Typed.cast discr in
-          let* variant =
-            match_on variants ~constr:(fun v ->
-                BV.of_literal v.discriminant ==@ discr)
-          in
-          let* variant =
-            match variant with Some v -> return v | None -> vanish ()
-          in
-          let++ fields = nondets_raw @@ field_tys variant.fields in
-          Typed.Adt.mk_enum adt variant.id fields
+      | Enum (_ :: _) ->
+          (* we don't recurse into the variants, to avoid branching *)
+          let+ enum = nondet (Typed.t_enum adt) in
+          Ok enum
       | Struct fields ->
           let++ fields = nondets_raw @@ field_tys fields in
           Typed.Adt.mk_tuple fields

--- a/soteria.opam
+++ b/soteria.opam
@@ -21,8 +21,8 @@ depends: [
   "ppx_expect" {>= "v0.17.0"}
   "ppx_blob" {>= "0.9.0"}
   "ppx_subliner" {>= "0.2.1"}
-  "ppx_deriving"
-  "ppx_deriving_hash"
+  "ppx_deriving" {>= "6.1.3"}
+  "ppx_deriving_hash" {>= "0.1.4"}
   "fmt"
   "printbox"
   "printbox-text"

--- a/soteria/lib/bv_values/encoding.ml
+++ b/soteria/lib/bv_values/encoding.ml
@@ -174,7 +174,8 @@ module Make (Typed : Typed_intf.Solver_value) = struct
     | Nop (Distinct, vs) ->
         let vs = List.map encode_value_memo vs in
         distinct vs
-    | Extension x -> Typed.Ext.encode_value encode_value_memo x
+    | Extension x ->
+        Typed.Ext.encode_value sort_of_ty encode_value_memo ~ty:v.node.ty x
 
   and encode_value_memo v =
     match Svalue.Hashtbl.find_opt memo_encode_value_tbl v with

--- a/soteria/lib/bv_values/eval.ml
+++ b/soteria/lib/bv_values/eval.ml
@@ -104,8 +104,7 @@ module Make (Ext : Value_ext) (V : module type of Svalue.Make (Ext) ()) = struct
         if (not force) && not changed then x else SSeq.mk ~seq_ty:x.node.ty l
     | Extension ext ->
         let ext' = Ext.eval eval ext in
-        if (not force) && ext == ext' then x
-        else Ext.mk x.node.ty ext' <| x.node.ty
+        if (not force) && ext == ext' then x else Ext.mk ( <| ) x.node.ty ext'
 
   (** Evaluates an expression; will call [eval_var] on each [Var] encountered.
       If evaluation errors (e.g. from a division by zero), gives up and returns

--- a/soteria/lib/bv_values/expr.ml
+++ b/soteria/lib/bv_values/expr.ml
@@ -68,7 +68,7 @@ struct
               (Svalue.Bool.mk_exists vs sv, s)
           | Extension x ->
               let x, s = Ext.apply_subst apply ~missing_var s x in
-              (Ext.mk v.node.ty x <| v.node.ty, s))
+              (Ext.mk ( <| ) v.node.ty x, s))
 
     and apply_list ~missing_var s vs =
       match vs with

--- a/soteria/lib/bv_values/svalue.ml
+++ b/soteria/lib/bv_values/svalue.ml
@@ -284,16 +284,24 @@ module type Value_ext = sig
   val hash : 'g t -> int
   val hash_ty : 'g ty -> int
 
-  (** [mk ty x] is the svalue node-kind representing extension value [x] at type
-      [ty] — typically [Extension x], but the extension may normalise to another
-      kind. {{!Soteria.Bv_values.Svalue.Make}[Make]} hash-conses the result.
-      Called when an svalue carrying an extension is rebuilt (e.g. after its
-      children are evaluated). *)
-  val mk : 'g super_ty -> 'g t -> ('g, 'g t, 'g ty) t_kind
+  (** [mk build ty x] is the value representing extension value [x] at type [ty]
+      — typically [build (Extension x) ty], but the extension may normalise to a
+      different svalue for simplifications.
+
+      [build] hash-conses a node kind at a type in the embedding
+      {{!Soteria.Bv_values.Svalue.Make}[Make]} application. It is provided as a
+      helper. *)
+  val mk :
+    (('g, 'g t, 'g ty) t_kind -> 'g super_ty -> 'g super_t) ->
+    'g super_ty ->
+    'g t ->
+    'g super_t
 
   (** [eval eval_super x] returns [x] with every enclosing svalue nested in it
-      replaced by [eval_super] applied to it — the extension's contribution to
-      the {{!Soteria.Bv_values.Eval}[Eval]} pass. *)
+      replaced by [eval_super] applied to it. This should {b not} attempt to
+      re-apply smart constructors: if the returned value is not physically equal
+      to the input, {!mk} will be applied to it, at which point smart
+      constructors are used. *)
   val eval : ('g super_t -> 'g super_t) -> 'g t -> 'g t
 
   val apply_subst :
@@ -306,8 +314,24 @@ module type Value_ext = sig
     'g t ->
     'g t * 'subst
 
+  (** [encode_ty encode_ty ty] is the SMT-LIB sort representing [ty];
+      [encode_ty] encodes the types nested inside it. The encoder may use
+      {{!Soteria.Solvers.Decls.declare}[Solvers.Decls.declare]} to introduce
+      auxiliary declarations (e.g. algebraic datatypes) its encoding relies on.
+  *)
   val encode_ty : ('g super_ty -> Smt.sexp) -> 'g ty -> Smt.sexp
-  val encode_value : ('g super_t -> Smt.sexp) -> 'g t -> Smt.sexp
+
+  (** [encode_value encode_ty encode ~ty x] is the SMT-LIB term representing
+      extension value [x], where [ty] is the type of the svalue whose kind is
+      [Extension x]; [encode_ty] (resp. [encode]) encodes nested types (resp.
+      values). Like {!encode_ty}, may call
+      {{!Soteria.Solvers.Decls.declare}[Solvers.Decls.declare]}. *)
+  val encode_value :
+    ('g super_ty -> Smt.sexp) ->
+    ('g super_t -> Smt.sexp) ->
+    ty:'g super_ty ->
+    'g t ->
+    Smt.sexp
 end
 
 (** The empty extension: [t] and [ty] are uninhabited, so an svalue built with
@@ -324,11 +348,11 @@ module Dummy_ext : Value_ext = struct
   let hash_ty (x : _ ty) = match x with _ -> .
   let pp _ _ (x : _ t) = match x with _ -> .
   let pp_ty _ (x : _ ty) = match x with _ -> .
-  let mk _ (x : _ t) = match x with _ -> .
+  let mk _ _ (x : _ t) = match x with _ -> .
   let eval _ (x : _ t) = match x with _ -> .
   let apply_subst _ ~missing_var:_ _ (x : _ t) = match x with _ -> .
   let encode_ty _ (x : _ ty) = match x with _ -> .
-  let encode_value _ (x : _ t) = match x with _ -> .
+  let encode_value _ _ ~ty:_ (x : _ t) = match x with _ -> .
 end
 
 (** Builds the untyped svalue layer for extension [V]: the value/type

--- a/soteria/lib/smt/smt.ml
+++ b/soteria/lib/smt/smt.ml
@@ -293,6 +293,7 @@ let bv_smulo l r = "bvsmulo" $$. [ l; r ]
 
 (** {2 Sequences} *)
 
+(* [t_seq elt] is the type of sequences of [elt]. *)
 let t_seq elt = "Seq" $. elt
 let seq_empty = atom "seq.empty"
 let seq_singl x = "seq.unit" $. x

--- a/soteria/lib/soteria_std/iarray.ml
+++ b/soteria/lib/soteria_std/iarray.ml
@@ -28,4 +28,6 @@ let map_changed f vs =
   in
   (res, !changed)
 
+let hash_combine a b = (31 * a) + b
+let hash hash_elt = fold_left (fun acc v -> hash_combine acc (hash_elt v)) 0
 let pp ?sep pp_elt = Fmt.iter ?sep iter pp_elt

--- a/soteria/lib/soteria_std/iarray.mli
+++ b/soteria/lib/soteria_std/iarray.mli
@@ -22,6 +22,9 @@ val copy_and_set : int -> 'a -> 'a t -> 'a t
     [!=]). *)
 val map_changed : ('a -> 'a) -> 'a t -> 'a t * bool
 
+(** Hashes this Iarray, using the given hashing function for its elements. *)
+val hash : ('a -> int) -> 'a t -> int
+
 val pp :
   ?sep:(Format.formatter -> unit -> unit) ->
   (Format.formatter -> 'a -> unit) ->


### PR DESCRIPTION
Builds on top of #460 and #462 
Closes #421 

Finally ! Add encoding of Rust values to SMT-LIB. All commits build and work on their own. There are also a couple commits that are just about moving things around, so you can ignore those.

Adds an encoding into SMT for all the Rust values, and then add operators for whatever additional functions we need. All of this code is unreachable so far, because we don't actually create nondeterministic Rust values; I've tested the code and it seems correct though, I just don't want to mix the PR that focuses on SMT with a PR that does behaviour changes.