### PR TITLE
Soteria Rust clarification of `#[test]` entrypoints

### DIFF
--- a/soteria-rust/lib/config.ml
+++ b/soteria-rust/lib/config.ml
@@ -100,9 +100,18 @@ type t = {
       (** Whether to compile without accessing the network, which can be useful
           for reproducibility. This will pass --offline to Cargo.. *)
   test : string option; [@docs Sections.frontend] [@names [ "test" ]]
-      (** The test profile to use to compile the crate; this only has an effect
-          if analysing a crate. Use [lib] for unit tests in [src/]. By default,
-          the crate's source is analysed, not the tests. *)
+      (** The integration-test target to compile and analyse (a file in
+          [tests/]); this only has an effect if analysing a crate. By default,
+          the crate's source is analysed, not the tests. Mutually exclusive with
+          --lib. *)
+  lib : bool; [@docs Sections.frontend] [@make.default false] [@names [ "lib" ]]
+      (** Analyse the library's unit tests in [src/]. By default, the crate's
+          source is analysed, not the tests. Mutually exclusive with --test. *)
+  with_libtest : bool;
+      [@docs Sections.frontend] [@make.default false] [@names [ "libtest" ]]
+      (** When analysing a test target (--test or --lib), also discover the
+          crate's ordinary #[test] functions, not just Soteria's own harnesses
+          (#[soteria::test]). Has no effect when analysing source. *)
   (* Plugins *)
   with_kani : bool;
       [@docs Sections.frontend] [@make.default false] [@names [ "kani" ]]
@@ -225,5 +234,9 @@ let set_and_lock_global (mode : mode) (config : global) =
   if config.soteria_rust.polymorphic && config.soteria_rust.frontend = Obol then
     Exn.config_error
       "Obol does not support polymorphic analyses; use --frontend charon";
+  if Option.is_some config.soteria_rust.test && config.soteria_rust.lib then
+    Exn.config_error
+      "--test and --lib are mutually exclusive: use --lib for the library's \
+       unit tests in src/, or --test <name> for an integration test";
   set_mode_and_lock mode;
   set_and_lock config.soteria_rust

--- a/soteria-rust/lib/frontend.ml
+++ b/soteria-rust/lib/frontend.ml
@@ -292,21 +292,24 @@ let create_using_current_config () : mk_cmd * entry_point_filter =
   in
   let cmd = List.fold_left Cmd.concat_cmd Cmd.empty cmd_parts in
   let cmd =
-    match config.test with
-    | None -> cmd
-    | Some _ ->
-        (* HACK: if we're in test mode, we want to ignore main because Rust will
-           compile it in a quirky way and it requires having a sysroot. Instead
-           we want to look for the tests directly! So we add #[test] *)
-        let entry_points =
-          Cmd.(entry (Attrib "test"))
-          :: List.filter
-               (function
-                 | Cmd.{ matcher = Pub | Name "main"; _ } -> false | _ -> true)
-               cmd.entry_points
-        in
-        let expect_error = Cmd.Attrib "should_panic" :: cmd.expect_error in
-        { cmd with entry_points; expect_error }
+    if Option.is_none config.test && not config.lib then cmd
+    else
+      (* HACK: in test mode (--test or --lib) we ignore main because Rust will
+         compile it in a quirky way and it requires having a sysroot. Instead we
+         look for the tests directly! *)
+      let test_attr =
+        if config.with_libtest then
+          [ Cmd.{ matcher = Attrib "test"; args = [] } ]
+        else []
+      in
+      let entry_points =
+        test_attr @ cmd.entry_points
+        |> List.filter (function
+          | Cmd.{ matcher = Cmd.Pub | Name "main"; _ } -> false
+          | _ -> true)
+      in
+      let expect_error = Cmd.Attrib "should_panic" :: cmd.expect_error in
+      { cmd with entry_points; expect_error }
   in
   let mk_cmd =
    fun ?input ~output () ->
@@ -373,10 +376,12 @@ let parse_ullbc_of_file ~(mk_cmd : mk_cmd) file_name =
 
 (** Given a Rust file, parse it into LLBC, using Charon. *)
 let parse_ullbc_of_crate ~(mk_cmd : mk_cmd) crate_dir =
+  let config = Config.get () in
   let filename =
-    match (Config.get ()).test with
-    | Some test -> "test-" ^ test ^ ".ullbc"
-    | None -> "crate.ullbc"
+    match (config.test, config.lib) with
+    | Some test, _ -> "test-" ^ test ^ ".ullbc"
+    | None, true -> "test-lib.ullbc"
+    | _ -> "crate.ullbc"
   in
   let output = crate_dir / filename in
   let cmd = mk_cmd ~output () in

--- a/soteria-rust/lib/frontend_runtime.ml
+++ b/soteria-rust/lib/frontend_runtime.ml
@@ -267,11 +267,12 @@ module Cmd = struct
         in
         (cmd, ("rustc" :: args) @ [ "--" ] @ rustc @ target_flag, [])
     | Cargo ->
+        let config = Config.get () in
         let cargo =
-          match (Config.get ()).test with
-          | Some "lib" -> [ "--lib" ]
-          | Some test -> [ "--test"; test ]
-          | None -> []
+          match (config.test, config.lib) with
+          | Some test, false -> [ "--test"; test ]
+          | None, true -> [ "--lib" ]
+          | _ -> []
         in
         let cargo = cargo @ cargo_flags () @ target_flag in
         let rustc = flags_for_cargo rustc in

--- a/soteria-rust/test/cram/cargo-test.t/run.t
+++ b/soteria-rust/test/cram/cargo-test.t/run.t
@@ -1,75 +1,84 @@
 Test running Soteria Rust on a crate with tests
-  $ soteria-rust exec . --test tests
-  Compiling... done in <time>
-  => Running tests::test_ok#1...
-  note: tests::test_ok#1: done in <time>, ran 1 branch
-  PC 1: empty
-  
-  => Running tests::test_nok#1...
-  error: tests::test_nok#1: found issues in <time>, errors in 1 branch (out of 1)
-  error: Failed assertion in tests::test_nok#1
-      --> $RUSTLIB/library/core/src/panicking.rs:407:5
-  407 |      assert_failed_inner(kind, &left, &right, args)
-      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      |      |
-      |      Triggering operation
-      |      3: Call trace
-      --> tests/tests.rs:10:5
-    9 |  fn test_nok() {
-      |  ------------- 1: Entry point
-   10 |      assert_eq!(get_answer(), 67);
-      |      ---------------------------- 2: Call trace
-  PC 1: empty
-  
-  => Running tests::test_nok_expected#1...
-  error: tests::test_nok_expected#1: found issues in <time>, errors in 1 branch (out of 1)
-  error: Failed assertion in tests::test_nok_expected#1
-      --> $RUSTLIB/library/core/src/panicking.rs:407:5
-  407 |      assert_failed_inner(kind, &left, &right, args)
-      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      |      |
-      |      Triggering operation
-      |      3: Call trace
-      --> tests/tests.rs:17:5
-   16 |  fn test_nok_expected() {
-      |  ---------------------- 1: Entry point
-   17 |      assert_eq!(get_answer(), 67);
-      |      ---------------------------- 2: Call trace
-  PC 1: empty
-  
-  [1]
+
+A target's #[soteria::test] harnesses run by default, without --libtest.
   $ soteria-rust exec . --test soteria
   Compiling... done in <time>
-  => Running soteria::tests::test_ok#1...
-  note: soteria::tests::test_ok#1: done in <time>, ran 1 branch
+  => Running soteria::tests::harness_ok...
+  note: soteria::tests::harness_ok: done in <time>, ran 1 branch
   PC 1: (V|1| == 0x0000002a) /\ (V|1| == 0x0000002a)
   
-  => Running soteria::tests::test_nok#1...
-  error: soteria::tests::test_nok#1: found issues in <time>, errors in 1 branch (out of 2)
-  error: Failed assertion in soteria::tests::test_nok#1
+  => Running soteria::tests::harness_nok...
+  error: soteria::tests::harness_nok: found issues in <time>, errors in 1 branch (out of 2)
+  error: Failed assertion in soteria::tests::harness_nok
       --> $RUSTLIB/library/core/src/panicking.rs:407:5
   407 |      assert_failed_inner(kind, &left, &right, args)
       |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |      |
       |      Triggering operation
       |      3: Call trace
-      --> tests/soteria.rs:15:9
-   13 |      fn test_nok() {
-      |      ------------- 1: Entry point
-   14 |          let x: i32 = soteria::nondet_bytes();
-   15 |          assert_eq!(x, get_answer());
+      --> tests/soteria.rs:19:9
+   17 |      fn harness_nok() {
+      |      ---------------- 1: Entry point
+   18 |          let x: i32 = soteria::nondet_bytes();
+   19 |          assert_eq!(x, get_answer());
       |          --------------------------- 2: Call trace
   PC 1: (V|1| != 0x0000002a)
   
-  => Running soteria::tests::test_nok_ok#1...
-  note: soteria::tests::test_nok_ok#1: done in <time>, ran 2 branches
+  => Running soteria::tests::harness_nok_ok...
+  note: soteria::tests::harness_nok_ok: done in <time>, ran 2 branches
   PC 1: (V|1| != 0x0000002a)
   
   [1]
 
-  $ soteria-rust exec . --test lib --cargo="--features my_feature"
+With --libtest, the target's ordinary #[test] functions run alongside them.
+  $ soteria-rust exec . --test soteria --libtest
+  Compiling... done in <time>
+  => Running soteria::tests::harness_ok...
+  note: soteria::tests::harness_ok: done in <time>, ran 1 branch
+  PC 1: (V|1| == 0x0000002a) /\ (V|1| == 0x0000002a)
+  
+  => Running soteria::tests::harness_nok...
+  error: soteria::tests::harness_nok: found issues in <time>, errors in 1 branch (out of 2)
+  error: Failed assertion in soteria::tests::harness_nok
+      --> $RUSTLIB/library/core/src/panicking.rs:407:5
+  407 |      assert_failed_inner(kind, &left, &right, args)
+      |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |      |
+      |      Triggering operation
+      |      3: Call trace
+      --> tests/soteria.rs:19:9
+   17 |      fn harness_nok() {
+      |      ---------------- 1: Entry point
+   18 |          let x: i32 = soteria::nondet_bytes();
+   19 |          assert_eq!(x, get_answer());
+      |          --------------------------- 2: Call trace
+  PC 1: (V|1| != 0x0000002a)
+  
+  => Running soteria::tests::harness_nok_ok...
+  note: soteria::tests::harness_nok_ok: done in <time>, ran 2 branches
+  PC 1: (V|1| != 0x0000002a)
+  
+  => Running soteria::tests::unit_in_test_target#1...
+  note: soteria::tests::unit_in_test_target#1: done in <time>, ran 1 branch
+  PC 1: empty
+  
+  [1]
+
+A target with only ordinary #[test] functions and no harnesses is empty by
+default (nothing is discovered without --libtest).
+  $ soteria-rust exec . --test tests
+  Compiling... done in <time>
+  error: Fatal: No entry points found
+  [2]
+
+--lib analyses the library's unit tests in src/.
+  $ soteria-rust exec . --lib --libtest --cargo="--features my_feature"
   Compiling... done in <time>
   => Running my_crate::test::test_in_src#1...
   note: my_crate::test::test_in_src#1: done in <time>, ran 1 branch
   PC 1: empty
   
+--test and --lib are mutually exclusive.
+  $ soteria-rust exec . --test tests --lib
+  error: Fatal (Config): --test and --lib are mutually exclusive: use --lib for the library's unit tests in src/, or --test <name> for an integration test
+  [124]

--- a/soteria-rust/test/cram/cargo-test.t/tests/soteria.rs
+++ b/soteria-rust/test/cram/cargo-test.t/tests/soteria.rs
@@ -1,24 +1,35 @@
+// A mix of Soteria harnesses (#[soteria::test], discovered and run by default)
+// and an ordinary #[test] (discovered only under --libtest).
 #[cfg(soteria)]
 mod tests {
     use my_crate::get_answer;
 
-    #[test]
-    fn test_ok() {
+    // Harness: passes — x is constrained to 42 before the assertion.
+    #[soteria::test]
+    fn harness_ok() {
         let x: i32 = soteria::nondet_bytes();
         soteria::assume(x == 42);
         assert_eq!(x, get_answer());
     }
 
-    #[test]
-    fn test_nok() {
+    // Harness: finds a bug — x is unconstrained, so x != 42 is reachable.
+    #[soteria::test]
+    fn harness_nok() {
         let x: i32 = soteria::nondet_bytes();
         assert_eq!(x, get_answer());
     }
 
-    #[test]
+    // Harness expected to fail: the failing branch is the expected outcome.
+    #[soteria::test]
     #[soteria::expect_fail]
-    fn test_nok_ok() {
+    fn harness_nok_ok() {
         let x: i32 = soteria::nondet_bytes();
         assert_eq!(x, get_answer());
+    }
+
+    // Ordinary unit test: only discovered under --libtest.
+    #[test]
+    fn unit_in_test_target() {
+        assert_eq!(get_answer(), 42);
     }
 }

--- a/soteria-rust/test/cram/cli.t/run.t
+++ b/soteria-rust/test/cram/cli.t/run.t
@@ -149,6 +149,16 @@
          --kani
              Use the Kani library
   
+         --lib
+             Analyse the library's unit tests in [src/]. By default, the
+             crate's source is analysed, not the tests. Mutually exclusive with
+             --test.
+  
+         --libtest
+             When analysing a test target (--test or --lib), also discover the
+             crate's ordinary #[test] functions, not just Soteria's own
+             harnesses (#[soteria::test]). Has no effect when analysing source.
+  
          --log-compilation
              Log the compilation process
   
@@ -186,9 +196,10 @@
              the current machine is used.
   
          --test=VAL
-             The test profile to use to compile the crate; this only has an
-             effect if analysing a crate. Use [lib] for unit tests in [src/].
-             By default, the crate's source is analysed, not the tests.
+             The integration-test target to compile and analyse (a file in
+             [tests/]); this only has an effect if analysing a crate. By
+             default, the crate's source is analysed, not the tests. Mutually
+             exclusive with --lib.
   
   ANALYSIS OPTIONS
          --approx-floating-ops=ENUM (absent=warn)
@@ -438,6 +449,16 @@
          --kani
              Use the Kani library
   
+         --lib
+             Analyse the library's unit tests in [src/]. By default, the
+             crate's source is analysed, not the tests. Mutually exclusive with
+             --test.
+  
+         --libtest
+             When analysing a test target (--test or --lib), also discover the
+             crate's ordinary #[test] functions, not just Soteria's own
+             harnesses (#[soteria::test]). Has no effect when analysing source.
+  
          --log-compilation
              Log the compilation process
   
@@ -475,9 +496,10 @@
              the current machine is used.
   
          --test=VAL
-             The test profile to use to compile the crate; this only has an
-             effect if analysing a crate. Use [lib] for unit tests in [src/].
-             By default, the crate's source is analysed, not the tests.
+             The integration-test target to compile and analyse (a file in
+             [tests/]); this only has an effect if analysing a crate. By
+             default, the crate's source is analysed, not the tests. Mutually
+             exclusive with --lib.
   
   ANALYSIS OPTIONS
          --approx-floating-ops=ENUM (absent=warn)
@@ -723,6 +745,16 @@
          --kani
              Use the Kani library
   
+         --lib
+             Analyse the library's unit tests in [src/]. By default, the
+             crate's source is analysed, not the tests. Mutually exclusive with
+             --test.
+  
+         --libtest
+             When analysing a test target (--test or --lib), also discover the
+             crate's ordinary #[test] functions, not just Soteria's own
+             harnesses (#[soteria::test]). Has no effect when analysing source.
+  
          --log-compilation
              Log the compilation process
   
@@ -760,9 +792,10 @@
              the current machine is used.
   
          --test=VAL
-             The test profile to use to compile the crate; this only has an
-             effect if analysing a crate. Use [lib] for unit tests in [src/].
-             By default, the crate's source is analysed, not the tests.
+             The integration-test target to compile and analyse (a file in
+             [tests/]); this only has an effect if analysing a crate. By
+             default, the crate's source is analysed, not the tests. Mutually
+             exclusive with --lib.
   
   ANALYSIS OPTIONS
          --approx-floating-ops=ENUM (absent=warn)


### PR DESCRIPTION
Supercedes #424 (thanks Rain for the contribution!)

* Use `--lib` instead of the magic `--test lib`.
* Only parse `#[soteria::test]` entrypoints by default in all cases.
* Add `--libtest` to also parse `#[test]` entrypoints. This makes it easy to crisply explain how soteria works (always `#[soteria::test]` by default + opt into `#[test]` and `#[kani::proof]` as needed).
* Update help text.
