### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ request.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-08-07
+
+### Changed
+
+- Changed the dependencies of Soteria's test, removing an unresolved import in the absence of `soteria-c`.
+- Explicitly set `zarith`'s min version to `1.13`
+
 ## [0.2.0] - 2026-08-07
 
 A small patch update while we work on large scale changes. A Soteria Rust flag was changed, and we saw overall performance improvements of Soteria Rust and C, by up to 20% and 8% respectively!

--- a/dune-project
+++ b/dune-project
@@ -47,13 +47,15 @@
   ppx_deriving
   ppx_deriving_hash
   fmt
+  printbox
   printbox-text
   htmlit
   (progress
    (>= 0.5.0))
   (grace
    (= 0.3.0))
-  zarith
+  (zarith
+   (>= 1.13))
   (odoc :with-doc)
   (mdx :with-test)
   (alcotest :with-test)

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Central version configuration for Soteria. Run `scripts/versionsync.py check` to verify versions are in sync, or `scripts/versionsync.py update` to update versions everywhere.",
-  "SOTERIA_VERSION": "0.2.0",
+  "SOTERIA_VERSION": "0.2.1",
   "CHARON_REPO": "soteria-tools/charon",
   "CHARON_COMMIT_HASH": "4398b734716b0f3c26a8b43b8791e698bc242139",
   "OBOL_REPO": "soteria-tools/obol",

--- a/soteria.opam
+++ b/soteria.opam
@@ -24,11 +24,12 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_hash"
   "fmt"
+  "printbox"
   "printbox-text"
   "htmlit"
   "progress" {>= "0.5.0"}
   "grace" {= "0.3.0"}
-  "zarith"
+  "zarith" {>= "1.13"}
   "odoc" {with-doc}
   "mdx" {with-test}
   "alcotest" {with-test}

--- a/soteria/lib/dune
+++ b/soteria/lib/dune
@@ -11,6 +11,7 @@
   hc
   htmlit
   iter
+  printbox
   printbox-text
   progress
   str

--- a/soteria/lib/version.ml
+++ b/soteria/lib/version.ml
@@ -1,5 +1,5 @@
 (* Kept in sync with scripts/versions.json by scripts/versionsync.py; do not
    edit the version string by hand. *)
 
-(* [versionsync: SOTERIA_VERSION=0.2.0] *)
-let version = "0.2.0"
+(* [versionsync: SOTERIA_VERSION=0.2.1] *)
+let version = "0.2.1"

--- a/soteria/tests/symex/dune
+++ b/soteria/tests/symex/dune
@@ -1,6 +1,6 @@
 (tests
  (names run_twice deep_give_up if_sure interrupt fail_fast consume)
- (libraries soteria soteria_c_lib alcotest)
+ (libraries soteria alcotest)
  (flags :standard -open Soteria.Tiny_values)
  (preprocess
   (pps soteria.ppx)))


### PR DESCRIPTION
Our `soteria` release was failing on opam (see https://github.com/ocaml/opam-repository/pull/30431). Tried fixing it, let's see if that's enough.
