### PR TITLE
Fix the Licensing to reflect Imperial's ownership

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,19 @@
 Soteria
 
-Copyright 2026 Soteria Tools Ltd.
+Soteria was originally developed at Imperial College London and is now developed
+and maintained by Soteria Tools Ltd.
 
-This product includes software developed by Soteria Tools Ltd. and contributors.
+Copyright 2024-2025 Imperial College London
+Copyright 2025-2026 Soteria Tools Ltd.
+
+Copyright in contributions made on or before 18 December 2025 is held by Imperial
+College London. Copyright in contributions made on or after 19 December 2025 is
+held by Soteria Tools Ltd. All contributions are licensed under the Apache
+License, Version 2.0. Individual files may contain contributions from both
+periods and are therefore jointly attributed above.
+
+This product includes software developed at Imperial College London and by
+Soteria Tools Ltd. and contributors.
 
 Project maintainers:
 - Sacha-Élie Ayoun <s.ayoun17@imperial.ac.uk>

--- a/README.md
+++ b/README.md
@@ -167,6 +167,6 @@ We would especially like to thank:
 
 ## License
 
-Soteria and derived tools in this repository are under Apache-2.0 license, copyright Soteria Tools Ltd 2026.
+Soteria and derived tools in this repository are under the Apache-2.0 license. Copyright 2024–2025 Imperial College London and 2025–2026 Soteria Tools Ltd.; see the [NOTICE](./NOTICE) file for how copyright is split between the two.
 
 The Soteria logo is a trademark of the Soteria Tools Ltd.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: 2026 Soteria Tools Ltd.
+# SPDX-FileCopyrightText: 2024-2025 Imperial College London
+# SPDX-FileCopyrightText: 2025-2026 Soteria Tools Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
 version = 1
@@ -44,7 +45,9 @@ path = [
   "AI_POLICY.md",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "2026 Soteria Tools Ltd."
+# Copyright is held jointly: Imperial College London for contributions made
+# through 18 Dec 2025, Soteria Tools Ltd. from 19 Dec 2025 onward (see NOTICE).
+SPDX-FileCopyrightText = ["2024-2025 Imperial College London", "2025-2026 Soteria Tools Ltd."]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]

--- a/doc/odoc-theme/odoc.css
+++ b/doc/odoc-theme/odoc.css
@@ -3,7 +3,7 @@
  * Soteria Custom odoc Theme
  * Aligned with https://soteria-tools.com design system
  *
- * Copyright (c) 2024-2026 Soteria Tools Ltd. All rights reserved.
+ * Copyright (c) 2024-2025 Imperial College London and 2025-2026 Soteria Tools Ltd.
  * Based on odoc default theme, ISC license.
  */
 


### PR DESCRIPTION
The original codebase is under Imperial College ownership, and then, starting Dec 18th 2025, changes onwards belong to Soteria Tools.