### PR TITLE
Set dune version in switch installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,9 @@ packaging/soteria-rust/linux_dylibs.txt:
 
 .PHONY: switch
 switch:
-	$(OPAM) switch create . ocaml-base-compiler.$(OCAML_VERSION) --deps-only --with-test --with-doc -y
+	$(OPAM) switch create --empty -y
+	$(OPAM) install ocaml-base-compile.$(OCAML_VERSION) dune.$(DUNE_VERSION) -y
+	$(OPAM) install . --deps-only --with-test --with-doc -y
 	$(OPAM) install ocaml-lsp-server odig ocamlformat.$(OCAMLFORMAT_VERSION) -y
 
 .PHONY: glob-switch


### PR DESCRIPTION
The `make switch` command was crashing because the dune version was being bumped to 3.24 and cerberus could not be installed due to Coq-related issues with newer dune versions. Now, this command sets the correct dune version and the switch can be successfully created.